### PR TITLE
chore: update gg to v0.26.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,9 +2,10 @@ module github.com/gogpu/ui
 
 go 1.25.0
 
-require github.com/gogpu/gg v0.15.7
+require github.com/gogpu/gg v0.26.1
 
 require (
-	golang.org/x/image v0.34.0 // indirect
-	golang.org/x/text v0.32.0 // indirect
+	github.com/go-text/typesetting v0.3.3 // indirect
+	golang.org/x/image v0.35.0 // indirect
+	golang.org/x/text v0.33.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,10 @@
-github.com/gogpu/gg v0.15.7 h1:nwfcW+Sb6bJMQq6G7wtsB64oLzloYcst1kQIWUDoI3A=
-github.com/gogpu/gg v0.15.7/go.mod h1:ZUC+T1e7y2+/t4/Rj/BNlgI4Oc5jUzE7f0PXrAaNvnA=
-golang.org/x/image v0.34.0 h1:33gCkyw9hmwbZJeZkct8XyR11yH889EQt/QH4VmXMn8=
-golang.org/x/image v0.34.0/go.mod h1:2RNFBZRB+vnwwFil8GkMdRvrJOFd1AzdZI6vOY+eJVU=
-golang.org/x/text v0.32.0 h1:ZD01bjUt1FQ9WJ0ClOL5vxgxOI/sVCNgX1YtKwcY0mU=
-golang.org/x/text v0.32.0/go.mod h1:o/rUWzghvpD5TXrTIBuJU77MTaN0ljMWE47kxGJQ7jY=
+github.com/go-text/typesetting v0.3.3 h1:ihGNJU9KzdK2QRDy1Bm7FT5RFQoYb+3n3EIhI/4eaQc=
+github.com/go-text/typesetting v0.3.3/go.mod h1:vIRUT25mLQaSh4C8H/lIsKppQz/Gdb8Pu/tNwpi52ts=
+github.com/go-text/typesetting-utils v0.0.0-20250618110550-c820a94c77b8 h1:4KCscI9qYWMGTuz6BpJtbUSRzcBrUSSE0ENMJbNSrFs=
+github.com/go-text/typesetting-utils v0.0.0-20250618110550-c820a94c77b8/go.mod h1:3/62I4La/HBRX9TcTpBj4eipLiwzf+vhI+7whTc9V7o=
+github.com/gogpu/gg v0.26.1 h1:e09ItVRqxAaszRdRxvMU3gh+a/5mLMxYYRrUuCHbvtw=
+github.com/gogpu/gg v0.26.1/go.mod h1:PCjIVMCn4icItjmWFktbfjeZLxrtecyBPyZONcqMaOU=
+golang.org/x/image v0.35.0 h1:LKjiHdgMtO8z7Fh18nGY6KDcoEtVfsgLDPeLyguqb7I=
+golang.org/x/image v0.35.0/go.mod h1:MwPLTVgvxSASsxdLzKrl8BRFuyqMyGhLwmC+TO1Sybk=
+golang.org/x/text v0.33.0 h1:B3njUFyqtHDUI5jMn1YIr5B0IE2U0qck04r6d4KPAxE=
+golang.org/x/text v0.33.0/go.mod h1:LuMebE6+rBincTi9+xWTY8TztLzKHc/9C1uBCG27+q8=


### PR DESCRIPTION
Update gg dependency v0.15.7 → v0.26.1 (CPU=core, GPU=accelerator architecture).