### PR TITLE
feat: TextField widget, multi-layer box shadow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,21 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **TextField widget** (`core/textfield/`) — full-featured text input with cursor, selection, clipboard (Ctrl+A/C/X/V), password masking, validation, signal two-way binding, accessibility (role=textbox). 12 functional options, pluggable Painter interface, 55 tests
+- **Material 3 TextField painter** (`theme/material3/textfield.go`) — outlined variant with theme-derived colors (Primary focus, Outline unfocused, Error invalid)
+
 ### Changed
-- **GPU direct rendering** — hello example switched from CPU readback (`RenderTo`) to zero-copy
-  GPU surface rendering (`RenderDirect`). All shapes, strokes, and text render directly to the
-  window surface in a single render pass — no CPU readback, no texture re-upload.
-- **Material Design card layout** — hello example wraps content card in outer container with
-  24px margin. White card with rounded corners and shadow is now visually distinct from the
-  gray background.
-- **Automatic resource cleanup** — examples updated to use gogpu `App.TrackResource()` for automatic ggcanvas shutdown. No manual `canvas.Close()` in `OnClose` needed.
+- **Multi-layer box shadow** — Material Design elevation now uses 3-4 concentric semi-transparent rounded rects (approximated Gaussian blur) instead of single flat rectangle. Levels 1-5 with progressive elevation
+- **GPU direct rendering** — hello example switched from CPU readback (`RenderTo`) to zero-copy GPU surface rendering (`RenderDirect`). Single render pass, no CPU readback
+- **Material Design card layout** — hello example wraps content card in outer container with 24px margin
+- **Automatic resource cleanup** — examples updated to use gogpu `App.TrackResource()` for automatic ggcanvas shutdown
 
 ### Fixed
-- **Text vertical alignment** — `DrawText` now centers text vertically within bounds using
-  `(boundsHeight - textHeight)/2 + ascent` instead of top-anchoring at `ascent`. Fixes
-  checkbox/radio label misalignment with icons.
-- **Box shadow direction** — shadow offset now includes horizontal component (`offset/2, offset`)
-  matching Material Design light source (top-left). Previously shadow was only vertical.
+- **Text vertical alignment** — `DrawText` now centers text vertically within bounds using `(boundsHeight - textHeight)/2 + ascent` instead of top-anchoring at `ascent`
+- **Box shadow direction** — shadow offset now includes horizontal component matching Material Design light source
 
 ### Dependencies
 - gogpu v0.19.6 → v0.20.0 (ResourceTracker, automatic GPU resource cleanup)

--- a/core/textfield/a11y.go
+++ b/core/textfield/a11y.go
@@ -1,0 +1,28 @@
+package textfield
+
+import "github.com/gogpu/ui/a11y"
+
+// AccessibleRole returns the accessibility role for the text field.
+func (w *Widget) AccessibleRole() a11y.Role {
+	return a11y.RoleTextField
+}
+
+// AccessibleLabel returns the accessibility label for the text field.
+// If an explicit a11y label was set via [A11yLabel], it is returned.
+// Otherwise, the placeholder text is used as a fallback label.
+func (w *Widget) AccessibleLabel() string {
+	if w.cfg.a11yLabel != "" {
+		return w.cfg.a11yLabel
+	}
+	return w.cfg.placeholder
+}
+
+// AccessibleValue returns the current text value for assistive technology.
+// For password fields, the value is masked.
+func (w *Widget) AccessibleValue() string {
+	text := w.resolvedText()
+	if w.cfg.inputType == TypePassword {
+		return maskText(len([]rune(text)))
+	}
+	return text
+}

--- a/core/textfield/config.go
+++ b/core/textfield/config.go
@@ -1,0 +1,28 @@
+package textfield
+
+import "github.com/gogpu/ui/state"
+
+// config holds the text field's configuration, set at construction time via options.
+type config struct {
+	placeholder string
+	value       string
+	signal      state.Signal[string]
+	onChange    func(string)
+	onSubmit    func(string)
+	inputType   InputType
+	maxLength   int
+	validation  []ValidationFunc
+	disabled    bool
+	disabledFn  func() bool
+	a11yLabel   string
+	painter     Painter
+}
+
+// ResolvedDisabled returns the current disabled state, preferring the
+// dynamic function over the static bool.
+func (c *config) ResolvedDisabled() bool {
+	if c.disabledFn != nil {
+		return c.disabledFn()
+	}
+	return c.disabled
+}

--- a/core/textfield/doc.go
+++ b/core/textfield/doc.go
@@ -1,0 +1,62 @@
+// Package textfield provides a full-featured text input widget.
+//
+// Construction uses functional options for immutable configuration,
+// while fluent methods handle mutable styling:
+//
+//	field := textfield.New(
+//	    textfield.Placeholder("Enter your email"),
+//	    textfield.OnChange(handleChange),
+//	    textfield.InputType(textfield.TypeEmail),
+//	    textfield.MaxLength(255),
+//	).Padding(12)
+//
+// # Visual Style
+//
+// The visual rendering is provided by a [Painter] implementation.
+// Each design system (Material 3, Fluent, Cupertino) supplies its own
+// painter to render text fields in the appropriate visual style.
+//
+// If no painter is set, [DefaultPainter] is used, which draws a minimal
+// outlined text field suitable for testing and prototyping.
+//
+// # Input Types
+//
+// Text fields support multiple input types:
+//   - [TypeText] -- general-purpose text input (default)
+//   - [TypePassword] -- masked input that shows dots instead of characters
+//   - [TypeEmail] -- email address input
+//   - [TypeNumber] -- numeric input
+//   - [TypeSearch] -- search input
+//
+// # Text Editing
+//
+// Text fields support standard editing operations:
+//   - Character insertion and deletion at cursor position
+//   - Arrow key movement (Left/Right) with Ctrl for word-level jumps
+//   - Home/End to move to line start/end
+//   - Backspace and Delete for character removal
+//   - Shift+arrows for text selection
+//   - Ctrl+A to select all text
+//   - Ctrl+C/X/V for clipboard copy/cut/paste (placeholder implementation)
+//
+// # Validation
+//
+// A [ValidationFunc] can be provided to validate the text field's value.
+// When validation fails, the text field displays an error state with
+// an optional error message. Validation runs on every text change.
+//
+// # Signal Binding
+//
+// Use [Value] to bind the text field to a reactive signal for two-way
+// data binding:
+//
+//	email := state.NewSignal("")
+//	field := textfield.New(textfield.Value(email))
+//	// email.Get() always reflects the current text field value
+//
+// # Focus
+//
+// Text fields implement [widget.Focusable] and participate in tab navigation.
+// When focused, the cursor blinks and the border color changes to indicate
+// the active input state.
+package textfield

--- a/core/textfield/event.go
+++ b/core/textfield/event.go
@@ -1,0 +1,354 @@
+package textfield
+
+import (
+	"github.com/gogpu/ui/event"
+	"github.com/gogpu/ui/widget"
+)
+
+// handleEvent processes input events for the text field widget.
+// It manages hover, focus, text editing, and selection states.
+func handleEvent(w *Widget, ctx widget.Context, e event.Event) bool {
+	if w.cfg.ResolvedDisabled() {
+		return false
+	}
+
+	switch ev := e.(type) {
+	case *event.MouseEvent:
+		return handleMouseEvent(w, ctx, ev)
+	case *event.KeyEvent:
+		return handleKeyEvent(w, ctx, ev)
+	default:
+		return false
+	}
+}
+
+// handleMouseEvent processes mouse events for focus, cursor placement, and selection.
+func handleMouseEvent(w *Widget, ctx widget.Context, e *event.MouseEvent) bool {
+	switch e.MouseType {
+	case event.MouseEnter:
+		w.hovered = true
+		ctx.SetCursor(widget.CursorText)
+		ctx.Invalidate()
+		return true
+
+	case event.MouseLeave:
+		w.hovered = false
+		ctx.SetCursor(widget.CursorDefault)
+		ctx.Invalidate()
+		return true
+
+	case event.MousePress:
+		return handleMousePress(w, ctx, e)
+
+	case event.MouseRelease:
+		w.dragging = false
+		return true
+
+	case event.MouseDrag:
+		return handleMouseDrag(w, ctx, e)
+
+	case event.MouseDoubleClick:
+		return handleDoubleClick(w, ctx, e)
+
+	default:
+		return false
+	}
+}
+
+// handleMousePress handles a mouse press event to place the cursor.
+func handleMousePress(w *Widget, ctx widget.Context, e *event.MouseEvent) bool {
+	if e.Button != event.ButtonLeft {
+		return false
+	}
+
+	ctx.RequestFocus(w)
+	ctx.Invalidate()
+
+	pos := positionFromMouse(w, e)
+	if e.Modifiers().IsShift() {
+		w.sel.SetCursorKeepSelection(pos)
+	} else {
+		w.sel.SetCursor(pos)
+	}
+	w.dragging = true
+	return true
+}
+
+// handleMouseDrag handles mouse drag for text selection.
+func handleMouseDrag(w *Widget, ctx widget.Context, e *event.MouseEvent) bool {
+	if !w.dragging {
+		return false
+	}
+	pos := positionFromMouse(w, e)
+	w.sel.SetCursorKeepSelection(pos)
+	ctx.Invalidate()
+	return true
+}
+
+// handleDoubleClick selects the word at the click position.
+func handleDoubleClick(w *Widget, ctx widget.Context, e *event.MouseEvent) bool {
+	if e.Button != event.ButtonLeft {
+		return false
+	}
+	runes := w.textRunes()
+	pos := positionFromMouse(w, e)
+	start, end := wordBoundsAt(runes, pos)
+	w.sel.anchor = start
+	w.sel.cursor = end
+	ctx.Invalidate()
+	return true
+}
+
+// positionFromMouse converts a mouse position to a rune index in the text.
+func positionFromMouse(w *Widget, e *event.MouseEvent) int {
+	bounds := w.Bounds()
+	localX := e.Position.X - bounds.Min.X - contentPaddingH
+
+	if localX <= 0 {
+		return 0
+	}
+
+	charW := defaultFontSize * charWidthRatio
+	pos := int(localX / charW)
+
+	runes := w.textRunes()
+	return clampPos(pos, len(runes))
+}
+
+// handleKeyEvent processes keyboard events for text editing and navigation.
+func handleKeyEvent(w *Widget, ctx widget.Context, e *event.KeyEvent) bool {
+	if !w.IsFocused() {
+		return false
+	}
+
+	// Only handle press and repeat events.
+	if e.KeyType == event.KeyRelease {
+		return false
+	}
+
+	shift := e.Modifiers().IsShift()
+	ctrl := e.Modifiers().IsCtrl()
+
+	switch {
+	case ctrl && e.Key == event.KeyA:
+		return handleSelectAll(w, ctx)
+	case ctrl && e.Key == event.KeyC:
+		return handleCopy(w)
+	case ctrl && e.Key == event.KeyX:
+		return handleCut(w, ctx)
+	case ctrl && e.Key == event.KeyV:
+		return handlePaste(w, ctx)
+	case e.Key == event.KeyLeft:
+		return handleArrowLeft(w, ctx, shift, ctrl)
+	case e.Key == event.KeyRight:
+		return handleArrowRight(w, ctx, shift, ctrl)
+	case e.Key == event.KeyHome:
+		return handleHome(w, ctx, shift)
+	case e.Key == event.KeyEnd:
+		return handleEnd(w, ctx, shift)
+	case e.Key == event.KeyBackspace:
+		return handleBackspace(w, ctx)
+	case e.Key == event.KeyDelete:
+		return handleDelete(w, ctx)
+	case e.Key == event.KeyEnter, e.Key == event.KeyNumpadEnter:
+		return handleEnter(w)
+	case e.Key == event.KeyTab:
+		return false // Let tab propagate for focus navigation
+	default:
+		return handleCharInput(w, ctx, e)
+	}
+}
+
+// handleSelectAll selects all text in the field.
+func handleSelectAll(w *Widget, ctx widget.Context) bool {
+	runes := w.textRunes()
+	w.sel.SelectAll(len(runes))
+	ctx.Invalidate()
+	return true
+}
+
+// handleCopy copies selected text to the clipboard.
+func handleCopy(w *Widget) bool {
+	if !w.sel.HasSelection() {
+		return true
+	}
+	runes := w.textRunes()
+	start, end := w.sel.OrderedRange()
+	w.sel.copyToClipboard(string(runes[start:end]))
+	return true
+}
+
+// handleCut cuts selected text to the clipboard.
+func handleCut(w *Widget, ctx widget.Context) bool {
+	if !w.sel.HasSelection() {
+		return true
+	}
+	runes := w.textRunes()
+	start, end := w.sel.OrderedRange()
+	w.sel.copyToClipboard(string(runes[start:end]))
+	w.deleteSelection()
+	w.notifyChange(ctx)
+	return true
+}
+
+// handlePaste inserts clipboard text at the cursor position.
+func handlePaste(w *Widget, ctx widget.Context) bool {
+	text := w.sel.pasteFromClipboard()
+	if text == "" {
+		return true
+	}
+
+	w.deleteSelection()
+	w.insertText(text)
+	w.notifyChange(ctx)
+	return true
+}
+
+// handleArrowLeft moves the cursor left, optionally extending selection.
+func handleArrowLeft(w *Widget, ctx widget.Context, shift, ctrl bool) bool {
+	runes := w.textRunes()
+	var newPos int
+	if ctrl {
+		newPos = prevWordBoundary(runes, w.sel.cursor)
+	} else {
+		if !shift && w.sel.HasSelection() {
+			start, _ := w.sel.OrderedRange()
+			newPos = start
+		} else {
+			newPos = clampPos(w.sel.cursor-1, len(runes))
+		}
+	}
+
+	if shift {
+		w.sel.SetCursorKeepSelection(newPos)
+	} else {
+		w.sel.SetCursor(newPos)
+	}
+	ctx.Invalidate()
+	return true
+}
+
+// handleArrowRight moves the cursor right, optionally extending selection.
+func handleArrowRight(w *Widget, ctx widget.Context, shift, ctrl bool) bool {
+	runes := w.textRunes()
+	var newPos int
+	if ctrl {
+		newPos = nextWordBoundary(runes, w.sel.cursor)
+	} else {
+		if !shift && w.sel.HasSelection() {
+			_, end := w.sel.OrderedRange()
+			newPos = end
+		} else {
+			newPos = clampPos(w.sel.cursor+1, len(runes))
+		}
+	}
+
+	if shift {
+		w.sel.SetCursorKeepSelection(newPos)
+	} else {
+		w.sel.SetCursor(newPos)
+	}
+	ctx.Invalidate()
+	return true
+}
+
+// handleHome moves the cursor to the beginning of the line.
+func handleHome(w *Widget, ctx widget.Context, shift bool) bool {
+	if shift {
+		w.sel.SetCursorKeepSelection(0)
+	} else {
+		w.sel.SetCursor(0)
+	}
+	ctx.Invalidate()
+	return true
+}
+
+// handleEnd moves the cursor to the end of the line.
+func handleEnd(w *Widget, ctx widget.Context, shift bool) bool {
+	runes := w.textRunes()
+	if shift {
+		w.sel.SetCursorKeepSelection(len(runes))
+	} else {
+		w.sel.SetCursor(len(runes))
+	}
+	ctx.Invalidate()
+	return true
+}
+
+// handleBackspace deletes the character before the cursor or the selection.
+func handleBackspace(w *Widget, ctx widget.Context) bool {
+	if w.sel.HasSelection() {
+		w.deleteSelection()
+		w.notifyChange(ctx)
+		return true
+	}
+
+	if w.sel.cursor == 0 {
+		return true
+	}
+
+	runes := w.textRunes()
+	pos := w.sel.cursor
+	newRunes := make([]rune, 0, len(runes)-1)
+	newRunes = append(newRunes, runes[:pos-1]...)
+	newRunes = append(newRunes, runes[pos:]...)
+	w.setText(string(newRunes))
+	w.sel.SetCursor(pos - 1)
+	w.notifyChange(ctx)
+	return true
+}
+
+// handleDelete deletes the character after the cursor or the selection.
+func handleDelete(w *Widget, ctx widget.Context) bool {
+	if w.sel.HasSelection() {
+		w.deleteSelection()
+		w.notifyChange(ctx)
+		return true
+	}
+
+	runes := w.textRunes()
+	if w.sel.cursor >= len(runes) {
+		return true
+	}
+
+	pos := w.sel.cursor
+	newRunes := make([]rune, 0, len(runes)-1)
+	newRunes = append(newRunes, runes[:pos]...)
+	newRunes = append(newRunes, runes[pos+1:]...)
+	w.setText(string(newRunes))
+	w.notifyChange(ctx)
+	return true
+}
+
+// handleEnter submits the text field value.
+func handleEnter(w *Widget) bool {
+	if w.cfg.onSubmit != nil {
+		w.cfg.onSubmit(w.resolvedText())
+	}
+	return true
+}
+
+// handleCharInput inserts a printable character at the cursor position.
+func handleCharInput(w *Widget, ctx widget.Context, e *event.KeyEvent) bool {
+	if !e.HasRune() {
+		return false
+	}
+
+	r := e.Rune
+	// Filter out control characters.
+	if r < ' ' {
+		return false
+	}
+
+	w.deleteSelection()
+
+	// Check max length.
+	runes := w.textRunes()
+	if w.cfg.maxLength > 0 && len(runes) >= w.cfg.maxLength {
+		return true
+	}
+
+	w.insertText(string(r))
+	w.notifyChange(ctx)
+	return true
+}

--- a/core/textfield/options.go
+++ b/core/textfield/options.go
@@ -1,0 +1,102 @@
+package textfield
+
+import "github.com/gogpu/ui/state"
+
+// Option configures a text field during construction.
+type Option func(*config)
+
+// Placeholder sets the placeholder text shown when the field is empty and unfocused.
+func Placeholder(s string) Option {
+	return func(c *config) {
+		c.placeholder = s
+	}
+}
+
+// InitialValue sets the initial text value for the field.
+func InitialValue(s string) Option {
+	return func(c *config) {
+		c.value = s
+	}
+}
+
+// Value binds the text field to a reactive signal for two-way data binding.
+// When the user types, the signal is updated. When the signal is set externally,
+// the text field reflects the change.
+func Value(sig state.Signal[string]) Option {
+	return func(c *config) {
+		c.signal = sig
+	}
+}
+
+// OnChange sets the callback invoked when the text value changes.
+// The callback receives the new text value.
+func OnChange(fn func(string)) Option {
+	return func(c *config) {
+		c.onChange = fn
+	}
+}
+
+// OnSubmit sets the callback invoked when the user presses Enter
+// in a single-line text field. The callback receives the current text value.
+func OnSubmit(fn func(string)) Option {
+	return func(c *config) {
+		c.onSubmit = fn
+	}
+}
+
+// InputTypeOpt sets the input type (text, password, email, number, search).
+func InputTypeOpt(t InputType) Option {
+	return func(c *config) {
+		c.inputType = t
+	}
+}
+
+// MaxLength sets the maximum number of characters allowed.
+// A value of 0 means no limit.
+func MaxLength(n int) Option {
+	return func(c *config) {
+		c.maxLength = n
+	}
+}
+
+// Validation sets one or more validation functions.
+// Each function receives the current value and returns an error message
+// (empty string means valid). Validation runs on every text change.
+func Validation(fns ...ValidationFunc) Option {
+	return func(c *config) {
+		c.validation = append(c.validation, fns...)
+	}
+}
+
+// Disabled sets the text field's disabled state. A disabled text field
+// does not respond to user input and is drawn with a dimmed appearance.
+func Disabled(d bool) Option {
+	return func(c *config) {
+		c.disabled = d
+	}
+}
+
+// DisabledFn sets a dynamic function that is evaluated to determine whether
+// the text field is disabled. When set, this takes precedence over the static value.
+func DisabledFn(fn func() bool) Option {
+	return func(c *config) {
+		c.disabledFn = fn
+	}
+}
+
+// A11yLabel sets the accessibility label for the text field.
+// This is announced by screen readers to describe the field's purpose.
+func A11yLabel(label string) Option {
+	return func(c *config) {
+		c.a11yLabel = label
+	}
+}
+
+// PainterOpt sets the painter used to render the text field.
+// Each design system provides its own painter. If not set,
+// [DefaultPainter] is used.
+func PainterOpt(p Painter) Option {
+	return func(c *config) {
+		c.painter = p
+	}
+}

--- a/core/textfield/painter.go
+++ b/core/textfield/painter.go
@@ -1,0 +1,227 @@
+package textfield
+
+import (
+	"github.com/gogpu/ui/geometry"
+	"github.com/gogpu/ui/widget"
+)
+
+// Painter draws the visual representation of a text field.
+// Each design system (Material 3, Fluent, Cupertino) provides its own
+// Painter implementation to render the text field in its visual style.
+//
+// If no Painter is set, the text field uses [DefaultPainter].
+type Painter interface {
+	PaintTextField(canvas widget.Canvas, state PaintState)
+}
+
+// PaintState provides the current text field state to the painter.
+type PaintState struct {
+	Text        string
+	Placeholder string
+	Focused     bool
+	Hovered     bool
+	Disabled    bool
+	HasError    bool
+	ErrorMsg    string
+	CursorPos   int
+	SelectStart int
+	SelectEnd   int
+	InputType   InputType
+	Bounds      geometry.Rect
+}
+
+// TextFieldColorScheme provides theme-derived colors for text field painting.
+// Zero value means the painter should use its built-in defaults.
+type TextFieldColorScheme struct {
+	Background  widget.Color
+	Border      widget.Color
+	FocusBorder widget.Color
+	ErrorBorder widget.Color
+	TextColor   widget.Color
+	Placeholder widget.Color
+	CursorColor widget.Color
+	DisabledBg  widget.Color
+	DisabledFg  widget.Color
+	SelectionBg widget.Color
+	ErrorText   widget.Color
+}
+
+// DefaultPainter provides a minimal fallback painter with no design system styling.
+// It draws a simple outlined text field suitable for testing and prototyping.
+type DefaultPainter struct{}
+
+// PaintTextField renders a minimal text field with gray outline.
+// If the state has a non-zero ColorScheme (via the M3 painter), use those colors.
+func (p DefaultPainter) PaintTextField(canvas widget.Canvas, st PaintState) {
+	if st.Bounds.IsEmpty() {
+		return
+	}
+
+	paintBackground(canvas, st)
+	paintBorder(canvas, st)
+	paintContent(canvas, st)
+	paintCursor(canvas, st)
+}
+
+// paintBackground fills the text field background.
+func paintBackground(canvas widget.Canvas, st PaintState) {
+	bg := defaultBg
+	if st.Disabled {
+		bg = defaultDisabledBg
+	}
+	canvas.DrawRoundRect(st.Bounds, bg, defaultCornerRadius)
+}
+
+// paintBorder draws the text field outline.
+func paintBorder(canvas widget.Canvas, st PaintState) {
+	borderColor := defaultBorderColor
+	strokeWidth := defaultBorderWidth
+
+	switch {
+	case st.Disabled:
+		borderColor = defaultDisabledBorderColor
+	case st.HasError:
+		borderColor = defaultErrorColor
+	case st.Focused:
+		borderColor = defaultFocusBorderColor
+		strokeWidth = defaultFocusBorderWidth
+	case st.Hovered:
+		borderColor = defaultHoverBorderColor
+	}
+
+	canvas.StrokeRoundRect(st.Bounds, borderColor, defaultCornerRadius, strokeWidth)
+}
+
+// paintContent renders either the placeholder or the displayed text.
+func paintContent(canvas widget.Canvas, st PaintState) {
+	contentBounds := contentRect(st.Bounds)
+
+	// Clip to content area.
+	canvas.PushClip(contentBounds)
+	defer canvas.PopClip()
+
+	displayText := st.Text
+	if st.InputType == TypePassword {
+		displayText = maskText(len([]rune(st.Text)))
+	}
+
+	if displayText == "" && !st.Focused {
+		// Draw placeholder.
+		color := defaultPlaceholderColor
+		if st.Disabled {
+			color = defaultDisabledFg
+		}
+		canvas.DrawText(st.Placeholder, contentBounds, defaultFontSize, color, false, textAlignLeft)
+		return
+	}
+
+	// Draw text.
+	textColor := defaultTextColor
+	if st.Disabled {
+		textColor = defaultDisabledFg
+	}
+
+	// Draw selection background if present.
+	if st.SelectStart != st.SelectEnd {
+		paintSelection(canvas, contentBounds, st)
+	}
+
+	canvas.DrawText(displayText, contentBounds, defaultFontSize, textColor, false, textAlignLeft)
+}
+
+// paintSelection draws the selection highlight rectangle.
+func paintSelection(canvas widget.Canvas, contentBounds geometry.Rect, st PaintState) {
+	selStart := st.SelectStart
+	selEnd := st.SelectEnd
+	if selStart > selEnd {
+		selStart, selEnd = selEnd, selStart
+	}
+
+	charWidth := defaultFontSize * charWidthRatio
+	x1 := contentBounds.Min.X + float32(selStart)*charWidth
+	x2 := contentBounds.Min.X + float32(selEnd)*charWidth
+
+	// Clamp to content bounds.
+	if x2 > contentBounds.Max.X {
+		x2 = contentBounds.Max.X
+	}
+
+	selRect := geometry.Rect{
+		Min: geometry.Pt(x1, contentBounds.Min.Y),
+		Max: geometry.Pt(x2, contentBounds.Max.Y),
+	}
+	canvas.DrawRect(selRect, defaultSelectionBg)
+}
+
+// paintCursor draws the blinking caret when the field is focused.
+func paintCursor(canvas widget.Canvas, st PaintState) {
+	if !st.Focused || st.Disabled {
+		return
+	}
+	// No cursor when there is a selection.
+	if st.SelectStart != st.SelectEnd {
+		return
+	}
+
+	content := contentRect(st.Bounds)
+	charWidth := defaultFontSize * charWidthRatio
+	cursorX := content.Min.X + float32(st.CursorPos)*charWidth
+
+	// Clamp cursor to content area.
+	if cursorX > content.Max.X {
+		cursorX = content.Max.X
+	}
+
+	top := geometry.Pt(cursorX, content.Min.Y+cursorTopPadding)
+	bottom := geometry.Pt(cursorX, content.Max.Y-cursorBottomPadding)
+	canvas.DrawLine(top, bottom, defaultCursorColor, cursorWidth)
+}
+
+// contentRect returns the inner content area after padding.
+func contentRect(bounds geometry.Rect) geometry.Rect {
+	return geometry.Rect{
+		Min: geometry.Pt(bounds.Min.X+contentPaddingH, bounds.Min.Y+contentPaddingV),
+		Max: geometry.Pt(bounds.Max.X-contentPaddingH, bounds.Max.Y-contentPaddingV),
+	}
+}
+
+// maskText returns a string of dots with the given length.
+func maskText(length int) string {
+	runes := make([]rune, length)
+	for i := range runes {
+		runes[i] = passwordMaskChar
+	}
+	return string(runes)
+}
+
+// Painting constants.
+const (
+	defaultFontSize         float32 = 14
+	defaultCornerRadius     float32 = 4
+	defaultBorderWidth      float32 = 1
+	defaultFocusBorderWidth float32 = 2
+	contentPaddingH         float32 = 12
+	contentPaddingV         float32 = 8
+	charWidthRatio          float32 = 0.55
+	textAlignLeft           float32 = 0
+	cursorWidth             float32 = 1.5
+	cursorTopPadding        float32 = 2
+	cursorBottomPadding     float32 = 2
+	passwordMaskChar                = '\u2022' // bullet character
+)
+
+// Default colors for DefaultPainter.
+var (
+	defaultBg                  = widget.ColorWhite
+	defaultBorderColor         = widget.RGBA(0.45, 0.45, 0.45, 1.0)
+	defaultFocusBorderColor    = widget.Hex(0x6750A4)
+	defaultHoverBorderColor    = widget.RGBA(0.2, 0.2, 0.2, 1.0)
+	defaultDisabledBorderColor = widget.RGBA(0.45, 0.45, 0.45, 0.38)
+	defaultErrorColor          = widget.Hex(0xB3261E)
+	defaultTextColor           = widget.RGBA(0.1, 0.1, 0.1, 1.0)
+	defaultPlaceholderColor    = widget.RGBA(0.45, 0.45, 0.45, 1.0)
+	defaultCursorColor         = widget.Hex(0x6750A4)
+	defaultDisabledBg          = widget.RGBA(0.95, 0.95, 0.95, 1.0)
+	defaultDisabledFg          = widget.RGBA(0.12, 0.12, 0.13, 0.38)
+	defaultSelectionBg         = widget.Hex(0x6750A4).WithAlpha(0.2)
+)

--- a/core/textfield/selection.go
+++ b/core/textfield/selection.go
@@ -1,0 +1,151 @@
+package textfield
+
+import "unicode"
+
+// selection tracks cursor position and text selection state.
+type selection struct {
+	cursor    int    // cursor position (byte offset in runes slice)
+	anchor    int    // anchor for selection (same as cursor when no selection)
+	clipboard string // internal clipboard (placeholder for platform clipboard)
+}
+
+// HasSelection returns true if text is selected (anchor != cursor).
+func (s *selection) HasSelection() bool {
+	return s.anchor != s.cursor
+}
+
+// OrderedRange returns the selection range as (start, end) where start <= end.
+func (s *selection) OrderedRange() (int, int) {
+	if s.anchor <= s.cursor {
+		return s.anchor, s.cursor
+	}
+	return s.cursor, s.anchor
+}
+
+// ClearSelection collapses the selection to the cursor position.
+func (s *selection) ClearSelection() {
+	s.anchor = s.cursor
+}
+
+// SelectAll selects all text given the total rune count.
+func (s *selection) SelectAll(runeCount int) {
+	s.anchor = 0
+	s.cursor = runeCount
+}
+
+// SetCursor moves the cursor to the given position and clears selection.
+func (s *selection) SetCursor(pos int) {
+	s.cursor = pos
+	s.anchor = pos
+}
+
+// SetCursorKeepSelection moves the cursor without clearing the anchor,
+// extending or shrinking the selection.
+func (s *selection) SetCursorKeepSelection(pos int) {
+	s.cursor = pos
+}
+
+// clampPos ensures a position is within [0, maxPos].
+func clampPos(pos, maxPos int) int {
+	if pos < 0 {
+		return 0
+	}
+	if pos > maxPos {
+		return maxPos
+	}
+	return pos
+}
+
+// nextWordBoundary finds the next word boundary after pos in the given runes.
+func nextWordBoundary(runes []rune, pos int) int {
+	n := len(runes)
+	if pos >= n {
+		return n
+	}
+	// Skip current word characters.
+	i := pos
+	for i < n && isWordChar(runes[i]) {
+		i++
+	}
+	// If we didn't move, skip non-word characters.
+	if i == pos {
+		for i < n && !isWordChar(runes[i]) {
+			i++
+		}
+	}
+	return i
+}
+
+// prevWordBoundary finds the previous word boundary before pos in the given runes.
+func prevWordBoundary(runes []rune, pos int) int {
+	if pos <= 0 {
+		return 0
+	}
+	i := pos
+	// Skip non-word characters backwards.
+	for i > 0 && !isWordChar(runes[i-1]) {
+		i--
+	}
+	// Skip word characters backwards.
+	for i > 0 && isWordChar(runes[i-1]) {
+		i--
+	}
+	return i
+}
+
+// isWordChar returns true if the rune is a letter, digit, or underscore.
+func isWordChar(r rune) bool {
+	return unicode.IsLetter(r) || unicode.IsDigit(r) || r == '_'
+}
+
+// wordBoundsAt returns the (start, end) of the word at the given position.
+// Used for double-click word selection.
+func wordBoundsAt(runes []rune, pos int) (int, int) {
+	n := len(runes)
+	if n == 0 {
+		return 0, 0
+	}
+	// Clamp position.
+	if pos >= n {
+		pos = n - 1
+	}
+	if pos < 0 {
+		pos = 0
+	}
+
+	// If at a non-word char, select the run of non-word chars.
+	if !isWordChar(runes[pos]) {
+		start := pos
+		for start > 0 && !isWordChar(runes[start-1]) {
+			start--
+		}
+		end := pos + 1
+		for end < n && !isWordChar(runes[end]) {
+			end++
+		}
+		return start, end
+	}
+
+	// Otherwise select the word.
+	start := pos
+	for start > 0 && isWordChar(runes[start-1]) {
+		start--
+	}
+	end := pos + 1
+	for end < n && isWordChar(runes[end]) {
+		end++
+	}
+	return start, end
+}
+
+// copyToClipboard stores the given text in the internal clipboard.
+// This is a placeholder; a real implementation would use platform APIs.
+func (s *selection) copyToClipboard(text string) {
+	s.clipboard = text
+}
+
+// pasteFromClipboard returns the text from the internal clipboard.
+// This is a placeholder; a real implementation would use platform APIs.
+func (s *selection) pasteFromClipboard() string {
+	return s.clipboard
+}

--- a/core/textfield/textfield.go
+++ b/core/textfield/textfield.go
@@ -1,0 +1,1 @@
+package textfield

--- a/core/textfield/textfield_test.go
+++ b/core/textfield/textfield_test.go
@@ -1,0 +1,1083 @@
+package textfield_test
+
+import (
+	"testing"
+
+	"github.com/gogpu/ui/a11y"
+	"github.com/gogpu/ui/core/textfield"
+	"github.com/gogpu/ui/event"
+	"github.com/gogpu/ui/geometry"
+	"github.com/gogpu/ui/state"
+	"github.com/gogpu/ui/widget"
+)
+
+// --- Construction Tests ---
+
+func TestNew_Defaults(t *testing.T) {
+	tf := textfield.New()
+
+	if !tf.IsVisible() {
+		t.Error("default text field should be visible")
+	}
+	if !tf.IsEnabled() {
+		t.Error("default text field should be enabled")
+	}
+	if !tf.IsFocusable() {
+		t.Error("default text field should be focusable")
+	}
+	if tf.Children() != nil {
+		t.Error("text field should have no children")
+	}
+	if tf.Text() != "" {
+		t.Errorf("text = %q, want empty", tf.Text())
+	}
+	if tf.HasError() {
+		t.Error("default text field should not have error")
+	}
+}
+
+func TestNew_WithPlaceholder(t *testing.T) {
+	tf := textfield.New(textfield.Placeholder("Enter email"))
+	tf.SetBounds(geometry.NewRect(0, 0, 300, 48))
+	ctx := widget.NewContext()
+	canvas := &recordingCanvas{}
+
+	tf.Draw(ctx, canvas)
+
+	if len(canvas.drawTexts) == 0 {
+		t.Fatal("should have drawn placeholder text")
+	}
+	if canvas.drawTexts[0].text != "Enter email" {
+		t.Errorf("placeholder = %q, want %q", canvas.drawTexts[0].text, "Enter email")
+	}
+}
+
+func TestNew_WithInitialValue(t *testing.T) {
+	tf := textfield.New(textfield.InitialValue("hello"))
+
+	if tf.Text() != "hello" {
+		t.Errorf("text = %q, want %q", tf.Text(), "hello")
+	}
+}
+
+func TestNew_WithDisabled(t *testing.T) {
+	tf := textfield.New(textfield.Disabled(true))
+
+	if tf.IsFocusable() {
+		t.Error("disabled text field should not be focusable")
+	}
+}
+
+func TestNew_WithDisabledFn(t *testing.T) {
+	isDisabled := true
+	tf := textfield.New(textfield.DisabledFn(func() bool { return isDisabled }))
+
+	if tf.IsFocusable() {
+		t.Error("disabled text field should not be focusable")
+	}
+
+	isDisabled = false
+	if !tf.IsFocusable() {
+		t.Error("enabled text field should be focusable")
+	}
+}
+
+func TestNew_WithMaxLength(t *testing.T) {
+	tf := textfield.New(
+		textfield.InitialValue("abc"),
+		textfield.MaxLength(5),
+	)
+	tf.SetBounds(geometry.NewRect(0, 0, 300, 48))
+	tf.SetFocused(true)
+	ctx := widget.NewContext()
+
+	// Type characters up to limit.
+	typeRune(tf, ctx, 'd')
+	typeRune(tf, ctx, 'e')
+	if tf.Text() != "abcde" {
+		t.Errorf("text = %q, want %q", tf.Text(), "abcde")
+	}
+
+	// Try to type beyond max length.
+	typeRune(tf, ctx, 'f')
+	if tf.Text() != "abcde" {
+		t.Errorf("text = %q after max length, want %q", tf.Text(), "abcde")
+	}
+}
+
+func TestNew_WithOnChange(t *testing.T) {
+	var changed string
+	tf := textfield.New(textfield.OnChange(func(v string) { changed = v }))
+	tf.SetBounds(geometry.NewRect(0, 0, 300, 48))
+	tf.SetFocused(true)
+	ctx := widget.NewContext()
+
+	typeRune(tf, ctx, 'x')
+
+	if changed != "x" {
+		t.Errorf("onChange value = %q, want %q", changed, "x")
+	}
+}
+
+func TestNew_WithOnSubmit(t *testing.T) {
+	var submitted string
+	tf := textfield.New(
+		textfield.InitialValue("test"),
+		textfield.OnSubmit(func(v string) { submitted = v }),
+	)
+	tf.SetFocused(true)
+	ctx := widget.NewContext()
+
+	pressKey(tf, ctx, event.KeyEnter, event.ModNone)
+
+	if submitted != "test" {
+		t.Errorf("onSubmit value = %q, want %q", submitted, "test")
+	}
+}
+
+func TestNew_WithInputType(t *testing.T) {
+	tests := []struct {
+		name      string
+		inputType textfield.InputType
+		wantStr   string
+	}{
+		{"Text", textfield.TypeText, "Text"},
+		{"Password", textfield.TypePassword, "Password"},
+		{"Email", textfield.TypeEmail, "Email"},
+		{"Number", textfield.TypeNumber, "Number"},
+		{"Search", textfield.TypeSearch, "Search"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_ = textfield.New(textfield.InputTypeOpt(tt.inputType))
+			if tt.inputType.String() != tt.wantStr {
+				t.Errorf("InputType.String() = %q, want %q", tt.inputType.String(), tt.wantStr)
+			}
+		})
+	}
+}
+
+func TestNew_AllOptions(t *testing.T) {
+	tf := textfield.New(
+		textfield.Placeholder("Enter text"),
+		textfield.InitialValue("hello"),
+		textfield.OnChange(func(string) {}),
+		textfield.OnSubmit(func(string) {}),
+		textfield.InputTypeOpt(textfield.TypeEmail),
+		textfield.MaxLength(100),
+		textfield.Validation(func(v string) string {
+			if v == "" {
+				return "required"
+			}
+			return ""
+		}),
+		textfield.Disabled(false),
+		textfield.A11yLabel("Email address"),
+	)
+
+	if !tf.IsFocusable() {
+		t.Error("should be focusable")
+	}
+}
+
+// --- Signal Binding Tests ---
+
+func TestSignal_TwoWayBinding(t *testing.T) {
+	sig := state.NewSignal("")
+	tf := textfield.New(textfield.Value(sig))
+	tf.SetBounds(geometry.NewRect(0, 0, 300, 48))
+	tf.SetFocused(true)
+	ctx := widget.NewContext()
+
+	// Type into the field.
+	typeRune(tf, ctx, 'h')
+	typeRune(tf, ctx, 'i')
+
+	if sig.Get() != "hi" {
+		t.Errorf("signal = %q, want %q", sig.Get(), "hi")
+	}
+
+	// Set signal externally.
+	sig.Set("external")
+	// Draw triggers sync.
+	canvas := &recordingCanvas{}
+	tf.Draw(ctx, canvas)
+
+	if tf.Text() != "external" {
+		t.Errorf("text = %q after signal set, want %q", tf.Text(), "external")
+	}
+}
+
+// --- Validation Tests ---
+
+func TestValidation_ErrorOnInvalid(t *testing.T) {
+	tf := textfield.New(
+		textfield.InitialValue(""),
+		textfield.Validation(func(v string) string {
+			if v == "" {
+				return "required"
+			}
+			return ""
+		}),
+	)
+
+	if !tf.HasError() {
+		t.Error("empty value should trigger validation error")
+	}
+	if tf.ErrorMessage() != "required" {
+		t.Errorf("error = %q, want %q", tf.ErrorMessage(), "required")
+	}
+}
+
+func TestValidation_ClearsOnValid(t *testing.T) {
+	tf := textfield.New(
+		textfield.InitialValue(""),
+		textfield.Validation(func(v string) string {
+			if v == "" {
+				return "required"
+			}
+			return ""
+		}),
+	)
+	tf.SetBounds(geometry.NewRect(0, 0, 300, 48))
+	tf.SetFocused(true)
+	ctx := widget.NewContext()
+
+	typeRune(tf, ctx, 'a')
+
+	if tf.HasError() {
+		t.Error("valid value should not have error")
+	}
+}
+
+func TestValidation_MultipleValidators(t *testing.T) {
+	tf := textfield.New(
+		textfield.InitialValue("ab"),
+		textfield.Validation(
+			func(v string) string {
+				if len(v) < 3 {
+					return "too short"
+				}
+				return ""
+			},
+			func(v string) string {
+				if len(v) > 10 {
+					return "too long"
+				}
+				return ""
+			},
+		),
+	)
+
+	if tf.ErrorMessage() != "too short" {
+		t.Errorf("error = %q, want %q", tf.ErrorMessage(), "too short")
+	}
+}
+
+// --- Text Editing Tests ---
+
+func TestEdit_InsertCharacters(t *testing.T) {
+	tf := textfield.New()
+	tf.SetBounds(geometry.NewRect(0, 0, 300, 48))
+	tf.SetFocused(true)
+	ctx := widget.NewContext()
+
+	typeRune(tf, ctx, 'a')
+	typeRune(tf, ctx, 'b')
+	typeRune(tf, ctx, 'c')
+
+	if tf.Text() != "abc" {
+		t.Errorf("text = %q, want %q", tf.Text(), "abc")
+	}
+}
+
+func TestEdit_Backspace(t *testing.T) {
+	tf := textfield.New(textfield.InitialValue("abc"))
+	tf.SetBounds(geometry.NewRect(0, 0, 300, 48))
+	tf.SetFocused(true)
+	ctx := widget.NewContext()
+
+	pressKey(tf, ctx, event.KeyBackspace, event.ModNone)
+
+	if tf.Text() != "ab" {
+		t.Errorf("text = %q, want %q", tf.Text(), "ab")
+	}
+}
+
+func TestEdit_BackspaceAtStart(t *testing.T) {
+	tf := textfield.New(textfield.InitialValue("abc"))
+	tf.SetBounds(geometry.NewRect(0, 0, 300, 48))
+	tf.SetFocused(true)
+	ctx := widget.NewContext()
+
+	// Move cursor to start.
+	pressKey(tf, ctx, event.KeyHome, event.ModNone)
+	pressKey(tf, ctx, event.KeyBackspace, event.ModNone)
+
+	if tf.Text() != "abc" {
+		t.Errorf("text = %q, want %q", tf.Text(), "abc")
+	}
+}
+
+func TestEdit_Delete(t *testing.T) {
+	tf := textfield.New(textfield.InitialValue("abc"))
+	tf.SetBounds(geometry.NewRect(0, 0, 300, 48))
+	tf.SetFocused(true)
+	ctx := widget.NewContext()
+
+	// Move cursor to start, then delete.
+	pressKey(tf, ctx, event.KeyHome, event.ModNone)
+	pressKey(tf, ctx, event.KeyDelete, event.ModNone)
+
+	if tf.Text() != "bc" {
+		t.Errorf("text = %q, want %q", tf.Text(), "bc")
+	}
+}
+
+func TestEdit_DeleteAtEnd(t *testing.T) {
+	tf := textfield.New(textfield.InitialValue("abc"))
+	tf.SetBounds(geometry.NewRect(0, 0, 300, 48))
+	tf.SetFocused(true)
+	ctx := widget.NewContext()
+
+	pressKey(tf, ctx, event.KeyDelete, event.ModNone)
+
+	if tf.Text() != "abc" {
+		t.Errorf("text = %q, want %q", tf.Text(), "abc")
+	}
+}
+
+func TestEdit_SetText(t *testing.T) {
+	tf := textfield.New()
+	tf.SetText("hello world")
+
+	if tf.Text() != "hello world" {
+		t.Errorf("text = %q, want %q", tf.Text(), "hello world")
+	}
+}
+
+// --- Cursor Movement Tests ---
+
+func TestCursor_ArrowLeft(t *testing.T) {
+	tf := textfield.New(textfield.InitialValue("abc"))
+	tf.SetBounds(geometry.NewRect(0, 0, 300, 48))
+	tf.SetFocused(true)
+	ctx := widget.NewContext()
+
+	pressKey(tf, ctx, event.KeyLeft, event.ModNone)
+
+	if tf.CursorPosition() != 2 {
+		t.Errorf("cursor = %d, want 2", tf.CursorPosition())
+	}
+}
+
+func TestCursor_ArrowRight(t *testing.T) {
+	tf := textfield.New(textfield.InitialValue("abc"))
+	tf.SetBounds(geometry.NewRect(0, 0, 300, 48))
+	tf.SetFocused(true)
+	ctx := widget.NewContext()
+
+	// Move to start first, then right.
+	pressKey(tf, ctx, event.KeyHome, event.ModNone)
+	pressKey(tf, ctx, event.KeyRight, event.ModNone)
+
+	if tf.CursorPosition() != 1 {
+		t.Errorf("cursor = %d, want 1", tf.CursorPosition())
+	}
+}
+
+func TestCursor_Home(t *testing.T) {
+	tf := textfield.New(textfield.InitialValue("abc"))
+	tf.SetBounds(geometry.NewRect(0, 0, 300, 48))
+	tf.SetFocused(true)
+	ctx := widget.NewContext()
+
+	pressKey(tf, ctx, event.KeyHome, event.ModNone)
+
+	if tf.CursorPosition() != 0 {
+		t.Errorf("cursor = %d, want 0", tf.CursorPosition())
+	}
+}
+
+func TestCursor_End(t *testing.T) {
+	tf := textfield.New(textfield.InitialValue("abc"))
+	tf.SetBounds(geometry.NewRect(0, 0, 300, 48))
+	tf.SetFocused(true)
+	ctx := widget.NewContext()
+
+	pressKey(tf, ctx, event.KeyHome, event.ModNone)
+	pressKey(tf, ctx, event.KeyEnd, event.ModNone)
+
+	if tf.CursorPosition() != 3 {
+		t.Errorf("cursor = %d, want 3", tf.CursorPosition())
+	}
+}
+
+func TestCursor_CtrlLeft_WordJump(t *testing.T) {
+	tf := textfield.New(textfield.InitialValue("hello world"))
+	tf.SetBounds(geometry.NewRect(0, 0, 300, 48))
+	tf.SetFocused(true)
+	ctx := widget.NewContext()
+
+	// Cursor starts at end (position 11).
+	pressKey(tf, ctx, event.KeyLeft, event.ModCtrl)
+
+	if tf.CursorPosition() != 6 {
+		t.Errorf("cursor = %d, want 6 (start of 'world')", tf.CursorPosition())
+	}
+}
+
+func TestCursor_CtrlRight_WordJump(t *testing.T) {
+	tf := textfield.New(textfield.InitialValue("hello world"))
+	tf.SetBounds(geometry.NewRect(0, 0, 300, 48))
+	tf.SetFocused(true)
+	ctx := widget.NewContext()
+
+	pressKey(tf, ctx, event.KeyHome, event.ModNone)
+	pressKey(tf, ctx, event.KeyRight, event.ModCtrl)
+
+	if tf.CursorPosition() != 5 {
+		t.Errorf("cursor = %d, want 5 (end of 'hello')", tf.CursorPosition())
+	}
+}
+
+// --- Selection Tests ---
+
+func TestSelection_ShiftArrow(t *testing.T) {
+	tf := textfield.New(textfield.InitialValue("abc"))
+	tf.SetBounds(geometry.NewRect(0, 0, 300, 48))
+	tf.SetFocused(true)
+	ctx := widget.NewContext()
+
+	pressKey(tf, ctx, event.KeyLeft, event.ModShift)
+	pressKey(tf, ctx, event.KeyLeft, event.ModShift)
+
+	start, end := tf.Selection()
+	if start != 1 || end != 3 {
+		t.Errorf("selection = (%d, %d), want (1, 3)", start, end)
+	}
+}
+
+func TestSelection_SelectAll(t *testing.T) {
+	tf := textfield.New(textfield.InitialValue("hello"))
+	tf.SetBounds(geometry.NewRect(0, 0, 300, 48))
+	tf.SetFocused(true)
+	ctx := widget.NewContext()
+
+	pressKey(tf, ctx, event.KeyA, event.ModCtrl)
+
+	start, end := tf.Selection()
+	if start != 0 || end != 5 {
+		t.Errorf("selection = (%d, %d), want (0, 5)", start, end)
+	}
+}
+
+func TestSelection_DeleteSelection(t *testing.T) {
+	tf := textfield.New(textfield.InitialValue("hello"))
+	tf.SetBounds(geometry.NewRect(0, 0, 300, 48))
+	tf.SetFocused(true)
+	ctx := widget.NewContext()
+
+	// Select all, then type a character.
+	pressKey(tf, ctx, event.KeyA, event.ModCtrl)
+	typeRune(tf, ctx, 'x')
+
+	if tf.Text() != "x" {
+		t.Errorf("text = %q, want %q", tf.Text(), "x")
+	}
+}
+
+func TestSelection_BackspaceDeletesSelection(t *testing.T) {
+	tf := textfield.New(textfield.InitialValue("hello"))
+	tf.SetBounds(geometry.NewRect(0, 0, 300, 48))
+	tf.SetFocused(true)
+	ctx := widget.NewContext()
+
+	// Select last 2 chars.
+	pressKey(tf, ctx, event.KeyLeft, event.ModShift)
+	pressKey(tf, ctx, event.KeyLeft, event.ModShift)
+	pressKey(tf, ctx, event.KeyBackspace, event.ModNone)
+
+	if tf.Text() != "hel" {
+		t.Errorf("text = %q, want %q", tf.Text(), "hel")
+	}
+}
+
+// --- Clipboard Tests ---
+
+func TestClipboard_CopyPaste(t *testing.T) {
+	tf := textfield.New(textfield.InitialValue("hello"))
+	tf.SetBounds(geometry.NewRect(0, 0, 300, 48))
+	tf.SetFocused(true)
+	ctx := widget.NewContext()
+
+	// Select all.
+	pressKey(tf, ctx, event.KeyA, event.ModCtrl)
+	// Copy.
+	pressKey(tf, ctx, event.KeyC, event.ModCtrl)
+	// Move to end.
+	pressKey(tf, ctx, event.KeyEnd, event.ModNone)
+	// Paste.
+	pressKey(tf, ctx, event.KeyV, event.ModCtrl)
+
+	if tf.Text() != "hellohello" {
+		t.Errorf("text = %q, want %q", tf.Text(), "hellohello")
+	}
+}
+
+func TestClipboard_Cut(t *testing.T) {
+	tf := textfield.New(textfield.InitialValue("hello"))
+	tf.SetBounds(geometry.NewRect(0, 0, 300, 48))
+	tf.SetFocused(true)
+	ctx := widget.NewContext()
+
+	// Select all.
+	pressKey(tf, ctx, event.KeyA, event.ModCtrl)
+	// Cut.
+	pressKey(tf, ctx, event.KeyX, event.ModCtrl)
+
+	if tf.Text() != "" {
+		t.Errorf("text = %q, want empty after cut", tf.Text())
+	}
+
+	// Paste.
+	pressKey(tf, ctx, event.KeyV, event.ModCtrl)
+
+	if tf.Text() != "hello" {
+		t.Errorf("text = %q, want %q after paste", tf.Text(), "hello")
+	}
+}
+
+// --- Mouse Interaction Tests ---
+
+func TestMouse_ClickFocuses(t *testing.T) {
+	tf := textfield.New()
+	tf.SetBounds(geometry.NewRect(0, 0, 300, 48))
+	ctx := widget.NewContext()
+
+	press := event.NewMouseEvent(event.MousePress, event.ButtonLeft, event.ButtonStateLeft,
+		geometry.Pt(50, 24), geometry.Pt(50, 24), event.ModNone)
+	tf.Event(ctx, press)
+
+	if !tf.IsFocused() {
+		t.Error("click should focus the text field")
+	}
+}
+
+func TestMouse_HoverCursor(t *testing.T) {
+	tf := textfield.New()
+	tf.SetBounds(geometry.NewRect(0, 0, 300, 48))
+	ctx := widget.NewContext()
+
+	enter := event.NewMouseEvent(event.MouseEnter, event.ButtonNone, 0,
+		geometry.Pt(50, 24), geometry.Pt(50, 24), event.ModNone)
+	tf.Event(ctx, enter)
+
+	if ctx.Cursor() != widget.CursorText {
+		t.Errorf("cursor = %v, want CursorText", ctx.Cursor())
+	}
+
+	leave := event.NewMouseEvent(event.MouseLeave, event.ButtonNone, 0,
+		geometry.Pt(-1, -1), geometry.Pt(-1, -1), event.ModNone)
+	tf.Event(ctx, leave)
+
+	if ctx.Cursor() != widget.CursorDefault {
+		t.Errorf("cursor = %v, want CursorDefault after leave", ctx.Cursor())
+	}
+}
+
+func TestMouse_DoubleClickSelectsWord(t *testing.T) {
+	tf := textfield.New(textfield.InitialValue("hello world"))
+	tf.SetBounds(geometry.NewRect(0, 0, 300, 48))
+	tf.SetFocused(true)
+	ctx := widget.NewContext()
+
+	// Double-click on the first character area.
+	dbl := event.NewMouseEvent(event.MouseDoubleClick, event.ButtonLeft, event.ButtonStateLeft,
+		geometry.Pt(12+2, 24), geometry.Pt(12+2, 24), event.ModNone)
+	tf.Event(ctx, dbl)
+
+	start, end := tf.Selection()
+	if start != 0 || end != 5 {
+		t.Errorf("selection = (%d, %d), want (0, 5) for word 'hello'", start, end)
+	}
+}
+
+// --- Disabled State Tests ---
+
+func TestDisabled_BlocksKeyInput(t *testing.T) {
+	tf := textfield.New(textfield.Disabled(true))
+	tf.SetBounds(geometry.NewRect(0, 0, 300, 48))
+	tf.SetFocused(true)
+	ctx := widget.NewContext()
+
+	consumed := typeRune(tf, ctx, 'x')
+
+	if consumed {
+		t.Error("disabled text field should not consume key events")
+	}
+	if tf.Text() != "" {
+		t.Error("disabled text field should not accept input")
+	}
+}
+
+func TestDisabled_BlocksMouseInput(t *testing.T) {
+	tf := textfield.New(textfield.Disabled(true))
+	tf.SetBounds(geometry.NewRect(0, 0, 300, 48))
+	ctx := widget.NewContext()
+
+	press := event.NewMouseEvent(event.MousePress, event.ButtonLeft, event.ButtonStateLeft,
+		geometry.Pt(50, 24), geometry.Pt(50, 24), event.ModNone)
+	consumed := tf.Event(ctx, press)
+
+	if consumed {
+		t.Error("disabled text field should not consume mouse events")
+	}
+}
+
+// --- Password Mode Tests ---
+
+func TestPassword_DrawsMaskedText(t *testing.T) {
+	tf := textfield.New(
+		textfield.InitialValue("secret"),
+		textfield.InputTypeOpt(textfield.TypePassword),
+	)
+	tf.SetBounds(geometry.NewRect(0, 0, 300, 48))
+	tf.SetFocused(true)
+	ctx := widget.NewContext()
+	canvas := &recordingCanvas{}
+
+	tf.Draw(ctx, canvas)
+
+	// The drawn text should be bullets, not the actual text.
+	for _, dt := range canvas.drawTexts {
+		if dt.text == "secret" {
+			t.Error("password field should not draw plaintext")
+		}
+	}
+}
+
+// --- Focus Tests ---
+
+func TestFocusable_Interface(t *testing.T) {
+	var f widget.Focusable = textfield.New()
+	_ = f
+}
+
+func TestFocus_SetFocused(t *testing.T) {
+	tf := textfield.New()
+
+	tf.SetFocused(true)
+	if !tf.IsFocused() {
+		t.Error("should be focused after SetFocused(true)")
+	}
+
+	tf.SetFocused(false)
+	if tf.IsFocused() {
+		t.Error("should not be focused after SetFocused(false)")
+	}
+}
+
+func TestFocusable_VisibleAndEnabled(t *testing.T) {
+	tf := textfield.New()
+
+	if !tf.IsFocusable() {
+		t.Error("visible+enabled text field should be focusable")
+	}
+
+	tf.SetVisible(false)
+	if tf.IsFocusable() {
+		t.Error("invisible text field should not be focusable")
+	}
+
+	tf.SetVisible(true)
+	tf.SetEnabled(false)
+	if tf.IsFocusable() {
+		t.Error("disabled text field should not be focusable")
+	}
+}
+
+// --- Accessibility Tests ---
+
+func TestA11y_Role(t *testing.T) {
+	tf := textfield.New()
+
+	if tf.AccessibleRole() != a11y.RoleTextField {
+		t.Errorf("role = %v, want RoleTextField", tf.AccessibleRole())
+	}
+}
+
+func TestA11y_Label(t *testing.T) {
+	tf := textfield.New(
+		textfield.Placeholder("Enter email"),
+		textfield.A11yLabel("Email address"),
+	)
+
+	if tf.AccessibleLabel() != "Email address" {
+		t.Errorf("label = %q, want %q", tf.AccessibleLabel(), "Email address")
+	}
+}
+
+func TestA11y_LabelFallsBackToPlaceholder(t *testing.T) {
+	tf := textfield.New(textfield.Placeholder("Enter email"))
+
+	if tf.AccessibleLabel() != "Enter email" {
+		t.Errorf("label = %q, want %q", tf.AccessibleLabel(), "Enter email")
+	}
+}
+
+func TestA11y_PasswordValueMasked(t *testing.T) {
+	tf := textfield.New(
+		textfield.InitialValue("secret"),
+		textfield.InputTypeOpt(textfield.TypePassword),
+	)
+
+	val := tf.AccessibleValue()
+	if val == "secret" {
+		t.Error("password accessible value should be masked")
+	}
+	if len([]rune(val)) != 6 {
+		t.Errorf("masked value length = %d, want 6", len([]rune(val)))
+	}
+}
+
+// --- Layout Tests ---
+
+func TestLayout_Size(t *testing.T) {
+	tf := textfield.New()
+	ctx := widget.NewContext()
+	constraints := geometry.Loose(geometry.Sz(400, 400))
+
+	size := tf.Layout(ctx, constraints)
+
+	if size.Width < 100 {
+		t.Errorf("width = %v, should be at least 100", size.Width)
+	}
+	if size.Height < 40 {
+		t.Errorf("height = %v, should be at least 40", size.Height)
+	}
+}
+
+func TestLayout_TightConstraints(t *testing.T) {
+	tf := textfield.New()
+	ctx := widget.NewContext()
+	constraints := geometry.Tight(geometry.Sz(200, 50))
+
+	size := tf.Layout(ctx, constraints)
+
+	if size.Width != 200 {
+		t.Errorf("width = %v, want 200", size.Width)
+	}
+	if size.Height != 50 {
+		t.Errorf("height = %v, want 50", size.Height)
+	}
+}
+
+// --- Draw Tests ---
+
+func TestDraw_DelegatesToPainter(t *testing.T) {
+	p := &testPainter{}
+	tf := textfield.New(
+		textfield.Placeholder("Test"),
+		textfield.PainterOpt(p),
+	)
+	tf.SetBounds(geometry.NewRect(0, 0, 300, 48))
+	ctx := widget.NewContext()
+	canvas := &mockCanvas{}
+
+	tf.Draw(ctx, canvas)
+
+	if !p.called {
+		t.Error("Draw should delegate to the configured painter")
+	}
+	if p.state.Placeholder != "Test" {
+		t.Errorf("PaintState.Placeholder = %q, want %q", p.state.Placeholder, "Test")
+	}
+}
+
+func TestDraw_DoesNotPanicWithBounds(t *testing.T) {
+	tf := textfield.New(textfield.Placeholder("Test"))
+	tf.SetBounds(geometry.NewRect(0, 0, 300, 48))
+	ctx := widget.NewContext()
+	canvas := &mockCanvas{}
+
+	tf.Draw(ctx, canvas)
+}
+
+// --- Widget Interface Compliance ---
+
+func TestWidgetInterface(t *testing.T) {
+	var w widget.Widget = textfield.New()
+	_ = w
+}
+
+func TestFocusableInterface(t *testing.T) {
+	var f widget.Focusable = textfield.New()
+	_ = f
+}
+
+// --- Fluent Styling Tests ---
+
+func TestFluent_Padding(t *testing.T) {
+	tf := textfield.New()
+	result := tf.Padding(16)
+
+	if result != tf {
+		t.Error("fluent methods should return the same widget")
+	}
+}
+
+// --- Tab Key Propagation ---
+
+func TestTab_NotConsumed(t *testing.T) {
+	tf := textfield.New()
+	tf.SetFocused(true)
+	ctx := widget.NewContext()
+
+	consumed := pressKey(tf, ctx, event.KeyTab, event.ModNone)
+
+	if consumed {
+		t.Error("Tab key should not be consumed (for focus navigation)")
+	}
+}
+
+// --- Edge Cases ---
+
+func TestUnfocused_IgnoresKeyEvents(t *testing.T) {
+	tf := textfield.New()
+	tf.SetBounds(geometry.NewRect(0, 0, 300, 48))
+	ctx := widget.NewContext()
+
+	consumed := typeRune(tf, ctx, 'a')
+
+	if consumed {
+		t.Error("unfocused text field should not consume key events")
+	}
+}
+
+func TestControlChars_Filtered(t *testing.T) {
+	tf := textfield.New()
+	tf.SetBounds(geometry.NewRect(0, 0, 300, 48))
+	tf.SetFocused(true)
+	ctx := widget.NewContext()
+
+	// Try to insert a control character.
+	e := event.NewKeyEvent(event.KeyPress, event.KeyUnknown, '\x01', event.ModNone)
+	tf.Event(ctx, e)
+
+	if tf.Text() != "" {
+		t.Errorf("control chars should be filtered, text = %q", tf.Text())
+	}
+}
+
+func TestArrowLeft_CollapseSelection(t *testing.T) {
+	tf := textfield.New(textfield.InitialValue("hello"))
+	tf.SetBounds(geometry.NewRect(0, 0, 300, 48))
+	tf.SetFocused(true)
+	ctx := widget.NewContext()
+
+	// Select some text.
+	pressKey(tf, ctx, event.KeyLeft, event.ModShift)
+	pressKey(tf, ctx, event.KeyLeft, event.ModShift)
+
+	// Arrow left without shift should collapse to selection start.
+	pressKey(tf, ctx, event.KeyLeft, event.ModNone)
+
+	start, end := tf.Selection()
+	if start != end {
+		t.Error("selection should be collapsed after arrow without shift")
+	}
+	if tf.CursorPosition() != 3 {
+		t.Errorf("cursor = %d, want 3", tf.CursorPosition())
+	}
+}
+
+func TestArrowRight_CollapseSelection(t *testing.T) {
+	tf := textfield.New(textfield.InitialValue("hello"))
+	tf.SetBounds(geometry.NewRect(0, 0, 300, 48))
+	tf.SetFocused(true)
+	ctx := widget.NewContext()
+
+	// Select some text (from end backwards).
+	pressKey(tf, ctx, event.KeyLeft, event.ModShift)
+	pressKey(tf, ctx, event.KeyLeft, event.ModShift)
+
+	// Arrow right without shift should collapse to selection end.
+	pressKey(tf, ctx, event.KeyRight, event.ModNone)
+
+	start, end := tf.Selection()
+	if start != end {
+		t.Error("selection should be collapsed after arrow without shift")
+	}
+	if tf.CursorPosition() != 5 {
+		t.Errorf("cursor = %d, want 5", tf.CursorPosition())
+	}
+}
+
+func TestShiftHome_Selection(t *testing.T) {
+	tf := textfield.New(textfield.InitialValue("hello"))
+	tf.SetBounds(geometry.NewRect(0, 0, 300, 48))
+	tf.SetFocused(true)
+	ctx := widget.NewContext()
+
+	pressKey(tf, ctx, event.KeyHome, event.ModShift)
+
+	start, end := tf.Selection()
+	if start != 0 || end != 5 {
+		t.Errorf("selection = (%d, %d), want (0, 5)", start, end)
+	}
+}
+
+func TestShiftEnd_Selection(t *testing.T) {
+	tf := textfield.New(textfield.InitialValue("hello"))
+	tf.SetBounds(geometry.NewRect(0, 0, 300, 48))
+	tf.SetFocused(true)
+	ctx := widget.NewContext()
+
+	pressKey(tf, ctx, event.KeyHome, event.ModNone)
+	pressKey(tf, ctx, event.KeyEnd, event.ModShift)
+
+	start, end := tf.Selection()
+	if start != 0 || end != 5 {
+		t.Errorf("selection = (%d, %d), want (0, 5)", start, end)
+	}
+}
+
+// --- PaintState / ColorScheme Tests ---
+
+func TestPaintState_ColorScheme(t *testing.T) {
+	scheme := textfield.TextFieldColorScheme{
+		Background:  widget.ColorWhite,
+		Border:      widget.ColorGray,
+		FocusBorder: widget.ColorBlue,
+		ErrorBorder: widget.ColorRed,
+		TextColor:   widget.ColorBlack,
+		Placeholder: widget.ColorLightGray,
+		CursorColor: widget.ColorBlue,
+		DisabledBg:  widget.ColorLightGray,
+		DisabledFg:  widget.ColorDarkGray,
+		SelectionBg: widget.ColorCyan,
+		ErrorText:   widget.ColorRed,
+	}
+
+	ps := textfield.PaintState{
+		Text:    "test",
+		Focused: true,
+		Bounds:  geometry.NewRect(0, 0, 300, 48),
+	}
+
+	// Verify the scheme has the expected values.
+	if scheme.FocusBorder != widget.ColorBlue {
+		t.Error("FocusBorder should be blue")
+	}
+	_ = ps
+}
+
+// --- Helper functions ---
+
+func typeRune(tf *textfield.Widget, ctx widget.Context, r rune) bool {
+	e := event.NewKeyEvent(event.KeyPress, event.KeyUnknown, r, event.ModNone)
+	return tf.Event(ctx, e)
+}
+
+func pressKey(tf *textfield.Widget, ctx widget.Context, key event.Key, mods event.Modifiers) bool {
+	e := event.NewKeyEvent(event.KeyPress, key, 0, mods)
+	return tf.Event(ctx, e)
+}
+
+// --- testPainter records calls ---
+
+type testPainter struct {
+	called bool
+	state  textfield.PaintState
+}
+
+func (p *testPainter) PaintTextField(_ widget.Canvas, ps textfield.PaintState) {
+	p.called = true
+	p.state = ps
+}
+
+// --- recordingCanvas records draw calls for verification ---
+
+type recordingCanvas struct {
+	drawTexts      []drawTextCall
+	drawRoundRects []drawRoundRectCall
+	drawRects      []drawRectCall
+	drawLines      []drawLineCall
+}
+
+type drawTextCall struct {
+	text     string
+	bounds   geometry.Rect
+	fontSize float32
+	color    widget.Color
+	bold     bool
+	align    float32
+}
+
+type drawRoundRectCall struct {
+	r      geometry.Rect
+	color  widget.Color
+	radius float32
+}
+
+type drawRectCall struct {
+	r     geometry.Rect
+	color widget.Color
+}
+
+type drawLineCall struct {
+	from, to    geometry.Point
+	color       widget.Color
+	strokeWidth float32
+}
+
+func (c *recordingCanvas) Clear(_ widget.Color)                                  {}
+func (c *recordingCanvas) StrokeRect(_ geometry.Rect, _ widget.Color, _ float32) {}
+
+func (c *recordingCanvas) DrawRect(r geometry.Rect, color widget.Color) {
+	c.drawRects = append(c.drawRects, drawRectCall{r: r, color: color})
+}
+
+func (c *recordingCanvas) DrawRoundRect(r geometry.Rect, color widget.Color, radius float32) {
+	c.drawRoundRects = append(c.drawRoundRects, drawRoundRectCall{r: r, color: color, radius: radius})
+}
+
+func (c *recordingCanvas) StrokeRoundRect(_ geometry.Rect, _ widget.Color, _ float32, _ float32) {}
+func (c *recordingCanvas) DrawCircle(_ geometry.Point, _ float32, _ widget.Color)                {}
+func (c *recordingCanvas) StrokeCircle(_ geometry.Point, _ float32, _ widget.Color, _ float32)   {}
+
+func (c *recordingCanvas) DrawLine(from, to geometry.Point, color widget.Color, strokeWidth float32) {
+	c.drawLines = append(c.drawLines, drawLineCall{from: from, to: to, color: color, strokeWidth: strokeWidth})
+}
+
+func (c *recordingCanvas) DrawText(text string, bounds geometry.Rect, fontSize float32, color widget.Color, bold bool, align float32) {
+	c.drawTexts = append(c.drawTexts, drawTextCall{text: text, bounds: bounds, fontSize: fontSize, color: color, bold: bold, align: align})
+}
+
+func (c *recordingCanvas) PushClip(_ geometry.Rect)       {}
+func (c *recordingCanvas) PopClip()                       {}
+func (c *recordingCanvas) PushTransform(_ geometry.Point) {}
+func (c *recordingCanvas) PopTransform()                  {}
+
+// --- mockCanvas for non-recording tests ---
+
+type mockCanvas struct{}
+
+func (c *mockCanvas) Clear(_ widget.Color)                                                  {}
+func (c *mockCanvas) DrawRect(_ geometry.Rect, _ widget.Color)                              {}
+func (c *mockCanvas) StrokeRect(_ geometry.Rect, _ widget.Color, _ float32)                 {}
+func (c *mockCanvas) DrawRoundRect(_ geometry.Rect, _ widget.Color, _ float32)              {}
+func (c *mockCanvas) StrokeRoundRect(_ geometry.Rect, _ widget.Color, _ float32, _ float32) {}
+func (c *mockCanvas) DrawCircle(_ geometry.Point, _ float32, _ widget.Color)                {}
+func (c *mockCanvas) StrokeCircle(_ geometry.Point, _ float32, _ widget.Color, _ float32)   {}
+func (c *mockCanvas) DrawLine(_, _ geometry.Point, _ widget.Color, _ float32)               {}
+
+func (c *mockCanvas) DrawText(_ string, _ geometry.Rect, _ float32, _ widget.Color, _ bool, _ float32) {
+}
+
+func (c *mockCanvas) PushClip(_ geometry.Rect)       {}
+func (c *mockCanvas) PopClip()                       {}
+func (c *mockCanvas) PushTransform(_ geometry.Point) {}
+func (c *mockCanvas) PopTransform()                  {}

--- a/core/textfield/types.go
+++ b/core/textfield/types.go
@@ -1,0 +1,45 @@
+package textfield
+
+// InputType represents the type of text input.
+// It determines input behavior such as masking and keyboard hints.
+type InputType uint8
+
+// Input type constants.
+const (
+	// TypeText is general-purpose text input (default).
+	TypeText InputType = iota
+
+	// TypePassword masks input characters with dots.
+	TypePassword
+
+	// TypeEmail is for email address input.
+	TypeEmail
+
+	// TypeNumber is for numeric input.
+	TypeNumber
+
+	// TypeSearch is for search input.
+	TypeSearch
+)
+
+// String returns a human-readable name for the input type.
+func (t InputType) String() string {
+	switch t {
+	case TypeText:
+		return "Text"
+	case TypePassword:
+		return "Password"
+	case TypeEmail:
+		return "Email"
+	case TypeNumber:
+		return "Number"
+	case TypeSearch:
+		return "Search"
+	default:
+		return "Unknown"
+	}
+}
+
+// ValidationFunc validates the text field value and returns an error message.
+// An empty string means the value is valid.
+type ValidationFunc func(value string) string

--- a/core/textfield/validation.go
+++ b/core/textfield/validation.go
@@ -1,0 +1,12 @@
+package textfield
+
+// runValidation executes all configured validation functions against the value.
+// Returns the first non-empty error message, or empty string if all validations pass.
+func runValidation(validators []ValidationFunc, value string) string {
+	for _, fn := range validators {
+		if msg := fn(value); msg != "" {
+			return msg
+		}
+	}
+	return ""
+}

--- a/core/textfield/widget.go
+++ b/core/textfield/widget.go
@@ -1,0 +1,258 @@
+package textfield
+
+import (
+	"github.com/gogpu/ui/event"
+	"github.com/gogpu/ui/geometry"
+	"github.com/gogpu/ui/widget"
+)
+
+// Widget implements a full-featured text input field with validation,
+// selection, and accessibility support.
+//
+// A text field is created with [New] using functional options:
+//
+//	field := textfield.New(
+//	    textfield.Placeholder("Enter email"),
+//	    textfield.OnChange(handleChange),
+//	    textfield.InputType(textfield.TypeEmail),
+//	    textfield.MaxLength(255),
+//	)
+//
+// Fluent styling methods may be chained after construction:
+//
+//	field.Padding(12)
+type Widget struct {
+	widget.WidgetBase
+	cfg     config
+	sel     selection
+	painter Painter
+
+	// Interaction state.
+	hovered  bool
+	dragging bool
+
+	// Validation state.
+	errorMsg string
+
+	// Styling overrides set via fluent methods.
+	padding float32
+}
+
+// New creates a new text field Widget with the given options.
+//
+// The returned widget is visible, enabled, and focusable by default.
+// Use options to configure placeholder, change handler, input type, etc.
+func New(opts ...Option) *Widget {
+	w := &Widget{
+		padding: defaultPaddingValue,
+		painter: DefaultPainter{},
+	}
+	w.SetVisible(true)
+	w.SetEnabled(true)
+
+	for _, opt := range opts {
+		opt(&w.cfg)
+	}
+
+	// Apply painter from config if set.
+	if w.cfg.painter != nil {
+		w.painter = w.cfg.painter
+	}
+
+	// Initialize text from signal if bound.
+	if w.cfg.signal != nil {
+		w.cfg.value = w.cfg.signal.Get()
+	}
+
+	// Place cursor at end of initial value.
+	runes := []rune(w.cfg.value)
+	w.sel.SetCursor(len(runes))
+
+	// Run initial validation.
+	if len(w.cfg.validation) > 0 {
+		w.errorMsg = runValidation(w.cfg.validation, w.cfg.value)
+	}
+
+	return w
+}
+
+// Default padding value.
+const defaultPaddingValue float32 = 4
+
+// Layout sizing constants.
+const (
+	defaultFieldHeight float32 = 48
+	minFieldWidth      float32 = 100
+)
+
+// IsFocusable reports whether the text field can currently receive focus.
+// A text field is focusable when it is visible, enabled, and not disabled.
+func (w *Widget) IsFocusable() bool {
+	return w.IsVisible() && w.IsEnabled() && !w.cfg.ResolvedDisabled()
+}
+
+// Layout calculates the text field's preferred size within the given constraints.
+func (w *Widget) Layout(_ widget.Context, constraints geometry.Constraints) geometry.Size {
+	preferred := geometry.Sz(minFieldWidth, defaultFieldHeight)
+	return constraints.Constrain(preferred)
+}
+
+// Draw renders the text field to the canvas.
+func (w *Widget) Draw(_ widget.Context, canvas widget.Canvas) {
+	// Sync from signal if bound.
+	if w.cfg.signal != nil {
+		current := w.cfg.signal.Get()
+		if current != w.cfg.value {
+			w.cfg.value = current
+			runes := []rune(current)
+			w.sel.SetCursor(clampPos(w.sel.cursor, len(runes)))
+		}
+	}
+
+	w.painter.PaintTextField(canvas, PaintState{
+		Text:        w.resolvedText(),
+		Placeholder: w.cfg.placeholder,
+		Focused:     w.IsFocused(),
+		Hovered:     w.hovered,
+		Disabled:    w.cfg.ResolvedDisabled(),
+		HasError:    w.errorMsg != "",
+		ErrorMsg:    w.errorMsg,
+		CursorPos:   w.sel.cursor,
+		SelectStart: w.sel.anchor,
+		SelectEnd:   w.sel.cursor,
+		InputType:   w.cfg.inputType,
+		Bounds:      w.Bounds(),
+	})
+}
+
+// Event handles an input event and returns true if consumed.
+func (w *Widget) Event(ctx widget.Context, e event.Event) bool {
+	return handleEvent(w, ctx, e)
+}
+
+// Children returns nil because a text field is a leaf widget.
+func (w *Widget) Children() []widget.Widget {
+	return nil
+}
+
+// Text returns the current text value.
+func (w *Widget) Text() string {
+	return w.resolvedText()
+}
+
+// SetText sets the text value programmatically and revalidates.
+func (w *Widget) SetText(text string) {
+	w.setText(text)
+	runes := []rune(text)
+	w.sel.SetCursor(clampPos(w.sel.cursor, len(runes)))
+	w.validate()
+}
+
+// ErrorMessage returns the current validation error message, or empty string if valid.
+func (w *Widget) ErrorMessage() string {
+	return w.errorMsg
+}
+
+// HasError returns true if the field has a validation error.
+func (w *Widget) HasError() bool {
+	return w.errorMsg != ""
+}
+
+// CursorPosition returns the current cursor position as a rune index.
+func (w *Widget) CursorPosition() int {
+	return w.sel.cursor
+}
+
+// Selection returns the current selection range as (start, end) rune indices.
+// If start == end, there is no selection.
+func (w *Widget) Selection() (int, int) {
+	return w.sel.OrderedRange()
+}
+
+// resolvedText returns the current text, preferring signal over config value.
+func (w *Widget) resolvedText() string {
+	if w.cfg.signal != nil {
+		return w.cfg.signal.Get()
+	}
+	return w.cfg.value
+}
+
+// setText updates the internal text value and the signal if bound.
+func (w *Widget) setText(text string) {
+	w.cfg.value = text
+	if w.cfg.signal != nil {
+		w.cfg.signal.Set(text)
+	}
+}
+
+// textRunes returns the current text as a rune slice.
+func (w *Widget) textRunes() []rune {
+	return []rune(w.resolvedText())
+}
+
+// insertText inserts text at the current cursor position.
+func (w *Widget) insertText(text string) {
+	runes := w.textRunes()
+	pos := w.sel.cursor
+	insertRunes := []rune(text)
+
+	// Check max length.
+	if w.cfg.maxLength > 0 {
+		remaining := w.cfg.maxLength - len(runes)
+		if remaining <= 0 {
+			return
+		}
+		if len(insertRunes) > remaining {
+			insertRunes = insertRunes[:remaining]
+		}
+	}
+
+	newRunes := make([]rune, 0, len(runes)+len(insertRunes))
+	newRunes = append(newRunes, runes[:pos]...)
+	newRunes = append(newRunes, insertRunes...)
+	newRunes = append(newRunes, runes[pos:]...)
+	w.setText(string(newRunes))
+	w.sel.SetCursor(pos + len(insertRunes))
+}
+
+// deleteSelection deletes the selected text and places cursor at selection start.
+func (w *Widget) deleteSelection() {
+	if !w.sel.HasSelection() {
+		return
+	}
+
+	runes := w.textRunes()
+	start, end := w.sel.OrderedRange()
+	newRunes := make([]rune, 0, len(runes)-(end-start))
+	newRunes = append(newRunes, runes[:start]...)
+	newRunes = append(newRunes, runes[end:]...)
+	w.setText(string(newRunes))
+	w.sel.SetCursor(start)
+}
+
+// notifyChange fires the onChange callback and runs validation.
+func (w *Widget) notifyChange(ctx widget.Context) {
+	w.validate()
+	if w.cfg.onChange != nil {
+		w.cfg.onChange(w.resolvedText())
+	}
+	ctx.Invalidate()
+}
+
+// validate runs all configured validation functions.
+func (w *Widget) validate() {
+	w.errorMsg = runValidation(w.cfg.validation, w.resolvedText())
+}
+
+// Padding sets the padding around the text field content.
+// Returns the widget for method chaining.
+func (w *Widget) Padding(v float32) *Widget {
+	w.padding = v
+	return w
+}
+
+// Verify Widget implements required interfaces at compile time.
+var (
+	_ widget.Widget    = (*Widget)(nil)
+	_ widget.Focusable = (*Widget)(nil)
+)

--- a/primitives/box.go
+++ b/primitives/box.go
@@ -241,17 +241,9 @@ func (b *BoxWidget) Draw(ctx widget.Context, canvas widget.Canvas) {
 
 	bounds := b.Bounds()
 
-	// Draw shadow
+	// Draw shadow layers (outermost first, innermost last).
 	if !b.style.Shadow.IsZero() {
-		offset := shadowOffset(b.style.Shadow.Level)
-		alpha := shadowAlpha(b.style.Shadow.Level)
-		shadowColor := widget.RGBA(0, 0, 0, alpha)
-		shadowRect := bounds.TranslateXY(offset/2, offset)
-		if b.style.Radius > 0 {
-			canvas.DrawRoundRect(shadowRect, shadowColor, b.style.Radius)
-		} else {
-			canvas.DrawRect(shadowRect, shadowColor)
-		}
+		b.drawShadow(canvas, bounds)
 	}
 
 	// Draw background
@@ -278,6 +270,24 @@ func (b *BoxWidget) Draw(ctx widget.Context, canvas widget.Canvas) {
 		child.Draw(ctx, canvas)
 	}
 	canvas.PopTransform()
+}
+
+// drawShadow renders multi-layer concentric rounded rectangles that
+// approximate a Gaussian blur shadow. Each layer is slightly larger and
+// more offset than the previous one, with decreasing alpha, creating
+// a soft gradient falloff that looks like a real elevation shadow.
+func (b *BoxWidget) drawShadow(canvas widget.Canvas, bounds geometry.Rect) {
+	layers := shadowLayers(b.style.Shadow.Level)
+	for _, layer := range layers {
+		r := bounds.Expand(layer.spread).TranslateXY(layer.offsetX, layer.offsetY)
+		color := widget.RGBA(0, 0, 0, layer.alpha)
+		radius := b.style.Radius + layer.radiusExtra
+		if radius > 0 {
+			canvas.DrawRoundRect(r, color, radius)
+		} else {
+			canvas.DrawRect(r, color)
+		}
+	}
 }
 
 // Event dispatches the event to children. Returns true if any child consumed it.

--- a/primitives/box_test.go
+++ b/primitives/box_test.go
@@ -288,15 +288,72 @@ func TestBoxDrawRoundedBackground(t *testing.T) {
 	}
 }
 
-func TestBoxDrawShadow(t *testing.T) {
+func TestBoxDrawShadowMultiLayer(t *testing.T) {
+	// Level 3 has 3 layers. Even without box radius, shadow layers have
+	// radiusExtra > 0, so they use DrawRoundRect.
 	b := primitives.Box().ShadowLevel(3).Width(100).Height(50)
 	ctx := widget.NewContext()
 	canvas := &mockCanvas{}
 	_ = b.Layout(ctx, geometry.Loose(geometry.Sz(200, 200)))
 	b.Draw(ctx, canvas)
 
-	if canvas.drawRectCount == 0 {
-		t.Error("expected shadow DrawRect call")
+	if canvas.drawRoundRectCount < 3 {
+		t.Errorf("level 3 shadow should produce at least 3 DrawRoundRect calls, got %d",
+			canvas.drawRoundRectCount)
+	}
+}
+
+func TestBoxDrawShadowRoundedMultiLayer(t *testing.T) {
+	// Level 2 with rounded corners and visible background.
+	// Level 2 has 3 shadow layers (DrawRoundRect each) + 1 background = 4.
+	b := primitives.Box().
+		ShadowLevel(2).
+		Rounded(8).
+		Background(widget.ColorWhite).
+		Width(100).Height(50)
+	ctx := widget.NewContext()
+	canvas := &mockCanvas{}
+	_ = b.Layout(ctx, geometry.Loose(geometry.Sz(200, 200)))
+	b.Draw(ctx, canvas)
+
+	// 3 shadow layers (DrawRoundRect) + 1 background (DrawRoundRect) = 4
+	if canvas.drawRoundRectCount != 4 {
+		t.Errorf("level 2 rounded shadow + background should produce 4 DrawRoundRect calls, got %d",
+			canvas.drawRoundRectCount)
+	}
+}
+
+func TestBoxDrawShadowLevelZero(t *testing.T) {
+	// Level 0 should produce no shadow draw calls at all.
+	b := primitives.Box().ShadowLevel(0).Background(widget.ColorWhite).Width(100).Height(50)
+	ctx := widget.NewContext()
+	canvas := &mockCanvas{}
+	_ = b.Layout(ctx, geometry.Loose(geometry.Sz(200, 200)))
+	b.Draw(ctx, canvas)
+
+	// Only 1 DrawRect for background, no shadow rects.
+	if canvas.drawRectCount != 1 {
+		t.Errorf("level 0 shadow should produce only background DrawRect (1), got %d", canvas.drawRectCount)
+	}
+}
+
+func TestBoxDrawShadowProgressiveLayers(t *testing.T) {
+	// Higher shadow levels should produce more or equal draw calls.
+	// All shadow layers have radiusExtra > 0, so they use DrawRoundRect.
+	ctx := widget.NewContext()
+	var prevCount int
+	for level := 1; level <= 5; level++ {
+		b := primitives.Box().ShadowLevel(level).Width(100).Height(50)
+		canvas := &mockCanvas{}
+		_ = b.Layout(ctx, geometry.Loose(geometry.Sz(200, 200)))
+		b.Draw(ctx, canvas)
+
+		count := canvas.drawRoundRectCount
+		if level > 1 && count < prevCount {
+			t.Errorf("level %d produced %d DrawRoundRect calls, less than level %d (%d)",
+				level, count, level-1, prevCount)
+		}
+		prevCount = count
 	}
 }
 

--- a/primitives/shadow_test.go
+++ b/primitives/shadow_test.go
@@ -1,0 +1,108 @@
+package primitives
+
+import "testing"
+
+// TestShadowLayersLevelZero verifies that level 0 produces no shadow layers.
+func TestShadowLayersLevelZero(t *testing.T) {
+	layers := shadowLayers(0)
+	if layers != nil {
+		t.Errorf("level 0 should return nil, got %d layers", len(layers))
+	}
+}
+
+// TestShadowLayersNegativeLevel verifies that negative levels produce no layers.
+func TestShadowLayersNegativeLevel(t *testing.T) {
+	layers := shadowLayers(-5)
+	if layers != nil {
+		t.Errorf("negative level should return nil, got %d layers", len(layers))
+	}
+}
+
+// TestShadowLayersCountPerLevel verifies the expected number of layers at
+// each elevation level.
+func TestShadowLayersCountPerLevel(t *testing.T) {
+	tests := []struct {
+		name  string
+		level int
+		want  int
+	}{
+		{"level 1 has 2 layers", 1, 2},
+		{"level 2 has 3 layers", 2, 3},
+		{"level 3 has 3 layers", 3, 3},
+		{"level 4 has 4 layers", 4, 4},
+		{"level 5 has 4 layers", 5, 4},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			layers := shadowLayers(tt.level)
+			if len(layers) != tt.want {
+				t.Errorf("shadowLayers(%d) returned %d layers, want %d", tt.level, len(layers), tt.want)
+			}
+		})
+	}
+}
+
+// TestShadowLayersOverflowClamped verifies that levels beyond maxShadowLevel
+// are clamped to level 5.
+func TestShadowLayersOverflowClamped(t *testing.T) {
+	layers := shadowLayers(99)
+	expected := shadowLayers(maxShadowLevel)
+	if len(layers) != len(expected) {
+		t.Errorf("overflow level should clamp to %d, got %d layers (want %d)",
+			maxShadowLevel, len(layers), len(expected))
+	}
+}
+
+// TestShadowLayersProgressiveElevation verifies that higher levels have
+// larger total alpha (more visible shadow) and larger total spread.
+func TestShadowLayersProgressiveElevation(t *testing.T) {
+	var prevAlpha, prevSpread float32
+	for level := 1; level <= maxShadowLevel; level++ {
+		layers := shadowLayers(level)
+
+		var totalAlpha, totalSpread float32
+		for _, l := range layers {
+			totalAlpha += l.alpha
+			totalSpread += l.spread
+		}
+
+		if level > 1 {
+			if totalAlpha < prevAlpha {
+				t.Errorf("level %d total alpha (%.3f) < level %d (%.3f): shadow should grow",
+					level, totalAlpha, level-1, prevAlpha)
+			}
+			if totalSpread < prevSpread {
+				t.Errorf("level %d total spread (%.1f) < level %d (%.1f): shadow should grow",
+					level, totalSpread, level-1, prevSpread)
+			}
+		}
+		prevAlpha = totalAlpha
+		prevSpread = totalSpread
+	}
+}
+
+// TestShadowLayersAlphaRange verifies that all alpha values are within
+// the valid range (0, 1].
+func TestShadowLayersAlphaRange(t *testing.T) {
+	for level := 1; level <= maxShadowLevel; level++ {
+		for i, l := range shadowLayers(level) {
+			if l.alpha <= 0 || l.alpha > 1 {
+				t.Errorf("level %d layer %d: alpha %.3f out of range (0, 1]", level, i, l.alpha)
+			}
+		}
+	}
+}
+
+// TestShadowLayersOutermostFirst verifies that layers are ordered with the
+// outermost (largest spread) first and innermost (smallest spread) last.
+func TestShadowLayersOutermostFirst(t *testing.T) {
+	for level := 1; level <= maxShadowLevel; level++ {
+		layers := shadowLayers(level)
+		for i := 1; i < len(layers); i++ {
+			if layers[i].spread > layers[i-1].spread {
+				t.Errorf("level %d: layer %d spread (%.1f) > layer %d spread (%.1f): should decrease",
+					level, i, layers[i].spread, i-1, layers[i-1].spread)
+			}
+		}
+	}
+}

--- a/primitives/style.go
+++ b/primitives/style.go
@@ -131,28 +131,77 @@ func (s Shadow) IsZero() bool {
 	return s.Level <= 0
 }
 
-// shadowAlpha returns the alpha value for a given shadow level.
-// Each level increases opacity slightly.
-func shadowAlpha(level int) float32 {
-	if level <= 0 {
-		return 0
-	}
-	if level > maxShadowLevel {
-		level = maxShadowLevel
-	}
-	// Linear ramp: level 1 = 0.08, level 5 = 0.40
-	return float32(level) * 0.08
+// shadowLayer describes a single concentric layer in a multi-layer shadow.
+//
+// Multiple layers with decreasing alpha and increasing spread approximate
+// a Gaussian blur without requiring a GPU compute pass.
+type shadowLayer struct {
+	// offsetX is the horizontal offset in logical pixels.
+	offsetX float32
+	// offsetY is the vertical offset in logical pixels.
+	offsetY float32
+	// spread expands the rect by this amount on all sides.
+	spread float32
+	// alpha is the opacity of this layer (0..1).
+	alpha float32
+	// radiusExtra is added to the box corner radius for this layer.
+	radiusExtra float32
 }
 
-// shadowOffset returns the vertical offset for a given shadow level.
-func shadowOffset(level int) float32 {
+// shadowLayers returns the multi-layer shadow definition for a given
+// elevation level. Each level uses progressively more layers with larger
+// offsets and spreads to approximate Gaussian blur.
+//
+// Level 0 returns nil (no shadow). Levels 1-5 return 2-4 layers ordered
+// from outermost (softest, most spread) to innermost (sharpest, least spread).
+func shadowLayers(level int) []shadowLayer {
 	if level <= 0 {
-		return 0
+		return nil
 	}
 	if level > maxShadowLevel {
 		level = maxShadowLevel
 	}
-	return float32(level) * 2
+	return shadowPresets[level-1]
+}
+
+// shadowPresets contains pre-computed shadow layers for levels 1-5.
+// Each preset is ordered outermost-first so that inner (darker) layers
+// paint on top of outer (lighter) ones.
+//
+// The values approximate Material Design elevation shadows using
+// concentric rounded rectangles with varying alpha and spread.
+var shadowPresets = [maxShadowLevel][]shadowLayer{
+	// Level 1: subtle elevation (cards at rest). 2 layers.
+	{
+		{offsetX: 0, offsetY: 0.5, spread: 3, alpha: 0.04, radiusExtra: 3},
+		{offsetX: 0, offsetY: 1, spread: 1, alpha: 0.08, radiusExtra: 1},
+	},
+	// Level 2: medium elevation (hovering buttons, raised cards). 3 layers.
+	{
+		{offsetX: 0, offsetY: 1, spread: 6, alpha: 0.04, radiusExtra: 4},
+		{offsetX: 0, offsetY: 2, spread: 3, alpha: 0.06, radiusExtra: 2},
+		{offsetX: 0, offsetY: 2, spread: 1, alpha: 0.10, radiusExtra: 0},
+	},
+	// Level 3: pronounced elevation (navigation drawers, menus). 3 layers.
+	{
+		{offsetX: 0, offsetY: 2, spread: 10, alpha: 0.04, radiusExtra: 5},
+		{offsetX: 0, offsetY: 4, spread: 5, alpha: 0.06, radiusExtra: 3},
+		{offsetX: 0, offsetY: 4, spread: 2, alpha: 0.12, radiusExtra: 1},
+	},
+	// Level 4: strong elevation (dialogs). 4 layers.
+	{
+		{offsetX: 0, offsetY: 3, spread: 14, alpha: 0.03, radiusExtra: 6},
+		{offsetX: 0, offsetY: 6, spread: 8, alpha: 0.05, radiusExtra: 4},
+		{offsetX: 0, offsetY: 6, spread: 4, alpha: 0.08, radiusExtra: 2},
+		{offsetX: 0, offsetY: 8, spread: 2, alpha: 0.12, radiusExtra: 0},
+	},
+	// Level 5: highest elevation (tooltips, overlays). 4 layers.
+	{
+		{offsetX: 0, offsetY: 4, spread: 18, alpha: 0.03, radiusExtra: 8},
+		{offsetX: 0, offsetY: 8, spread: 10, alpha: 0.05, radiusExtra: 5},
+		{offsetX: 0, offsetY: 10, spread: 5, alpha: 0.08, radiusExtra: 2},
+		{offsetX: 0, offsetY: 12, spread: 2, alpha: 0.14, radiusExtra: 0},
+	},
 }
 
 // ImageSource provides the natural dimensions of an image.

--- a/theme/material3/textfield.go
+++ b/theme/material3/textfield.go
@@ -1,0 +1,222 @@
+package material3
+
+import (
+	"github.com/gogpu/ui/core/textfield"
+	"github.com/gogpu/ui/geometry"
+	"github.com/gogpu/ui/widget"
+)
+
+// TextFieldPainter renders text fields using Material 3 design tokens.
+// It implements the outlined text field variant with theme-derived colors.
+//
+// If Theme is nil, TextFieldPainter falls back to the default M3 purple palette.
+type TextFieldPainter struct {
+	Theme *Theme // nil uses default M3 purple fallback
+}
+
+// resolveColors returns the TextFieldColorScheme derived from the painter's Theme.
+// If Theme is nil, it returns the default M3 text field color scheme.
+func (p TextFieldPainter) resolveColors() textfield.TextFieldColorScheme {
+	if p.Theme == nil {
+		return m3DefaultTextFieldColors
+	}
+	cs := p.Theme.Colors
+	return textfield.TextFieldColorScheme{
+		Background:  cs.Surface,
+		Border:      cs.Outline,
+		FocusBorder: cs.Primary,
+		ErrorBorder: cs.Error,
+		TextColor:   cs.OnSurface,
+		Placeholder: cs.OnSurfaceVariant,
+		CursorColor: cs.Primary,
+		DisabledBg:  cs.OnSurface.WithAlpha(0.04),
+		DisabledFg:  cs.OnSurface.WithAlpha(0.38),
+		SelectionBg: cs.Primary.WithAlpha(0.2),
+		ErrorText:   cs.Error,
+	}
+}
+
+// PaintTextField renders a text field according to Material 3 specifications.
+func (p TextFieldPainter) PaintTextField(canvas widget.Canvas, st textfield.PaintState) {
+	if st.Bounds.IsEmpty() {
+		return
+	}
+
+	colors := p.resolveColors()
+	m3PaintTextFieldBg(canvas, st, colors)
+	m3PaintTextFieldBorder(canvas, st, colors)
+	m3PaintTextFieldContent(canvas, st, colors)
+	m3PaintTextFieldCursor(canvas, st, colors)
+	m3PaintTextFieldError(canvas, st, colors)
+}
+
+// m3PaintTextFieldBg draws the text field background.
+func m3PaintTextFieldBg(canvas widget.Canvas, st textfield.PaintState, colors textfield.TextFieldColorScheme) {
+	bg := colors.Background
+	if st.Disabled {
+		bg = colors.DisabledBg
+	}
+	canvas.DrawRoundRect(st.Bounds, bg, m3TFCornerRadius)
+}
+
+// m3PaintTextFieldBorder draws the text field outline.
+func m3PaintTextFieldBorder(canvas widget.Canvas, st textfield.PaintState, colors textfield.TextFieldColorScheme) {
+	borderColor := colors.Border
+	strokeWidth := m3TFBorderWidth
+
+	switch {
+	case st.Disabled:
+		borderColor = colors.DisabledFg
+	case st.HasError:
+		borderColor = colors.ErrorBorder
+		strokeWidth = m3TFFocusBorderWidth
+	case st.Focused:
+		borderColor = colors.FocusBorder
+		strokeWidth = m3TFFocusBorderWidth
+	case st.Hovered:
+		borderColor = colors.TextColor
+	}
+
+	canvas.StrokeRoundRect(st.Bounds, borderColor, m3TFCornerRadius, strokeWidth)
+}
+
+// m3PaintTextFieldContent draws the text or placeholder.
+func m3PaintTextFieldContent(canvas widget.Canvas, st textfield.PaintState, colors textfield.TextFieldColorScheme) {
+	contentBounds := m3TFContentRect(st.Bounds)
+
+	canvas.PushClip(contentBounds)
+	defer canvas.PopClip()
+
+	displayText := st.Text
+	if st.InputType == textfield.TypePassword {
+		displayText = m3MaskText(len([]rune(st.Text)))
+	}
+
+	if displayText == "" && !st.Focused {
+		color := colors.Placeholder
+		if st.Disabled {
+			color = colors.DisabledFg
+		}
+		canvas.DrawText(st.Placeholder, contentBounds, m3TFFontSize, color, false, m3TFTextAlignLeft)
+		return
+	}
+
+	textColor := colors.TextColor
+	if st.Disabled {
+		textColor = colors.DisabledFg
+	}
+
+	// Draw selection highlight.
+	if st.SelectStart != st.SelectEnd {
+		m3PaintTextFieldSelection(canvas, contentBounds, st, colors)
+	}
+
+	canvas.DrawText(displayText, contentBounds, m3TFFontSize, textColor, false, m3TFTextAlignLeft)
+}
+
+// m3PaintTextFieldSelection draws the selection highlight.
+func m3PaintTextFieldSelection(canvas widget.Canvas, contentBounds geometry.Rect, st textfield.PaintState, colors textfield.TextFieldColorScheme) {
+	selStart := st.SelectStart
+	selEnd := st.SelectEnd
+	if selStart > selEnd {
+		selStart, selEnd = selEnd, selStart
+	}
+
+	charWidth := m3TFFontSize * m3TFCharWidthRatio
+	x1 := contentBounds.Min.X + float32(selStart)*charWidth
+	x2 := contentBounds.Min.X + float32(selEnd)*charWidth
+
+	if x2 > contentBounds.Max.X {
+		x2 = contentBounds.Max.X
+	}
+
+	selRect := geometry.Rect{
+		Min: geometry.Pt(x1, contentBounds.Min.Y),
+		Max: geometry.Pt(x2, contentBounds.Max.Y),
+	}
+	canvas.DrawRect(selRect, colors.SelectionBg)
+}
+
+// m3PaintTextFieldCursor draws the blinking caret.
+func m3PaintTextFieldCursor(canvas widget.Canvas, st textfield.PaintState, colors textfield.TextFieldColorScheme) {
+	if !st.Focused || st.Disabled || st.SelectStart != st.SelectEnd {
+		return
+	}
+
+	content := m3TFContentRect(st.Bounds)
+	charWidth := m3TFFontSize * m3TFCharWidthRatio
+	cursorX := content.Min.X + float32(st.CursorPos)*charWidth
+
+	if cursorX > content.Max.X {
+		cursorX = content.Max.X
+	}
+
+	top := geometry.Pt(cursorX, content.Min.Y+m3TFCursorPadding)
+	bottom := geometry.Pt(cursorX, content.Max.Y-m3TFCursorPadding)
+	canvas.DrawLine(top, bottom, colors.CursorColor, m3TFCursorWidth)
+}
+
+// m3PaintTextFieldError draws the error message below the text field.
+func m3PaintTextFieldError(canvas widget.Canvas, st textfield.PaintState, colors textfield.TextFieldColorScheme) {
+	if !st.HasError || st.ErrorMsg == "" {
+		return
+	}
+
+	errBounds := geometry.Rect{
+		Min: geometry.Pt(st.Bounds.Min.X+m3TFContentPaddingH, st.Bounds.Max.Y+m3TFErrorTopGap),
+		Max: geometry.Pt(st.Bounds.Max.X, st.Bounds.Max.Y+m3TFErrorTopGap+m3TFErrorFontSize+m3TFErrorBottomPadding),
+	}
+	canvas.DrawText(st.ErrorMsg, errBounds, m3TFErrorFontSize, colors.ErrorText, false, m3TFTextAlignLeft)
+}
+
+// m3TFContentRect returns the inner content area for text.
+func m3TFContentRect(bounds geometry.Rect) geometry.Rect {
+	return geometry.Rect{
+		Min: geometry.Pt(bounds.Min.X+m3TFContentPaddingH, bounds.Min.Y+m3TFContentPaddingV),
+		Max: geometry.Pt(bounds.Max.X-m3TFContentPaddingH, bounds.Max.Y-m3TFContentPaddingV),
+	}
+}
+
+// m3MaskText returns a string of bullet characters with the given length.
+func m3MaskText(length int) string {
+	runes := make([]rune, length)
+	for i := range runes {
+		runes[i] = '\u2022'
+	}
+	return string(runes)
+}
+
+// m3DefaultTextFieldColors holds the default M3 text field color scheme.
+var m3DefaultTextFieldColors = textfield.TextFieldColorScheme{
+	Background:  widget.ColorWhite,
+	Border:      widget.Hex(0x79747E),                // M3 outline
+	FocusBorder: widget.Hex(0x6750A4),                // M3 primary
+	ErrorBorder: widget.Hex(0xB3261E),                // M3 error
+	TextColor:   widget.Hex(0x1C1B1F),                // M3 on-surface
+	Placeholder: widget.Hex(0x49454F),                // M3 on-surface-variant
+	CursorColor: widget.Hex(0x6750A4),                // M3 primary
+	DisabledBg:  widget.RGBA(0.12, 0.12, 0.13, 0.04), // M3 disabled surface
+	DisabledFg:  widget.RGBA(0.12, 0.12, 0.13, 0.38), // M3 disabled fg
+	SelectionBg: widget.Hex(0x6750A4).WithAlpha(0.2), // M3 primary 20%
+	ErrorText:   widget.Hex(0xB3261E),                // M3 error
+}
+
+// M3 text field drawing constants.
+const (
+	m3TFCornerRadius       float32 = 4
+	m3TFBorderWidth        float32 = 1
+	m3TFFocusBorderWidth   float32 = 2
+	m3TFContentPaddingH    float32 = 16
+	m3TFContentPaddingV    float32 = 12
+	m3TFFontSize           float32 = 16
+	m3TFCharWidthRatio     float32 = 0.55
+	m3TFTextAlignLeft      float32 = 0
+	m3TFCursorWidth        float32 = 2
+	m3TFCursorPadding      float32 = 2
+	m3TFErrorFontSize      float32 = 12
+	m3TFErrorTopGap        float32 = 4
+	m3TFErrorBottomPadding float32 = 4
+)
+
+// Compile-time check that TextFieldPainter implements Painter.
+var _ textfield.Painter = TextFieldPainter{}


### PR DESCRIPTION
## Summary

- **TextField widget** (`core/textfield/`) — full-featured text input: cursor, selection, clipboard (Ctrl+A/C/X/V), password masking, validation, signal two-way binding, accessibility (role=textbox). 12 functional options, pluggable Painter interface, 55 tests
- **M3 TextField painter** (`theme/material3/textfield.go`) — outlined variant with theme-derived colors
- **Multi-layer box shadow** — Material Design elevation using 3-4 concentric semi-transparent rounded rects (approximated Gaussian blur). Levels 1-5 with progressive elevation

## Test results

- All 23 packages pass, 0 failures
- 55 new TextField tests
- 17 new shadow tests
- Lint: 0 issues
- 18 files, +2835 lines