### PR TITLE
fix: move GPU cleanup to OnClose callback

### DIFF
--- a/examples/hello/main.go
+++ b/examples/hello/main.go
@@ -103,13 +103,20 @@ func main() {
 		}
 	})
 
+	// Release GPU resources before renderer destroys the device.
+	// OnClose runs on the render thread BEFORE Renderer.Destroy(),
+	// so the device is still alive for proper cleanup.
+	gogpuApp.OnClose(func() {
+		gg.CloseAccelerator()
+		if canvas != nil {
+			_ = canvas.Close()
+			canvas = nil
+		}
+	})
+
 	// Run application.
 	if err := gogpuApp.Run(); err != nil {
 		log.Fatal(err)
-	}
-
-	if canvas != nil {
-		canvas.Close()
 	}
 }
 


### PR DESCRIPTION
## Summary

- Move `canvas.Close()` from after `Run()` into `OnClose` callback
- `OnClose` runs on render thread BEFORE `Renderer.Destroy()`, so device is still alive
- Eliminates 10+ Vulkan validation errors on shutdown (undestroyed VkBuffer, VkImage, VkImageView)

## Test plan

- [x] `ui/examples/hello` — clean exit, 0 validation errors
- [x] `gg/examples/gogpu_integration` — renders correctly
- [x] `go vet`, `go fmt` — clean