### PR TITLE
feat: overlay infrastructure, dropdown/select widget, ThemeScope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Overlay infrastructure** (`overlay/`) — window-level overlay stack for popups, dropdowns, tooltips, and modals. Stack with push/pop/remove, Container with dismiss-on-click-outside and Escape key, Position helper with viewport clamping and flip logic. 30+ tests
+- **Dropdown/Select widget** (`core/dropdown/`) — full-featured dropdown with trigger, floating menu overlay, keyboard navigation (Up/Down/Enter/Escape/Home/End), mouse hover highlight, mouse wheel scrolling, max visible items with clipping, signal two-way binding, accessibility (role=combobox). 11 functional options, pluggable Painter interface, 55 tests
+- **Material 3 Dropdown painter** (`theme/material3/dropdown.go`) — outlined trigger with chevron indicator, menu with hover/selected highlights, theme-derived colors
+- **ThemeScope widget** (`primitives/themescope.go`) — overrides theme for widget subtree. Nested scoping (inner wins), nil passthrough, context wrapper pattern. 22 tests
 - **TextField widget** (`core/textfield/`) — full-featured text input with cursor, selection, clipboard (Ctrl+A/C/X/V), password masking, validation, signal two-way binding, accessibility (role=textbox). 12 functional options, pluggable Painter interface, 55 tests
 - **Material 3 TextField painter** (`theme/material3/textfield.go`) — outlined variant with theme-derived colors (Primary focus, Outline unfocused, Error invalid)
+- **OverlayManager interface** (`widget/context.go`) — `PushOverlay`, `PopOverlay`, `RemoveOverlay` on Context for widget access to overlay stack
+- **WindowSize on Context** (`widget/context.go`) — `WindowSize()` method for overlay positioning calculations
 
 ### Changed
 - **Multi-layer box shadow** — Material Design elevation now uses 3-4 concentric semi-transparent rounded rects (approximated Gaussian blur) instead of single flat rectangle. Levels 1-5 with progressive elevation

--- a/app/window.go
+++ b/app/window.go
@@ -6,6 +6,7 @@ import (
 	"github.com/gogpu/gpucontext"
 	"github.com/gogpu/ui/event"
 	"github.com/gogpu/ui/geometry"
+	"github.com/gogpu/ui/overlay"
 	"github.com/gogpu/ui/state"
 	"github.com/gogpu/ui/theme"
 	"github.com/gogpu/ui/widget"
@@ -32,6 +33,7 @@ type Window struct {
 	pp        gpucontext.PlatformProvider
 	scheduler *state.Scheduler
 	theme     *theme.Theme
+	overlays  *overlay.Stack
 
 	// needsLayout indicates that layout should be recalculated.
 	needsLayout bool
@@ -61,6 +63,14 @@ func newWindow(
 		needsLayout: true,
 	}
 
+	// Initialize overlay stack.
+	w.overlays = overlay.NewStack(func() {
+		w.needsLayout = true
+		if w.wp != nil {
+			w.wp.RequestRedraw()
+		}
+	})
+
 	// Set the theme provider on the context so widgets can access theme.
 	if t != nil {
 		ctx.SetThemeProvider(t)
@@ -71,6 +81,9 @@ func newWindow(
 
 	// Set initial window size.
 	w.updateWindowSize()
+
+	// Set overlay manager on context so widgets can push/remove overlays.
+	ctx.SetOverlayManager(&windowOverlayManager{window: w})
 
 	// Wire invalidation callback to request redraw.
 	ctx.SetOnInvalidate(func() {
@@ -115,8 +128,9 @@ func (w *Window) setTheme(t *theme.Theme) {
 
 // HandleEvent dispatches a single event to the widget tree.
 //
-// Events are propagated to the root widget. If the root widget does not
-// consume the event, it is silently discarded.
+// Events are first offered to the overlay stack (top overlay has priority).
+// If no overlay consumes the event (and no modal overlay blocks it),
+// the event is propagated to the root widget.
 func (w *Window) HandleEvent(e event.Event) {
 	if w.root == nil || e == nil {
 		return
@@ -124,6 +138,11 @@ func (w *Window) HandleEvent(e event.Event) {
 
 	// Update context time for event processing.
 	w.ctx.SetNow(time.Now())
+
+	// Overlays get priority.
+	if w.overlays.HandleEvent(w.ctx, e) {
+		return
+	}
 
 	// Dispatch event to root widget.
 	_ = w.root.Event(w.ctx, e)
@@ -230,11 +249,14 @@ func (w *Window) WindowSize() geometry.Size {
 	return w.windowSize
 }
 
-// layout performs the layout pass on the widget tree.
+// layout performs the layout pass on the widget tree and overlays.
 func (w *Window) layout() {
 	if w.root == nil {
 		return
 	}
+
+	// Update window size on context so widgets can access it.
+	w.ctx.SetWindowSize(w.windowSize)
 
 	// Create tight constraints matching the window size.
 	constraints := geometry.Tight(w.windowSize)
@@ -246,6 +268,9 @@ func (w *Window) layout() {
 	if setter, ok := w.root.(interface{ SetBounds(geometry.Rect) }); ok {
 		setter.SetBounds(geometry.NewRect(0, 0, size.Width, size.Height))
 	}
+
+	// Layout overlays with window-sized constraints.
+	w.overlays.Layout(w.ctx, w.windowSize)
 }
 
 // draw performs the draw pass on the widget tree.
@@ -267,13 +292,17 @@ func (w *Window) draw() {
 // DrawTo performs the draw pass using the provided canvas.
 //
 // This method is called by the host application when it has a canvas
-// ready for drawing.
+// ready for drawing. It draws the root widget tree and then all overlays
+// on top.
 func (w *Window) DrawTo(canvas widget.Canvas) {
 	if w.root == nil || canvas == nil {
 		return
 	}
 
 	w.root.Draw(w.ctx, canvas)
+
+	// Draw overlays on top (bottom to top).
+	w.overlays.Draw(w.ctx, canvas)
 }
 
 // syncCursor forwards the cursor state to the platform provider.
@@ -310,6 +339,50 @@ func (w *Window) updateWindowSize() {
 		w.windowSize = geometry.Sz(defaultWidth, defaultHeight)
 	}
 }
+
+// Overlays returns the window's overlay stack.
+func (w *Window) Overlays() *overlay.Stack {
+	return w.overlays
+}
+
+// windowOverlayManager adapts the Window's overlay.Stack to the
+// widget.OverlayManager interface. This avoids circular imports since
+// the widget package cannot import the overlay package.
+type windowOverlayManager struct {
+	window *Window
+}
+
+// PushOverlay wraps the widget in an overlay.Container and pushes it.
+func (m *windowOverlayManager) PushOverlay(w widget.Widget, onDismiss func()) {
+	container := overlay.NewContainer(w, m.window.windowSize,
+		overlay.WithOnDismiss(func() {
+			if onDismiss != nil {
+				onDismiss()
+			}
+		}),
+	)
+	m.window.overlays.Push(container)
+}
+
+// PopOverlay removes the topmost overlay.
+func (m *windowOverlayManager) PopOverlay() {
+	m.window.overlays.Pop()
+}
+
+// RemoveOverlay finds and removes the overlay containing the given widget.
+func (m *windowOverlayManager) RemoveOverlay(w widget.Widget) {
+	for _, o := range m.window.overlays.List() {
+		if c, ok := o.(*overlay.Container); ok {
+			if c.Content() == w {
+				m.window.overlays.Remove(o)
+				return
+			}
+		}
+	}
+}
+
+// Compile-time check.
+var _ widget.OverlayManager = (*windowOverlayManager)(nil)
 
 // widgetCursorToPlatform converts a widget.CursorType to gpucontext.CursorShape.
 func widgetCursorToPlatform(c widget.CursorType) gpucontext.CursorShape {

--- a/core/dropdown/a11y.go
+++ b/core/dropdown/a11y.go
@@ -1,0 +1,35 @@
+package dropdown
+
+// A11yRole returns the ARIA role for the dropdown widget.
+// Returns "combobox" per WAI-ARIA 1.2 spec for dropdown/select controls.
+func (w *Widget) A11yRole() string {
+	return "combobox"
+}
+
+// A11yLabel returns the accessible label for the dropdown.
+// It uses the configured accessibility hint if set, or falls back to
+// "dropdown" as a generic label.
+func (w *Widget) A11yLabel() string {
+	if w.cfg.a11yHint != "" {
+		return w.cfg.a11yHint
+	}
+	return "dropdown"
+}
+
+// A11yValue returns the currently displayed value for assistive technology.
+// If no item is selected, it returns the placeholder text.
+func (w *Widget) A11yValue() string {
+	if w.selectedIndex >= 0 && w.selectedIndex < len(w.cfg.items) {
+		return w.cfg.items[w.selectedIndex].DisplayText()
+	}
+	if w.cfg.placeholder != "" {
+		return w.cfg.placeholder
+	}
+	return ""
+}
+
+// A11yExpanded returns true if the dropdown menu is currently visible.
+// Maps to the aria-expanded attribute.
+func (w *Widget) A11yExpanded() bool {
+	return w.open
+}

--- a/core/dropdown/dropdown_test.go
+++ b/core/dropdown/dropdown_test.go
@@ -1,0 +1,949 @@
+package dropdown_test
+
+import (
+	"testing"
+
+	"github.com/gogpu/ui/core/dropdown"
+	"github.com/gogpu/ui/event"
+	"github.com/gogpu/ui/geometry"
+	"github.com/gogpu/ui/state"
+	"github.com/gogpu/ui/widget"
+)
+
+// --- Construction Tests ---
+
+func TestNew_Defaults(t *testing.T) {
+	dd := dropdown.New()
+
+	if !dd.IsVisible() {
+		t.Error("default dropdown should be visible")
+	}
+	if !dd.IsEnabled() {
+		t.Error("default dropdown should be enabled")
+	}
+	if !dd.IsFocusable() {
+		t.Error("default dropdown should be focusable")
+	}
+	if dd.Children() != nil {
+		t.Error("dropdown should have no children")
+	}
+	if dd.SelectedIndex() != -1 {
+		t.Errorf("SelectedIndex = %d, want -1", dd.SelectedIndex())
+	}
+	if dd.SelectedValue() != "" {
+		t.Errorf("SelectedValue = %q, want empty", dd.SelectedValue())
+	}
+	if dd.IsOpen() {
+		t.Error("dropdown should not be open by default")
+	}
+}
+
+func TestNew_WithItems(t *testing.T) {
+	dd := dropdown.New(
+		dropdown.Items("Red", "Green", "Blue"),
+	)
+
+	if dd.SelectedIndex() != -1 {
+		t.Errorf("SelectedIndex = %d, want -1", dd.SelectedIndex())
+	}
+}
+
+func TestNew_WithItemDefs(t *testing.T) {
+	items := []dropdown.ItemDef{
+		{Value: "r", Label: "Red"},
+		{Value: "g", Label: "Green"},
+		{Value: "b", Label: "Blue", Disabled: true},
+	}
+	dd := dropdown.New(dropdown.ItemDefs(items))
+
+	if dd.SelectedIndex() != -1 {
+		t.Errorf("SelectedIndex = %d, want -1", dd.SelectedIndex())
+	}
+}
+
+func TestNew_WithSelected(t *testing.T) {
+	dd := dropdown.New(
+		dropdown.Items("Red", "Green", "Blue"),
+		dropdown.Selected(1),
+	)
+
+	if dd.SelectedIndex() != 1 {
+		t.Errorf("SelectedIndex = %d, want 1", dd.SelectedIndex())
+	}
+	if dd.SelectedValue() != "Green" {
+		t.Errorf("SelectedValue = %q, want %q", dd.SelectedValue(), "Green")
+	}
+}
+
+func TestNew_WithPlaceholder(t *testing.T) {
+	dd := dropdown.New(
+		dropdown.Items("Red", "Green", "Blue"),
+		dropdown.Placeholder("Choose color..."),
+	)
+	dd.SetBounds(geometry.NewRect(0, 0, 200, 48))
+	ctx := widget.NewContext()
+	canvas := &recordingCanvas{}
+
+	dd.Draw(ctx, canvas)
+
+	if len(canvas.drawTexts) == 0 {
+		t.Fatal("should have drawn text")
+	}
+	if canvas.drawTexts[0].text != "Choose color..." {
+		t.Errorf("text = %q, want %q", canvas.drawTexts[0].text, "Choose color...")
+	}
+}
+
+func TestNew_WithOnChange(t *testing.T) {
+	dd := dropdown.New(
+		dropdown.Items("Red", "Green", "Blue"),
+		dropdown.OnChange(func(index int, value string) {}),
+	)
+	_ = dd
+}
+
+func TestNew_WithDisabled(t *testing.T) {
+	dd := dropdown.New(dropdown.Disabled(true))
+
+	if dd.IsFocusable() {
+		t.Error("disabled dropdown should not be focusable")
+	}
+}
+
+func TestNew_WithDisabledFn(t *testing.T) {
+	isDisabled := true
+	dd := dropdown.New(dropdown.DisabledFn(func() bool { return isDisabled }))
+
+	if dd.IsFocusable() {
+		t.Error("disabled dropdown should not be focusable")
+	}
+
+	isDisabled = false
+	if !dd.IsFocusable() {
+		t.Error("enabled dropdown should be focusable")
+	}
+}
+
+func TestNew_WithMaxVisibleItems(t *testing.T) {
+	dd := dropdown.New(
+		dropdown.Items("A", "B", "C", "D", "E"),
+		dropdown.MaxVisibleItems(3),
+	)
+	_ = dd
+}
+
+func TestNew_WithPainter(t *testing.T) {
+	p := &testPainter{}
+	dd := dropdown.New(
+		dropdown.Items("Red", "Green", "Blue"),
+		dropdown.PainterOpt(p),
+	)
+	dd.SetBounds(geometry.NewRect(0, 0, 200, 48))
+	ctx := widget.NewContext()
+	canvas := &mockCanvas{}
+
+	dd.Draw(ctx, canvas)
+
+	if !p.triggerCalled {
+		t.Error("Draw should delegate to configured painter's PaintTrigger")
+	}
+}
+
+func TestNew_WithSignal(t *testing.T) {
+	sig := state.NewSignal(1)
+	dd := dropdown.New(
+		dropdown.Items("Red", "Green", "Blue"),
+		dropdown.Signal(sig),
+	)
+
+	if dd.SelectedIndex() != 1 {
+		t.Errorf("SelectedIndex = %d, want 1 (from signal)", dd.SelectedIndex())
+	}
+}
+
+func TestNew_WithA11yHint(t *testing.T) {
+	dd := dropdown.New(dropdown.A11yHint("Select a color"))
+	_ = dd
+}
+
+func TestNew_AllOptions(t *testing.T) {
+	dd := dropdown.New(
+		dropdown.Items("Red", "Green", "Blue"),
+		dropdown.Selected(0),
+		dropdown.Placeholder("Choose..."),
+		dropdown.OnChange(func(int, string) {}),
+		dropdown.Disabled(false),
+		dropdown.MaxVisibleItems(5),
+		dropdown.A11yHint("color picker"),
+	)
+
+	if !dd.IsFocusable() {
+		t.Error("should be focusable")
+	}
+	if dd.SelectedIndex() != 0 {
+		t.Errorf("SelectedIndex = %d, want 0", dd.SelectedIndex())
+	}
+}
+
+// --- Selection Tests ---
+
+func TestSelectedValue_NoSelection(t *testing.T) {
+	dd := dropdown.New(dropdown.Items("Red", "Green", "Blue"))
+
+	if dd.SelectedValue() != "" {
+		t.Errorf("SelectedValue = %q, want empty", dd.SelectedValue())
+	}
+}
+
+func TestSelectedValue_WithSelection(t *testing.T) {
+	dd := dropdown.New(
+		dropdown.Items("Red", "Green", "Blue"),
+		dropdown.Selected(2),
+	)
+
+	if dd.SelectedValue() != "Blue" {
+		t.Errorf("SelectedValue = %q, want %q", dd.SelectedValue(), "Blue")
+	}
+}
+
+func TestSetSelectedIndex_Valid(t *testing.T) {
+	dd := dropdown.New(dropdown.Items("Red", "Green", "Blue"))
+
+	dd.SetSelectedIndex(1)
+
+	if dd.SelectedIndex() != 1 {
+		t.Errorf("SelectedIndex = %d, want 1", dd.SelectedIndex())
+	}
+	if dd.SelectedValue() != "Green" {
+		t.Errorf("SelectedValue = %q, want %q", dd.SelectedValue(), "Green")
+	}
+}
+
+func TestSetSelectedIndex_MinusOne(t *testing.T) {
+	dd := dropdown.New(
+		dropdown.Items("Red", "Green", "Blue"),
+		dropdown.Selected(1),
+	)
+
+	dd.SetSelectedIndex(-1)
+
+	if dd.SelectedIndex() != -1 {
+		t.Errorf("SelectedIndex = %d, want -1", dd.SelectedIndex())
+	}
+}
+
+func TestSetSelectedIndex_OutOfRange(t *testing.T) {
+	dd := dropdown.New(
+		dropdown.Items("Red", "Green", "Blue"),
+		dropdown.Selected(1),
+	)
+
+	dd.SetSelectedIndex(10)
+
+	if dd.SelectedIndex() != 1 {
+		t.Errorf("SelectedIndex should remain 1, got %d", dd.SelectedIndex())
+	}
+}
+
+func TestSetSelectedIndex_UpdatesSignal(t *testing.T) {
+	sig := state.NewSignal(-1)
+	dd := dropdown.New(
+		dropdown.Items("Red", "Green", "Blue"),
+		dropdown.Signal(sig),
+	)
+
+	dd.SetSelectedIndex(2)
+
+	if sig.Get() != 2 {
+		t.Errorf("signal.Get() = %d, want 2", sig.Get())
+	}
+}
+
+// --- Layout Tests ---
+
+func TestLayout_DefaultSize(t *testing.T) {
+	dd := dropdown.New(dropdown.Items("Red", "Green", "Blue"))
+	ctx := widget.NewContext()
+	constraints := geometry.Loose(geometry.Sz(400, 400))
+
+	size := dd.Layout(ctx, constraints)
+
+	if size.Width != 200 {
+		t.Errorf("width = %v, want 200", size.Width)
+	}
+	if size.Height != 48 {
+		t.Errorf("height = %v, want 48", size.Height)
+	}
+}
+
+func TestLayout_TightConstraints(t *testing.T) {
+	dd := dropdown.New(dropdown.Items("Red", "Green", "Blue"))
+	ctx := widget.NewContext()
+	constraints := geometry.Tight(geometry.Sz(100, 36))
+
+	size := dd.Layout(ctx, constraints)
+
+	if size.Width != 100 {
+		t.Errorf("width = %v, want 100", size.Width)
+	}
+	if size.Height != 36 {
+		t.Errorf("height = %v, want 36", size.Height)
+	}
+}
+
+// --- Draw Tests ---
+
+func TestDraw_DefaultPlaceholder(t *testing.T) {
+	dd := dropdown.New(dropdown.Items("Red", "Green", "Blue"))
+	dd.SetBounds(geometry.NewRect(0, 0, 200, 48))
+	ctx := widget.NewContext()
+	canvas := &recordingCanvas{}
+
+	dd.Draw(ctx, canvas)
+
+	if len(canvas.drawTexts) == 0 {
+		t.Fatal("should have drawn text")
+	}
+	if canvas.drawTexts[0].text != "Select..." {
+		t.Errorf("default placeholder = %q, want %q", canvas.drawTexts[0].text, "Select...")
+	}
+}
+
+func TestDraw_SelectedItemText(t *testing.T) {
+	dd := dropdown.New(
+		dropdown.Items("Red", "Green", "Blue"),
+		dropdown.Selected(1),
+	)
+	dd.SetBounds(geometry.NewRect(0, 0, 200, 48))
+	ctx := widget.NewContext()
+	canvas := &recordingCanvas{}
+
+	dd.Draw(ctx, canvas)
+
+	if len(canvas.drawTexts) == 0 {
+		t.Fatal("should have drawn text")
+	}
+	if canvas.drawTexts[0].text != "Green" {
+		t.Errorf("text = %q, want %q", canvas.drawTexts[0].text, "Green")
+	}
+}
+
+func TestDraw_ItemDefLabel(t *testing.T) {
+	items := []dropdown.ItemDef{
+		{Value: "r", Label: "Red"},
+		{Value: "g", Label: "Green"},
+	}
+	dd := dropdown.New(
+		dropdown.ItemDefs(items),
+		dropdown.Selected(0),
+	)
+	dd.SetBounds(geometry.NewRect(0, 0, 200, 48))
+	ctx := widget.NewContext()
+	canvas := &recordingCanvas{}
+
+	dd.Draw(ctx, canvas)
+
+	if len(canvas.drawTexts) == 0 {
+		t.Fatal("should have drawn text")
+	}
+	if canvas.drawTexts[0].text != "Red" {
+		t.Errorf("text = %q, want %q", canvas.drawTexts[0].text, "Red")
+	}
+}
+
+func TestDraw_NilCanvas(t *testing.T) {
+	dd := dropdown.New(dropdown.Items("Red", "Green", "Blue"))
+	dd.SetBounds(geometry.NewRect(0, 0, 200, 48))
+	ctx := widget.NewContext()
+
+	// Should not panic.
+	dd.Draw(ctx, nil)
+}
+
+func TestDraw_DelegatesToPainter(t *testing.T) {
+	p := &testPainter{}
+	dd := dropdown.New(
+		dropdown.Items("Red", "Green", "Blue"),
+		dropdown.Selected(0),
+		dropdown.PainterOpt(p),
+	)
+	dd.SetBounds(geometry.NewRect(0, 0, 200, 48))
+	ctx := widget.NewContext()
+	canvas := &mockCanvas{}
+
+	dd.Draw(ctx, canvas)
+
+	if !p.triggerCalled {
+		t.Error("should call PaintTrigger on custom painter")
+	}
+	if p.triggerState.SelectedText != "Red" {
+		t.Errorf("PaintTrigger SelectedText = %q, want %q", p.triggerState.SelectedText, "Red")
+	}
+	if p.triggerState.Bounds.IsEmpty() {
+		t.Error("PaintTrigger Bounds should not be empty")
+	}
+}
+
+// --- Event Handling Tests ---
+
+func TestEvent_DisabledIgnoresAll(t *testing.T) {
+	dd := dropdown.New(
+		dropdown.Items("Red", "Green", "Blue"),
+		dropdown.Disabled(true),
+	)
+	dd.SetBounds(geometry.NewRect(0, 0, 200, 48))
+	ctx := widget.NewContext()
+
+	press := event.NewMouseEvent(event.MousePress, event.ButtonLeft, event.ButtonStateLeft,
+		geometry.Pt(100, 24), geometry.Pt(100, 24), event.ModNone)
+	consumed := dd.Event(ctx, press)
+
+	if consumed {
+		t.Error("disabled dropdown should not consume events")
+	}
+}
+
+func TestEvent_MouseEnterSetsHover(t *testing.T) {
+	dd := dropdown.New(dropdown.Items("Red", "Green", "Blue"))
+	dd.SetBounds(geometry.NewRect(0, 0, 200, 48))
+	ctx := widget.NewContext()
+
+	enter := event.NewMouseEvent(event.MouseEnter, event.ButtonNone, 0,
+		geometry.Pt(100, 24), geometry.Pt(100, 24), event.ModNone)
+	consumed := dd.Event(ctx, enter)
+
+	if !consumed {
+		t.Error("should consume MouseEnter")
+	}
+}
+
+func TestEvent_MouseLeaveClearsHover(t *testing.T) {
+	dd := dropdown.New(dropdown.Items("Red", "Green", "Blue"))
+	dd.SetBounds(geometry.NewRect(0, 0, 200, 48))
+	ctx := widget.NewContext()
+
+	// Enter first.
+	enter := event.NewMouseEvent(event.MouseEnter, event.ButtonNone, 0,
+		geometry.Pt(100, 24), geometry.Pt(100, 24), event.ModNone)
+	dd.Event(ctx, enter)
+
+	// Then leave.
+	leave := event.NewMouseEvent(event.MouseLeave, event.ButtonNone, 0,
+		geometry.Pt(300, 24), geometry.Pt(300, 24), event.ModNone)
+	consumed := dd.Event(ctx, leave)
+
+	if !consumed {
+		t.Error("should consume MouseLeave")
+	}
+}
+
+func TestEvent_ClickTogglesMenu(t *testing.T) {
+	dd := dropdown.New(dropdown.Items("Red", "Green", "Blue"))
+	dd.SetBounds(geometry.NewRect(0, 0, 200, 48))
+	ctx := widget.NewContext()
+	setupOverlayManager(ctx)
+
+	// Simulate full click.
+	simulateClick(dd, ctx, 100, 24)
+
+	if !dd.IsOpen() {
+		t.Error("dropdown should be open after click")
+	}
+}
+
+func TestEvent_RightClickIgnored(t *testing.T) {
+	dd := dropdown.New(dropdown.Items("Red", "Green", "Blue"))
+	dd.SetBounds(geometry.NewRect(0, 0, 200, 48))
+	ctx := widget.NewContext()
+
+	press := event.NewMouseEvent(event.MousePress, event.ButtonRight, 0,
+		geometry.Pt(100, 24), geometry.Pt(100, 24), event.ModNone)
+	consumed := dd.Event(ctx, press)
+
+	if consumed {
+		t.Error("right click should not be consumed by dropdown")
+	}
+}
+
+func TestEvent_KeyEnterToggle(t *testing.T) {
+	dd := dropdown.New(dropdown.Items("Red", "Green", "Blue"))
+	dd.SetBounds(geometry.NewRect(0, 0, 200, 48))
+	dd.SetFocused(true)
+	ctx := widget.NewContext()
+	setupOverlayManager(ctx)
+
+	press := event.NewKeyEvent(event.KeyPress, event.KeyEnter, 0, event.ModNone)
+	consumed := dd.Event(ctx, press)
+
+	if !consumed {
+		t.Error("Enter should be consumed by focused dropdown")
+	}
+	if !dd.IsOpen() {
+		t.Error("Enter should open the dropdown")
+	}
+}
+
+func TestEvent_KeySpaceToggle(t *testing.T) {
+	dd := dropdown.New(dropdown.Items("Red", "Green", "Blue"))
+	dd.SetBounds(geometry.NewRect(0, 0, 200, 48))
+	dd.SetFocused(true)
+	ctx := widget.NewContext()
+	setupOverlayManager(ctx)
+
+	press := event.NewKeyEvent(event.KeyPress, event.KeySpace, 0, event.ModNone)
+	consumed := dd.Event(ctx, press)
+
+	if !consumed {
+		t.Error("Space should be consumed by focused dropdown")
+	}
+	if !dd.IsOpen() {
+		t.Error("Space should open the dropdown")
+	}
+}
+
+func TestEvent_KeyDownOpens(t *testing.T) {
+	dd := dropdown.New(dropdown.Items("Red", "Green", "Blue"))
+	dd.SetBounds(geometry.NewRect(0, 0, 200, 48))
+	dd.SetFocused(true)
+	ctx := widget.NewContext()
+	setupOverlayManager(ctx)
+
+	press := event.NewKeyEvent(event.KeyPress, event.KeyDown, 0, event.ModNone)
+	consumed := dd.Event(ctx, press)
+
+	if !consumed {
+		t.Error("Down arrow should be consumed by focused dropdown")
+	}
+	if !dd.IsOpen() {
+		t.Error("Down arrow should open the dropdown")
+	}
+}
+
+func TestEvent_KeyUpOpens(t *testing.T) {
+	dd := dropdown.New(dropdown.Items("Red", "Green", "Blue"))
+	dd.SetBounds(geometry.NewRect(0, 0, 200, 48))
+	dd.SetFocused(true)
+	ctx := widget.NewContext()
+	setupOverlayManager(ctx)
+
+	press := event.NewKeyEvent(event.KeyPress, event.KeyUp, 0, event.ModNone)
+	consumed := dd.Event(ctx, press)
+
+	if !consumed {
+		t.Error("Up arrow should be consumed by focused dropdown")
+	}
+	if !dd.IsOpen() {
+		t.Error("Up arrow should open the dropdown")
+	}
+}
+
+func TestEvent_KeyEscapeCloses(t *testing.T) {
+	dd := dropdown.New(dropdown.Items("Red", "Green", "Blue"))
+	dd.SetBounds(geometry.NewRect(0, 0, 200, 48))
+	dd.SetFocused(true)
+	ctx := widget.NewContext()
+	setupOverlayManager(ctx)
+
+	// Open first.
+	dd.Open(ctx)
+	if !dd.IsOpen() {
+		t.Fatal("dropdown should be open")
+	}
+
+	// Press Escape.
+	esc := event.NewKeyEvent(event.KeyPress, event.KeyEscape, 0, event.ModNone)
+	consumed := dd.Event(ctx, esc)
+
+	if !consumed {
+		t.Error("Escape should be consumed when dropdown is open")
+	}
+	if dd.IsOpen() {
+		t.Error("Escape should close the dropdown")
+	}
+}
+
+func TestEvent_EscapeNotConsumedWhenClosed(t *testing.T) {
+	dd := dropdown.New(dropdown.Items("Red", "Green", "Blue"))
+	dd.SetFocused(true)
+	ctx := widget.NewContext()
+
+	esc := event.NewKeyEvent(event.KeyPress, event.KeyEscape, 0, event.ModNone)
+	consumed := dd.Event(ctx, esc)
+
+	if consumed {
+		t.Error("Escape should not be consumed when dropdown is closed")
+	}
+}
+
+func TestEvent_KeyIgnoredWhenNotFocused(t *testing.T) {
+	dd := dropdown.New(dropdown.Items("Red", "Green", "Blue"))
+	ctx := widget.NewContext()
+
+	press := event.NewKeyEvent(event.KeyPress, event.KeyEnter, 0, event.ModNone)
+	consumed := dd.Event(ctx, press)
+
+	if consumed {
+		t.Error("key events should be ignored when not focused")
+	}
+}
+
+func TestEvent_KeyReleaseIgnored(t *testing.T) {
+	dd := dropdown.New(dropdown.Items("Red", "Green", "Blue"))
+	dd.SetFocused(true)
+	ctx := widget.NewContext()
+
+	release := event.NewKeyEvent(event.KeyRelease, event.KeyEnter, 0, event.ModNone)
+	consumed := dd.Event(ctx, release)
+
+	if consumed {
+		t.Error("key release should not be consumed")
+	}
+}
+
+// --- Open/Close Tests ---
+
+func TestOpen_CreatesOverlay(t *testing.T) {
+	dd := dropdown.New(dropdown.Items("Red", "Green", "Blue"))
+	dd.SetBounds(geometry.NewRect(0, 0, 200, 48))
+	ctx := widget.NewContext()
+	om := setupOverlayManager(ctx)
+
+	dd.Open(ctx)
+
+	if !dd.IsOpen() {
+		t.Error("dropdown should be open after Open()")
+	}
+	if om.pushCount != 1 {
+		t.Errorf("PushOverlay called %d times, want 1", om.pushCount)
+	}
+}
+
+func TestOpen_NoOpIfAlreadyOpen(t *testing.T) {
+	dd := dropdown.New(dropdown.Items("Red", "Green", "Blue"))
+	dd.SetBounds(geometry.NewRect(0, 0, 200, 48))
+	ctx := widget.NewContext()
+	om := setupOverlayManager(ctx)
+
+	dd.Open(ctx)
+	dd.Open(ctx) // Should be no-op.
+
+	if om.pushCount != 1 {
+		t.Errorf("PushOverlay called %d times, want 1", om.pushCount)
+	}
+}
+
+func TestOpen_NoOpIfDisabled(t *testing.T) {
+	dd := dropdown.New(
+		dropdown.Items("Red", "Green", "Blue"),
+		dropdown.Disabled(true),
+	)
+	dd.SetBounds(geometry.NewRect(0, 0, 200, 48))
+	ctx := widget.NewContext()
+	setupOverlayManager(ctx)
+
+	dd.Open(ctx)
+
+	if dd.IsOpen() {
+		t.Error("disabled dropdown should not open")
+	}
+}
+
+func TestOpen_NoOpWithoutOverlayManager(t *testing.T) {
+	dd := dropdown.New(dropdown.Items("Red", "Green", "Blue"))
+	dd.SetBounds(geometry.NewRect(0, 0, 200, 48))
+	ctx := widget.NewContext()
+	// No overlay manager set.
+
+	dd.Open(ctx)
+
+	if dd.IsOpen() {
+		t.Error("dropdown should not open without overlay manager")
+	}
+}
+
+func TestClose(t *testing.T) {
+	dd := dropdown.New(dropdown.Items("Red", "Green", "Blue"))
+	dd.SetBounds(geometry.NewRect(0, 0, 200, 48))
+	ctx := widget.NewContext()
+	om := setupOverlayManager(ctx)
+
+	dd.Open(ctx)
+	dd.Close(ctx)
+
+	if dd.IsOpen() {
+		t.Error("dropdown should be closed after Close()")
+	}
+	if om.removeCount != 1 {
+		t.Errorf("RemoveOverlay called %d times, want 1", om.removeCount)
+	}
+}
+
+func TestClose_NoOpIfAlreadyClosed(t *testing.T) {
+	dd := dropdown.New(dropdown.Items("Red", "Green", "Blue"))
+	ctx := widget.NewContext()
+
+	dd.Close(ctx) // Should be no-op.
+
+	if dd.IsOpen() {
+		t.Error("dropdown should remain closed")
+	}
+}
+
+// --- Focus Tests ---
+
+func TestFocus_SetFocused(t *testing.T) {
+	dd := dropdown.New(dropdown.Items("Red"))
+
+	dd.SetFocused(true)
+	if !dd.IsFocused() {
+		t.Error("should be focused after SetFocused(true)")
+	}
+
+	dd.SetFocused(false)
+	if dd.IsFocused() {
+		t.Error("should not be focused after SetFocused(false)")
+	}
+}
+
+func TestFocusable_VisibleAndEnabled(t *testing.T) {
+	dd := dropdown.New(dropdown.Items("Red"))
+
+	if !dd.IsFocusable() {
+		t.Error("visible+enabled dropdown should be focusable")
+	}
+
+	dd.SetVisible(false)
+	if dd.IsFocusable() {
+		t.Error("invisible dropdown should not be focusable")
+	}
+
+	dd.SetVisible(true)
+	dd.SetEnabled(false)
+	if dd.IsFocusable() {
+		t.Error("disabled dropdown should not be focusable")
+	}
+}
+
+// --- Accessibility Tests ---
+
+func TestA11y_Role(t *testing.T) {
+	dd := dropdown.New()
+
+	if dd.A11yRole() != "combobox" {
+		t.Errorf("A11yRole = %q, want %q", dd.A11yRole(), "combobox")
+	}
+}
+
+func TestA11y_Label(t *testing.T) {
+	dd := dropdown.New(dropdown.A11yHint("Select a color"))
+
+	if dd.A11yLabel() != "Select a color" {
+		t.Errorf("A11yLabel = %q, want %q", dd.A11yLabel(), "Select a color")
+	}
+}
+
+func TestA11y_LabelDefault(t *testing.T) {
+	dd := dropdown.New()
+
+	if dd.A11yLabel() != "dropdown" {
+		t.Errorf("A11yLabel = %q, want %q", dd.A11yLabel(), "dropdown")
+	}
+}
+
+func TestA11y_Value(t *testing.T) {
+	dd := dropdown.New(
+		dropdown.Items("Red", "Green", "Blue"),
+		dropdown.Selected(1),
+	)
+
+	if dd.A11yValue() != "Green" {
+		t.Errorf("A11yValue = %q, want %q", dd.A11yValue(), "Green")
+	}
+}
+
+func TestA11y_ValueEmpty(t *testing.T) {
+	dd := dropdown.New(
+		dropdown.Items("Red", "Green", "Blue"),
+		dropdown.Placeholder("Pick one"),
+	)
+
+	if dd.A11yValue() != "Pick one" {
+		t.Errorf("A11yValue = %q, want %q", dd.A11yValue(), "Pick one")
+	}
+}
+
+func TestA11y_Expanded(t *testing.T) {
+	dd := dropdown.New(dropdown.Items("Red", "Green", "Blue"))
+	dd.SetBounds(geometry.NewRect(0, 0, 200, 48))
+	ctx := widget.NewContext()
+	setupOverlayManager(ctx)
+
+	if dd.A11yExpanded() {
+		t.Error("should not be expanded initially")
+	}
+
+	dd.Open(ctx)
+
+	if !dd.A11yExpanded() {
+		t.Error("should be expanded after Open()")
+	}
+}
+
+// --- ItemDef Tests ---
+
+func TestItemDef_DisplayText(t *testing.T) {
+	tests := []struct {
+		name string
+		item dropdown.ItemDef
+		want string
+	}{
+		{"value only", dropdown.ItemDef{Value: "red"}, "red"},
+		{"label and value", dropdown.ItemDef{Value: "r", Label: "Red"}, "Red"},
+		{"empty value", dropdown.ItemDef{}, ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.item.DisplayText()
+			if got != tc.want {
+				t.Errorf("DisplayText() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// --- Widget Interface Compliance ---
+
+func TestWidgetInterface(t *testing.T) {
+	var w widget.Widget = dropdown.New()
+	_ = w
+}
+
+func TestFocusableInterface(t *testing.T) {
+	var f widget.Focusable = dropdown.New()
+	_ = f
+}
+
+// --- Helper functions ---
+
+func simulateClick(dd *dropdown.Widget, ctx widget.Context, x, y float32) {
+	press := event.NewMouseEvent(event.MousePress, event.ButtonLeft, event.ButtonStateLeft,
+		geometry.Pt(x, y), geometry.Pt(x, y), event.ModNone)
+	dd.Event(ctx, press)
+
+	release := event.NewMouseEvent(event.MouseRelease, event.ButtonLeft, 0,
+		geometry.Pt(x, y), geometry.Pt(x, y), event.ModNone)
+	dd.Event(ctx, release)
+}
+
+func setupOverlayManager(ctx *widget.ContextImpl) *mockOverlayManager {
+	om := &mockOverlayManager{}
+	ctx.SetOverlayManager(om)
+	ctx.SetWindowSize(geometry.Sz(800, 600))
+	return om
+}
+
+// --- Mock Overlay Manager ---
+
+type mockOverlayManager struct {
+	pushCount   int
+	popCount    int
+	removeCount int
+	lastWidget  widget.Widget
+}
+
+func (m *mockOverlayManager) PushOverlay(w widget.Widget, _ func()) {
+	m.pushCount++
+	m.lastWidget = w
+}
+
+func (m *mockOverlayManager) PopOverlay() {
+	m.popCount++
+}
+
+func (m *mockOverlayManager) RemoveOverlay(_ widget.Widget) {
+	m.removeCount++
+}
+
+// --- Test Painter ---
+
+type testPainter struct {
+	triggerCalled bool
+	menuCalled    bool
+	triggerState  dropdown.TriggerPaintState
+	menuState     dropdown.MenuPaintState
+}
+
+func (p *testPainter) PaintTrigger(_ widget.Canvas, st *dropdown.TriggerPaintState) {
+	p.triggerCalled = true
+	p.triggerState = *st
+}
+
+func (p *testPainter) PaintMenu(_ widget.Canvas, st *dropdown.MenuPaintState) {
+	p.menuCalled = true
+	p.menuState = *st
+}
+
+// --- Recording Canvas ---
+
+type recordingCanvas struct {
+	drawTexts      []drawTextCall
+	drawRoundRects []drawRoundRectCall
+}
+
+type drawTextCall struct {
+	text     string
+	bounds   geometry.Rect
+	fontSize float32
+	color    widget.Color
+	bold     bool
+	align    float32
+}
+
+type drawRoundRectCall struct {
+	r      geometry.Rect
+	color  widget.Color
+	radius float32
+}
+
+func (c *recordingCanvas) Clear(_ widget.Color)                                  {}
+func (c *recordingCanvas) DrawRect(_ geometry.Rect, _ widget.Color)              {}
+func (c *recordingCanvas) StrokeRect(_ geometry.Rect, _ widget.Color, _ float32) {}
+
+func (c *recordingCanvas) DrawRoundRect(r geometry.Rect, color widget.Color, radius float32) {
+	c.drawRoundRects = append(c.drawRoundRects, drawRoundRectCall{r: r, color: color, radius: radius})
+}
+
+func (c *recordingCanvas) StrokeRoundRect(_ geometry.Rect, _ widget.Color, _ float32, _ float32) {}
+func (c *recordingCanvas) DrawCircle(_ geometry.Point, _ float32, _ widget.Color)                {}
+func (c *recordingCanvas) StrokeCircle(_ geometry.Point, _ float32, _ widget.Color, _ float32)   {}
+func (c *recordingCanvas) DrawLine(_, _ geometry.Point, _ widget.Color, _ float32)               {}
+
+func (c *recordingCanvas) DrawText(text string, bounds geometry.Rect, fontSize float32, color widget.Color, bold bool, align float32) {
+	c.drawTexts = append(c.drawTexts, drawTextCall{text: text, bounds: bounds, fontSize: fontSize, color: color, bold: bold, align: align})
+}
+
+func (c *recordingCanvas) PushClip(_ geometry.Rect)       {}
+func (c *recordingCanvas) PopClip()                       {}
+func (c *recordingCanvas) PushTransform(_ geometry.Point) {}
+func (c *recordingCanvas) PopTransform()                  {}
+
+// --- Mock Canvas ---
+
+type mockCanvas struct{}
+
+func (c *mockCanvas) Clear(_ widget.Color)                                                  {}
+func (c *mockCanvas) DrawRect(_ geometry.Rect, _ widget.Color)                              {}
+func (c *mockCanvas) StrokeRect(_ geometry.Rect, _ widget.Color, _ float32)                 {}
+func (c *mockCanvas) DrawRoundRect(_ geometry.Rect, _ widget.Color, _ float32)              {}
+func (c *mockCanvas) StrokeRoundRect(_ geometry.Rect, _ widget.Color, _ float32, _ float32) {}
+func (c *mockCanvas) DrawCircle(_ geometry.Point, _ float32, _ widget.Color)                {}
+func (c *mockCanvas) StrokeCircle(_ geometry.Point, _ float32, _ widget.Color, _ float32)   {}
+func (c *mockCanvas) DrawLine(_, _ geometry.Point, _ widget.Color, _ float32)               {}
+
+func (c *mockCanvas) DrawText(_ string, _ geometry.Rect, _ float32, _ widget.Color, _ bool, _ float32) {
+}
+
+func (c *mockCanvas) PushClip(_ geometry.Rect)       {}
+func (c *mockCanvas) PopClip()                       {}
+func (c *mockCanvas) PushTransform(_ geometry.Point) {}
+func (c *mockCanvas) PopTransform()                  {}

--- a/core/dropdown/menu.go
+++ b/core/dropdown/menu.go
@@ -1,0 +1,289 @@
+package dropdown
+
+import (
+	"github.com/gogpu/ui/event"
+	"github.com/gogpu/ui/geometry"
+	"github.com/gogpu/ui/widget"
+)
+
+// menuWidget is an internal widget that renders the dropdown menu items
+// inside the overlay. It handles keyboard navigation, mouse hover
+// highlighting, mouse click selection, and mouse wheel scrolling.
+type menuWidget struct {
+	widget.WidgetBase
+
+	items            []ItemDef
+	selectedIndex    int
+	highlightedIndex int
+	scrollOffset     int
+	maxVisible       int
+	itemHeight       float32
+	painter          Painter
+	colorScheme      DropdownColorScheme
+
+	onSelect func(index int)
+}
+
+// menuItemHeight is the default height of each item row.
+const menuItemHeight float32 = 40
+
+// newMenuWidget creates a new internal menu widget.
+func newMenuWidget(
+	items []ItemDef,
+	selectedIndex int,
+	maxVisible int,
+	painter Painter,
+	onSelect func(index int),
+) *menuWidget {
+	m := &menuWidget{
+		items:            items,
+		selectedIndex:    selectedIndex,
+		highlightedIndex: selectedIndex,
+		maxVisible:       maxVisible,
+		itemHeight:       menuItemHeight,
+		painter:          painter,
+		onSelect:         onSelect,
+	}
+	m.SetVisible(true)
+	m.SetEnabled(true)
+
+	// If highlighted index is valid, ensure it is visible.
+	if m.highlightedIndex >= 0 {
+		m.ensureVisible(m.highlightedIndex)
+	}
+
+	return m
+}
+
+// Layout calculates the menu size based on visible items.
+func (m *menuWidget) Layout(_ widget.Context, constraints geometry.Constraints) geometry.Size {
+	visibleCount := m.visibleCount()
+	height := float32(visibleCount) * m.itemHeight
+
+	// Width matches constraints (typically matched to trigger width).
+	width := constraints.MaxWidth
+	if width >= geometry.Infinity {
+		width = 200 // reasonable fallback
+	}
+
+	preferred := geometry.Sz(width, height)
+	return constraints.Constrain(preferred)
+}
+
+// Draw renders the menu items.
+func (m *menuWidget) Draw(ctx widget.Context, canvas widget.Canvas) {
+	if canvas == nil {
+		return
+	}
+	m.painter.PaintMenu(canvas, &MenuPaintState{
+		Bounds:           m.Bounds(),
+		Items:            m.items,
+		HighlightedIndex: m.highlightedIndex,
+		SelectedIndex:    m.selectedIndex,
+		ScrollOffset:     m.scrollOffset,
+		VisibleCount:     m.visibleCount(),
+		ItemHeight:       m.itemHeight,
+		ColorScheme:      m.colorScheme,
+	})
+}
+
+// Event handles keyboard navigation, mouse hover, and mouse clicks.
+func (m *menuWidget) Event(ctx widget.Context, e event.Event) bool {
+	switch ev := e.(type) {
+	case *event.KeyEvent:
+		return m.handleKeyEvent(ctx, ev)
+	case *event.MouseEvent:
+		return m.handleMouseEvent(ctx, ev)
+	case *event.WheelEvent:
+		return m.handleWheelEvent(ctx, ev)
+	default:
+		return false
+	}
+}
+
+// Children returns nil; the menu is a leaf widget.
+func (m *menuWidget) Children() []widget.Widget {
+	return nil
+}
+
+// handleKeyEvent processes keyboard navigation.
+func (m *menuWidget) handleKeyEvent(ctx widget.Context, e *event.KeyEvent) bool {
+	if e.KeyType != event.KeyPress && e.KeyType != event.KeyRepeat {
+		return false
+	}
+
+	switch e.Key {
+	case event.KeyDown:
+		m.moveHighlight(1)
+		ctx.Invalidate()
+		return true
+	case event.KeyUp:
+		m.moveHighlight(-1)
+		ctx.Invalidate()
+		return true
+	case event.KeyEnter, event.KeySpace:
+		if m.highlightedIndex >= 0 && m.highlightedIndex < len(m.items) {
+			if !m.items[m.highlightedIndex].Disabled {
+				m.selectItem(m.highlightedIndex)
+			}
+		}
+		return true
+	case event.KeyHome:
+		m.highlightedIndex = m.findNextEnabled(0, 1)
+		m.ensureVisible(m.highlightedIndex)
+		ctx.Invalidate()
+		return true
+	case event.KeyEnd:
+		m.highlightedIndex = m.findNextEnabled(len(m.items)-1, -1)
+		m.ensureVisible(m.highlightedIndex)
+		ctx.Invalidate()
+		return true
+	default:
+		return false
+	}
+}
+
+// handleMouseEvent processes hover and click events.
+func (m *menuWidget) handleMouseEvent(ctx widget.Context, e *event.MouseEvent) bool {
+	bounds := m.Bounds()
+	if !bounds.Contains(e.Position) {
+		return false
+	}
+
+	switch e.MouseType {
+	case event.MouseMove:
+		index := m.indexAtPosition(e.Position)
+		if index != m.highlightedIndex {
+			m.highlightedIndex = index
+			ctx.Invalidate()
+		}
+		return true
+	case event.MousePress:
+		if e.Button != event.ButtonLeft {
+			return false
+		}
+		index := m.indexAtPosition(e.Position)
+		if index >= 0 && index < len(m.items) && !m.items[index].Disabled {
+			m.selectItem(index)
+		}
+		return true
+	default:
+		return true // consume other mouse events within bounds
+	}
+}
+
+// handleWheelEvent processes scroll wheel events.
+func (m *menuWidget) handleWheelEvent(ctx widget.Context, e *event.WheelEvent) bool {
+	bounds := m.Bounds()
+	if !bounds.Contains(e.Position) {
+		return false
+	}
+
+	maxScroll := len(m.items) - m.visibleCount()
+	if maxScroll < 0 {
+		maxScroll = 0
+	}
+
+	if e.Delta.Y > 0 {
+		// Scroll up.
+		if m.scrollOffset > 0 {
+			m.scrollOffset--
+			ctx.Invalidate()
+		}
+	} else if e.Delta.Y < 0 {
+		// Scroll down.
+		if m.scrollOffset < maxScroll {
+			m.scrollOffset++
+			ctx.Invalidate()
+		}
+	}
+	return true
+}
+
+// moveHighlight moves the highlight by delta, skipping disabled items.
+func (m *menuWidget) moveHighlight(delta int) {
+	if len(m.items) == 0 {
+		return
+	}
+
+	next := m.highlightedIndex + delta
+	next = m.findNextEnabled(next, delta)
+
+	if next >= 0 && next < len(m.items) {
+		m.highlightedIndex = next
+		m.ensureVisible(next)
+	}
+}
+
+// findNextEnabled finds the next non-disabled item starting from index,
+// moving in the given direction (1 or -1).
+func (m *menuWidget) findNextEnabled(start, direction int) int {
+	if direction == 0 {
+		direction = 1
+	}
+	for i := start; i >= 0 && i < len(m.items); i += direction {
+		if !m.items[i].Disabled {
+			return i
+		}
+	}
+	return m.highlightedIndex // stay in place if nothing found
+}
+
+// ensureVisible adjusts scrollOffset so that the given index is visible.
+func (m *menuWidget) ensureVisible(index int) {
+	if index < 0 {
+		return
+	}
+	visible := m.visibleCount()
+	if index < m.scrollOffset {
+		m.scrollOffset = index
+	} else if index >= m.scrollOffset+visible {
+		m.scrollOffset = index - visible + 1
+	}
+	// Clamp.
+	maxScroll := len(m.items) - visible
+	if maxScroll < 0 {
+		maxScroll = 0
+	}
+	if m.scrollOffset > maxScroll {
+		m.scrollOffset = maxScroll
+	}
+	if m.scrollOffset < 0 {
+		m.scrollOffset = 0
+	}
+}
+
+// visibleCount returns how many items are visible (capped by maxVisible).
+func (m *menuWidget) visibleCount() int {
+	count := len(m.items)
+	if m.maxVisible > 0 && count > m.maxVisible {
+		count = m.maxVisible
+	}
+	return count
+}
+
+// indexAtPosition returns the item index at the given mouse position,
+// or -1 if outside the items area.
+func (m *menuWidget) indexAtPosition(pos geometry.Point) int {
+	bounds := m.Bounds()
+	localY := pos.Y - bounds.Min.Y
+	if localY < 0 {
+		return -1
+	}
+	row := int(localY / m.itemHeight)
+	index := m.scrollOffset + row
+	if index < 0 || index >= len(m.items) {
+		return -1
+	}
+	return index
+}
+
+// selectItem triggers selection of the given index.
+func (m *menuWidget) selectItem(index int) {
+	if m.onSelect != nil {
+		m.onSelect(index)
+	}
+}
+
+// Compile-time check.
+var _ widget.Widget = (*menuWidget)(nil)

--- a/core/dropdown/options.go
+++ b/core/dropdown/options.go
@@ -1,0 +1,121 @@
+package dropdown
+
+import "github.com/gogpu/ui/state"
+
+// Option configures a dropdown during construction.
+type Option func(*config)
+
+// config holds the dropdown's configuration, set at construction time via options.
+type config struct {
+	items           []ItemDef
+	selectedIndex   int
+	placeholder     string
+	onChange        func(index int, value string)
+	disabled        bool
+	disabledFn      func() bool
+	maxVisibleItems int
+	painter         Painter
+	signal          state.Signal[int]
+	a11yHint        string
+}
+
+// defaultMaxVisible is the default number of visible items before scrolling.
+const defaultMaxVisible = 8
+
+// ResolvedDisabled returns the current disabled state, preferring the
+// dynamic function over the static bool.
+func (c *config) ResolvedDisabled() bool {
+	if c.disabledFn != nil {
+		return c.disabledFn()
+	}
+	return c.disabled
+}
+
+// Items sets the dropdown items from strings. Each string becomes both
+// the value and label.
+func Items(items ...string) Option {
+	return func(c *config) {
+		defs := make([]ItemDef, len(items))
+		for i, s := range items {
+			defs[i] = ItemDef{Value: s}
+		}
+		c.items = defs
+	}
+}
+
+// ItemDefs sets the dropdown items from ItemDef definitions.
+func ItemDefs(items []ItemDef) Option {
+	return func(c *config) {
+		c.items = items
+	}
+}
+
+// Selected sets the initially selected item index. Use -1 for no selection.
+func Selected(index int) Option {
+	return func(c *config) {
+		c.selectedIndex = index
+	}
+}
+
+// Placeholder sets the text shown when no item is selected.
+func Placeholder(text string) Option {
+	return func(c *config) {
+		c.placeholder = text
+	}
+}
+
+// OnChange sets the callback invoked when the selection changes.
+// The callback receives the new index and the selected item's value.
+func OnChange(fn func(index int, value string)) Option {
+	return func(c *config) {
+		c.onChange = fn
+	}
+}
+
+// Disabled sets the dropdown's disabled state.
+func Disabled(d bool) Option {
+	return func(c *config) {
+		c.disabled = d
+	}
+}
+
+// DisabledFn sets a dynamic function that determines whether the dropdown
+// is disabled. When set, this takes precedence over the static value.
+func DisabledFn(fn func() bool) Option {
+	return func(c *config) {
+		c.disabledFn = fn
+	}
+}
+
+// MaxVisibleItems sets the maximum number of items visible in the menu
+// before scrolling is required. Defaults to 8.
+func MaxVisibleItems(n int) Option {
+	return func(c *config) {
+		if n > 0 {
+			c.maxVisibleItems = n
+		}
+	}
+}
+
+// PainterOpt sets the painter used to render the dropdown.
+func PainterOpt(p Painter) Option {
+	return func(c *config) {
+		c.painter = p
+	}
+}
+
+// Signal binds the dropdown's selected index to a reactive signal for
+// two-way data binding. When the selection changes, the signal is updated.
+// When the signal is set externally, the dropdown reflects the change.
+func Signal(s state.Signal[int]) Option {
+	return func(c *config) {
+		c.signal = s
+	}
+}
+
+// A11yHint sets the accessibility hint text for the dropdown.
+func A11yHint(hint string) Option {
+	return func(c *config) {
+		c.a11yHint = hint
+	}
+}

--- a/core/dropdown/painter.go
+++ b/core/dropdown/painter.go
@@ -1,0 +1,254 @@
+package dropdown
+
+import (
+	"github.com/gogpu/ui/geometry"
+	"github.com/gogpu/ui/widget"
+)
+
+// Painter draws the visual representation of a dropdown.
+// Each design system (Material 3, Fluent, Cupertino) provides its own
+// Painter implementation. If no Painter is set, [DefaultPainter] is used.
+type Painter interface {
+	// PaintTrigger draws the closed dropdown trigger (shows current selection).
+	PaintTrigger(canvas widget.Canvas, state *TriggerPaintState)
+
+	// PaintMenu draws the open dropdown menu.
+	PaintMenu(canvas widget.Canvas, state *MenuPaintState)
+}
+
+// TriggerPaintState provides the current dropdown trigger state to the painter.
+type TriggerPaintState struct {
+	// Bounds is the trigger widget's bounds.
+	Bounds geometry.Rect
+
+	// SelectedText is the display text of the currently selected item,
+	// or the placeholder if nothing is selected.
+	SelectedText string
+
+	// IsPlaceholder is true if SelectedText is the placeholder (nothing selected).
+	IsPlaceholder bool
+
+	// Open is true if the dropdown menu is currently visible.
+	Open bool
+
+	// Focused is true if the dropdown has keyboard focus.
+	Focused bool
+
+	// Hovered is true if the mouse is over the trigger.
+	Hovered bool
+
+	// Disabled is true if the dropdown is disabled.
+	Disabled bool
+
+	// ColorScheme provides theme-derived colors. Zero value means use defaults.
+	ColorScheme DropdownColorScheme
+}
+
+// MenuPaintState provides the current menu state to the painter.
+type MenuPaintState struct {
+	// Bounds is the menu's bounds in window coordinates.
+	Bounds geometry.Rect
+
+	// Items is the list of menu items.
+	Items []ItemDef
+
+	// HighlightedIndex is the index of the currently highlighted item (-1 for none).
+	HighlightedIndex int
+
+	// SelectedIndex is the index of the currently selected item (-1 for none).
+	SelectedIndex int
+
+	// ScrollOffset is the index of the first visible item.
+	ScrollOffset int
+
+	// VisibleCount is the number of items visible without scrolling.
+	VisibleCount int
+
+	// ItemHeight is the height of each item in the menu.
+	ItemHeight float32
+
+	// ColorScheme provides theme-derived colors. Zero value means use defaults.
+	ColorScheme DropdownColorScheme
+}
+
+// DropdownColorScheme provides theme-derived colors for dropdown painting.
+// Zero value means the painter should use its built-in defaults.
+type DropdownColorScheme struct {
+	Background      widget.Color
+	Border          widget.Color
+	FocusBorder     widget.Color
+	TextColor       widget.Color
+	PlaceholderText widget.Color
+	DisabledBg      widget.Color
+	DisabledFg      widget.Color
+	MenuBg          widget.Color
+	MenuBorder      widget.Color
+	ItemHover       widget.Color
+	ItemSelected    widget.Color
+	ItemDisabled    widget.Color
+	ChevronColor    widget.Color
+	FocusRing       widget.Color
+}
+
+// DefaultPainter provides a minimal fallback painter for dropdowns.
+// It draws simple rectangles and text without design system styling.
+type DefaultPainter struct{}
+
+// PaintTrigger renders a minimal dropdown trigger.
+func (p DefaultPainter) PaintTrigger(canvas widget.Canvas, st *TriggerPaintState) {
+	if st.Bounds.IsEmpty() {
+		return
+	}
+
+	// Background.
+	bg := dfltTriggerBg
+	if st.Disabled {
+		bg = dfltDisabledBg
+	}
+	canvas.DrawRoundRect(st.Bounds, bg, dfltRadius)
+
+	// Border.
+	borderColor := dfltBorder
+	borderWidth := dfltBorderWidth
+	if st.Focused {
+		borderColor = dfltFocusBorder
+		borderWidth = dfltFocusBorderWidth
+	}
+	if st.Disabled {
+		borderColor = dfltDisabledFg
+	}
+	canvas.StrokeRoundRect(st.Bounds, borderColor, dfltRadius, borderWidth)
+
+	// Text.
+	textColor := dfltTextColor
+	if st.IsPlaceholder {
+		textColor = dfltPlaceholder
+	}
+	if st.Disabled {
+		textColor = dfltDisabledFg
+	}
+	textBounds := geometry.Rect{
+		Min: geometry.Pt(st.Bounds.Min.X+dfltPaddingH, st.Bounds.Min.Y),
+		Max: geometry.Pt(st.Bounds.Max.X-dfltChevronWidth-dfltPaddingH, st.Bounds.Max.Y),
+	}
+	canvas.DrawText(st.SelectedText, textBounds, dfltFontSize, textColor, false, dfltTextAlignLeft)
+
+	// Chevron indicator.
+	chevronColor := dfltChevronColor
+	if st.Disabled {
+		chevronColor = dfltDisabledFg
+	}
+	chevronX := st.Bounds.Max.X - dfltChevronWidth - dfltPaddingH/2
+	chevronY := st.Bounds.Center().Y
+	drawChevron(canvas, geometry.Pt(chevronX, chevronY), st.Open, chevronColor)
+}
+
+// PaintMenu renders a minimal dropdown menu.
+func (p DefaultPainter) PaintMenu(canvas widget.Canvas, st *MenuPaintState) {
+	if st.Bounds.IsEmpty() {
+		return
+	}
+
+	// Menu background.
+	canvas.DrawRoundRect(st.Bounds, dfltMenuBg, dfltMenuRadius)
+	canvas.StrokeRoundRect(st.Bounds, dfltMenuBorder, dfltMenuRadius, dfltBorderWidth)
+
+	// Clip to menu bounds.
+	canvas.PushClip(st.Bounds)
+	defer canvas.PopClip()
+
+	// Draw visible items.
+	endIndex := st.ScrollOffset + st.VisibleCount
+	if endIndex > len(st.Items) {
+		endIndex = len(st.Items)
+	}
+
+	for i := st.ScrollOffset; i < endIndex; i++ {
+		item := st.Items[i]
+		row := i - st.ScrollOffset
+		itemRect := geometry.Rect{
+			Min: geometry.Pt(st.Bounds.Min.X, st.Bounds.Min.Y+float32(row)*st.ItemHeight),
+			Max: geometry.Pt(st.Bounds.Max.X, st.Bounds.Min.Y+float32(row+1)*st.ItemHeight),
+		}
+
+		// Highlight.
+		switch i {
+		case st.HighlightedIndex:
+			canvas.DrawRect(itemRect, dfltItemHover)
+		case st.SelectedIndex:
+			canvas.DrawRect(itemRect, dfltItemSelected)
+		}
+
+		// Text.
+		textColor := dfltTextColor
+		if item.Disabled {
+			textColor = dfltDisabledFg
+		}
+		textRect := geometry.Rect{
+			Min: geometry.Pt(itemRect.Min.X+dfltPaddingH, itemRect.Min.Y),
+			Max: geometry.Pt(itemRect.Max.X-dfltPaddingH, itemRect.Max.Y),
+		}
+		canvas.DrawText(item.DisplayText(), textRect, dfltFontSize, textColor, false, dfltTextAlignLeft)
+	}
+}
+
+// drawChevron draws a simple up/down chevron indicator.
+func drawChevron(canvas widget.Canvas, center geometry.Point, open bool, color widget.Color) {
+	size := dfltChevronSize
+	if open {
+		// Up chevron: ^
+		canvas.DrawLine(
+			geometry.Pt(center.X-size, center.Y+size/2),
+			geometry.Pt(center.X, center.Y-size/2),
+			color, 1.5,
+		)
+		canvas.DrawLine(
+			geometry.Pt(center.X, center.Y-size/2),
+			geometry.Pt(center.X+size, center.Y+size/2),
+			color, 1.5,
+		)
+	} else {
+		// Down chevron: v
+		canvas.DrawLine(
+			geometry.Pt(center.X-size, center.Y-size/2),
+			geometry.Pt(center.X, center.Y+size/2),
+			color, 1.5,
+		)
+		canvas.DrawLine(
+			geometry.Pt(center.X, center.Y+size/2),
+			geometry.Pt(center.X+size, center.Y-size/2),
+			color, 1.5,
+		)
+	}
+}
+
+// Default painter constants.
+var (
+	dfltTriggerBg    = widget.ColorWhite
+	dfltBorder       = widget.Hex(0x79747E)
+	dfltFocusBorder  = widget.Hex(0x6750A4)
+	dfltTextColor    = widget.Hex(0x1C1B1F)
+	dfltPlaceholder  = widget.Hex(0x49454F)
+	dfltDisabledBg   = widget.RGBA(0.12, 0.12, 0.13, 0.04)
+	dfltDisabledFg   = widget.RGBA(0.12, 0.12, 0.13, 0.38)
+	dfltChevronColor = widget.Hex(0x49454F)
+	dfltMenuBg       = widget.ColorWhite
+	dfltMenuBorder   = widget.Hex(0xCAC4D0)
+	dfltItemHover    = widget.RGBA(0.4, 0.31, 0.64, 0.08)
+	dfltItemSelected = widget.RGBA(0.4, 0.31, 0.64, 0.12)
+)
+
+const (
+	dfltRadius           float32 = 4
+	dfltMenuRadius       float32 = 4
+	dfltBorderWidth      float32 = 1
+	dfltFocusBorderWidth float32 = 2
+	dfltPaddingH         float32 = 16
+	dfltFontSize         float32 = 16
+	dfltTextAlignLeft    float32 = 0
+	dfltChevronWidth     float32 = 24
+	dfltChevronSize      float32 = 5
+)
+
+// Compile-time check.
+var _ Painter = DefaultPainter{}

--- a/core/dropdown/types.go
+++ b/core/dropdown/types.go
@@ -1,0 +1,43 @@
+// Package dropdown provides a dropdown/select widget that displays a list of
+// items in a floating menu when activated. The user can select an item from the
+// list using mouse clicks or keyboard navigation (Up/Down/Enter/Escape).
+//
+// The dropdown consists of two parts:
+//   - A trigger element (button-like) that shows the current selection
+//   - A menu overlay that appears below the trigger when activated
+//
+// Dropdown follows the functional options pattern for construction:
+//
+//	dd := dropdown.New(
+//	    dropdown.Items("Red", "Green", "Blue"),
+//	    dropdown.Selected(0),
+//	    dropdown.OnChange(func(index int, value string) {
+//	        fmt.Println("Selected:", value)
+//	    }),
+//	)
+//
+// The visual appearance is controlled by a pluggable [Painter] interface.
+// The default painter provides a minimal fallback; use a design system painter
+// (e.g., material3.DropdownPainter) for production styling.
+package dropdown
+
+// ItemDef defines a single item in the dropdown list.
+type ItemDef struct {
+	// Value is the internal value associated with this item.
+	Value string
+
+	// Label is the display text. If empty, Value is used as the display text.
+	Label string
+
+	// Disabled prevents this item from being selected.
+	Disabled bool
+}
+
+// DisplayText returns the text to display for this item.
+// Returns Label if set, otherwise Value.
+func (d ItemDef) DisplayText() string {
+	if d.Label != "" {
+		return d.Label
+	}
+	return d.Value
+}

--- a/core/dropdown/widget.go
+++ b/core/dropdown/widget.go
@@ -1,0 +1,338 @@
+package dropdown
+
+import (
+	"github.com/gogpu/ui/event"
+	"github.com/gogpu/ui/geometry"
+	"github.com/gogpu/ui/overlay"
+	"github.com/gogpu/ui/widget"
+)
+
+// triggerHeight is the default height of the dropdown trigger.
+const triggerHeight float32 = 48
+
+// interactionState represents the current user interaction state.
+type interactionState uint8
+
+const (
+	stateNormal  interactionState = iota
+	stateHover                    // mouse is over the trigger
+	statePressed                  // mouse button is held down
+)
+
+// Widget implements a dropdown/select widget with a trigger element and a
+// floating menu overlay. It supports keyboard navigation, mouse selection,
+// and mouse wheel scrolling within the menu.
+//
+// Create with [New] using functional options.
+type Widget struct {
+	widget.WidgetBase
+
+	cfg           config
+	painter       Painter
+	state         interactionState
+	open          bool
+	selectedIndex int
+	menuWidget    *menuWidget // active menu widget (nil when closed)
+}
+
+// New creates a new dropdown Widget with the given options.
+//
+// The returned widget is visible, enabled, and focusable by default.
+func New(opts ...Option) *Widget {
+	w := &Widget{
+		selectedIndex: -1,
+		painter:       DefaultPainter{},
+	}
+	w.cfg.maxVisibleItems = defaultMaxVisible
+	w.cfg.selectedIndex = -1
+
+	w.SetVisible(true)
+	w.SetEnabled(true)
+
+	for _, opt := range opts {
+		opt(&w.cfg)
+	}
+
+	w.selectedIndex = w.cfg.selectedIndex
+
+	if w.cfg.painter != nil {
+		w.painter = w.cfg.painter
+	}
+
+	// If a signal is provided, initialize from it.
+	if w.cfg.signal != nil {
+		w.selectedIndex = w.cfg.signal.Get()
+	}
+
+	return w
+}
+
+// IsFocusable reports whether the dropdown can currently receive focus.
+func (w *Widget) IsFocusable() bool {
+	return w.IsVisible() && w.IsEnabled() && !w.cfg.ResolvedDisabled()
+}
+
+// Layout calculates the dropdown trigger's preferred size.
+func (w *Widget) Layout(_ widget.Context, constraints geometry.Constraints) geometry.Size {
+	preferred := geometry.Sz(200, triggerHeight)
+	return constraints.Constrain(preferred)
+}
+
+// Draw renders the dropdown trigger.
+func (w *Widget) Draw(ctx widget.Context, canvas widget.Canvas) {
+	if canvas == nil {
+		return
+	}
+
+	text := w.cfg.placeholder
+	isPlaceholder := true
+	if w.selectedIndex >= 0 && w.selectedIndex < len(w.cfg.items) {
+		text = w.cfg.items[w.selectedIndex].DisplayText()
+		isPlaceholder = false
+	}
+	if text == "" && isPlaceholder {
+		text = "Select..."
+	}
+
+	w.painter.PaintTrigger(canvas, &TriggerPaintState{
+		Bounds:        w.Bounds(),
+		SelectedText:  text,
+		IsPlaceholder: isPlaceholder,
+		Open:          w.open,
+		Focused:       w.IsFocused(),
+		Hovered:       w.state == stateHover,
+		Disabled:      w.cfg.ResolvedDisabled(),
+	})
+}
+
+// Event handles input events for the dropdown trigger.
+func (w *Widget) Event(ctx widget.Context, e event.Event) bool {
+	if w.cfg.ResolvedDisabled() {
+		return false
+	}
+
+	switch ev := e.(type) {
+	case *event.MouseEvent:
+		return w.handleMouseEvent(ctx, ev)
+	case *event.KeyEvent:
+		return w.handleKeyEvent(ctx, ev)
+	default:
+		return false
+	}
+}
+
+// Children returns nil; the dropdown trigger is a leaf widget.
+// The menu is rendered in the overlay, not as a child.
+func (w *Widget) Children() []widget.Widget {
+	return nil
+}
+
+// SelectedIndex returns the currently selected item index, or -1 if none.
+func (w *Widget) SelectedIndex() int {
+	return w.selectedIndex
+}
+
+// SelectedValue returns the value of the currently selected item,
+// or an empty string if nothing is selected.
+func (w *Widget) SelectedValue() string {
+	if w.selectedIndex < 0 || w.selectedIndex >= len(w.cfg.items) {
+		return ""
+	}
+	return w.cfg.items[w.selectedIndex].Value
+}
+
+// SetSelectedIndex programmatically sets the selected item.
+func (w *Widget) SetSelectedIndex(index int) {
+	if index < -1 || index >= len(w.cfg.items) {
+		return
+	}
+	w.selectedIndex = index
+	if w.cfg.signal != nil {
+		w.cfg.signal.Set(index)
+	}
+}
+
+// IsOpen returns true if the dropdown menu is currently visible.
+func (w *Widget) IsOpen() bool {
+	return w.open
+}
+
+// Open opens the dropdown menu overlay.
+func (w *Widget) Open(ctx widget.Context) {
+	if w.open || w.cfg.ResolvedDisabled() {
+		return
+	}
+
+	om := ctx.OverlayManager()
+	if om == nil {
+		return
+	}
+
+	w.open = true
+
+	// Create the menu widget.
+	w.menuWidget = newMenuWidget(
+		w.cfg.items,
+		w.selectedIndex,
+		w.cfg.maxVisibleItems,
+		w.painter,
+		func(index int) {
+			w.selectItem(ctx, index)
+		},
+	)
+
+	// Position the menu below the trigger.
+	triggerBounds := w.Bounds()
+	windowSize := ctx.WindowSize()
+	menuSize := geometry.Sz(triggerBounds.Width(), float32(w.menuWidget.visibleCount())*w.menuWidget.itemHeight)
+	pos := overlay.Position(overlay.PlacementBelow, triggerBounds, menuSize, windowSize, 2)
+
+	w.menuWidget.SetBounds(geometry.FromPointSize(pos, menuSize))
+
+	// Push to overlay stack.
+	om.PushOverlay(w.menuWidget, func() {
+		w.close(ctx)
+	})
+
+	ctx.Invalidate()
+}
+
+// Close closes the dropdown menu overlay.
+func (w *Widget) Close(ctx widget.Context) {
+	w.close(ctx)
+}
+
+// close is the internal close implementation.
+func (w *Widget) close(ctx widget.Context) {
+	if !w.open {
+		return
+	}
+
+	w.open = false
+
+	if w.menuWidget != nil {
+		om := ctx.OverlayManager()
+		if om != nil {
+			om.RemoveOverlay(w.menuWidget)
+		}
+		w.menuWidget = nil
+	}
+
+	ctx.Invalidate()
+}
+
+// selectItem is called when an item is selected from the menu.
+func (w *Widget) selectItem(ctx widget.Context, index int) {
+	if index < 0 || index >= len(w.cfg.items) {
+		return
+	}
+
+	w.selectedIndex = index
+
+	// Update signal if bound.
+	if w.cfg.signal != nil {
+		w.cfg.signal.Set(index)
+	}
+
+	// Fire callback.
+	if w.cfg.onChange != nil {
+		w.cfg.onChange(index, w.cfg.items[index].Value)
+	}
+
+	w.close(ctx)
+}
+
+// handleMouseEvent processes mouse events on the trigger.
+func (w *Widget) handleMouseEvent(ctx widget.Context, e *event.MouseEvent) bool {
+	switch e.MouseType {
+	case event.MouseEnter:
+		w.state = stateHover
+		ctx.SetCursor(widget.CursorPointer)
+		ctx.Invalidate()
+		return true
+
+	case event.MouseLeave:
+		w.state = stateNormal
+		ctx.SetCursor(widget.CursorDefault)
+		ctx.Invalidate()
+		return true
+
+	case event.MousePress:
+		if e.Button != event.ButtonLeft {
+			return false
+		}
+		w.state = statePressed
+		ctx.RequestFocus(w)
+		ctx.Invalidate()
+		return true
+
+	case event.MouseRelease:
+		if e.Button != event.ButtonLeft {
+			return false
+		}
+		wasPressed := w.state == statePressed
+		if w.Bounds().Contains(e.Position) {
+			w.state = stateHover
+		} else {
+			w.state = stateNormal
+		}
+		if wasPressed && w.Bounds().Contains(e.Position) {
+			w.toggle(ctx)
+		}
+		ctx.Invalidate()
+		return true
+
+	default:
+		return false
+	}
+}
+
+// handleKeyEvent processes keyboard events on the trigger.
+func (w *Widget) handleKeyEvent(ctx widget.Context, e *event.KeyEvent) bool {
+	if !w.IsFocused() {
+		return false
+	}
+
+	if e.KeyType != event.KeyPress && e.KeyType != event.KeyRepeat {
+		return false
+	}
+
+	switch e.Key {
+	case event.KeyEnter, event.KeySpace:
+		w.toggle(ctx)
+		return true
+	case event.KeyDown:
+		if !w.open {
+			w.Open(ctx)
+		}
+		return true
+	case event.KeyUp:
+		if !w.open {
+			w.Open(ctx)
+		}
+		return true
+	case event.KeyEscape:
+		if w.open {
+			w.close(ctx)
+			return true
+		}
+		return false
+	default:
+		return false
+	}
+}
+
+// toggle opens the menu if closed, closes it if open.
+func (w *Widget) toggle(ctx widget.Context) {
+	if w.open {
+		w.close(ctx)
+	} else {
+		w.Open(ctx)
+	}
+}
+
+// Compile-time interface checks.
+var (
+	_ widget.Widget    = (*Widget)(nil)
+	_ widget.Focusable = (*Widget)(nil)
+)

--- a/core/radio/internal_test.go
+++ b/core/radio/internal_test.go
@@ -1,9 +1,7 @@
 package radio
 
 import (
-	"sync"
 	"testing"
-	"time"
 
 	"github.com/gogpu/ui/event"
 	"github.com/gogpu/ui/geometry"
@@ -1457,95 +1455,6 @@ func (c *internalMockCanvas) PushClip(_ geometry.Rect)       {}
 func (c *internalMockCanvas) PopClip()                       {}
 func (c *internalMockCanvas) PushTransform(_ geometry.Point) {}
 func (c *internalMockCanvas) PopTransform()                  {}
-
-// --- Concurrent Access Tests ---
-// These tests verify that Draw/Event/Select don't deadlock under concurrent access.
-
-func TestConcurrent_DrawAndSelect(t *testing.T) {
-	g := NewGroup(
-		Items(
-			ItemDef{Value: "a", Label: "Alpha"},
-			ItemDef{Value: "b", Label: "Beta"},
-		),
-		Selected("a"),
-	)
-	g.items[0].SetBounds(geometry.NewRect(0, 0, 200, 30))
-	g.items[1].SetBounds(geometry.NewRect(0, 30, 200, 30))
-
-	ctx := widget.NewContext()
-	canvas := &internalMockCanvas{}
-
-	done := make(chan struct{})
-	go func() {
-		defer close(done)
-		for i := 0; i < 500; i++ {
-			if i%2 == 0 {
-				g.selectValue("a")
-			} else {
-				g.selectValue("b")
-			}
-		}
-	}()
-
-	// Draw concurrently with selectValue.
-	for i := 0; i < 500; i++ {
-		g.Draw(ctx, canvas)
-	}
-
-	select {
-	case <-done:
-	case <-time.After(5 * time.Second):
-		t.Fatal("deadlock detected: concurrent Draw+Select timed out")
-	}
-}
-
-func TestConcurrent_EventAndDraw(t *testing.T) {
-	g := NewGroup(
-		Items(
-			ItemDef{Value: "a", Label: "Alpha"},
-			ItemDef{Value: "b", Label: "Beta"},
-		),
-	)
-	g.items[0].SetBounds(geometry.NewRect(0, 0, 200, 30))
-	g.items[1].SetBounds(geometry.NewRect(0, 30, 200, 30))
-
-	ctx := widget.NewContext()
-	canvas := &internalMockCanvas{}
-
-	var wg sync.WaitGroup
-	wg.Add(2)
-
-	go func() {
-		defer wg.Done()
-		for i := 0; i < 500; i++ {
-			g.Draw(ctx, canvas)
-		}
-	}()
-
-	go func() {
-		defer wg.Done()
-		for i := 0; i < 500; i++ {
-			press := event.NewMouseEvent(event.MousePress, event.ButtonLeft,
-				event.ButtonStateLeft, geometry.Pt(10, 10), geometry.Pt(10, 10), event.ModNone)
-			g.Event(ctx, press)
-			release := event.NewMouseEvent(event.MouseRelease, event.ButtonLeft,
-				0, geometry.Pt(10, 10), geometry.Pt(10, 10), event.ModNone)
-			g.Event(ctx, release)
-		}
-	}()
-
-	done := make(chan struct{})
-	go func() {
-		wg.Wait()
-		close(done)
-	}()
-
-	select {
-	case <-done:
-	case <-time.After(5 * time.Second):
-		t.Fatal("deadlock detected: concurrent Event+Draw timed out")
-	}
-}
 
 // --- onChange dedup test ---
 

--- a/overlay/container.go
+++ b/overlay/container.go
@@ -1,0 +1,168 @@
+package overlay
+
+import (
+	"github.com/gogpu/ui/event"
+	"github.com/gogpu/ui/geometry"
+	"github.com/gogpu/ui/widget"
+)
+
+// scrimAlpha is the opacity of the semi-transparent backdrop for modal overlays.
+const scrimAlpha = 0.32
+
+// Container wraps overlay content with a full-window transparent backdrop.
+// Clicks on the backdrop (outside the content) trigger dismissal. For modal
+// overlays, a semi-transparent scrim is drawn behind the content.
+//
+// Container implements the [Overlay] interface.
+type Container struct {
+	widget.WidgetBase
+
+	content    widget.Widget
+	onDismiss  func()
+	modal      bool
+	windowSize geometry.Size
+}
+
+// ContainerOption configures a Container during construction.
+type ContainerOption func(*Container)
+
+// WithOnDismiss sets the callback invoked when the container is dismissed
+// (click outside content or Escape key).
+func WithOnDismiss(fn func()) ContainerOption {
+	return func(c *Container) {
+		c.onDismiss = fn
+	}
+}
+
+// WithModal makes the container modal. A modal container draws a
+// semi-transparent scrim and consumes all events not handled by the content.
+func WithModal(modal bool) ContainerOption {
+	return func(c *Container) {
+		c.modal = modal
+	}
+}
+
+// NewContainer creates a new overlay container wrapping the given content.
+// The windowSize is used to size the backdrop to fill the entire window.
+func NewContainer(content widget.Widget, windowSize geometry.Size, opts ...ContainerOption) *Container {
+	c := &Container{
+		content:    content,
+		windowSize: windowSize,
+	}
+	c.SetVisible(true)
+	c.SetEnabled(true)
+	for _, opt := range opts {
+		opt(c)
+	}
+	return c
+}
+
+// Layout fills the entire window and lays out the content unconstrained.
+func (c *Container) Layout(ctx widget.Context, constraints geometry.Constraints) geometry.Size {
+	size := constraints.Constrain(c.windowSize)
+	c.SetBounds(geometry.NewRect(0, 0, size.Width, size.Height))
+
+	if c.content != nil {
+		// Content is laid out with loose constraints so it can take its natural size.
+		c.content.Layout(ctx, geometry.Loose(size))
+	}
+	return size
+}
+
+// Draw renders the optional scrim and then the content.
+func (c *Container) Draw(ctx widget.Context, canvas widget.Canvas) {
+	if canvas == nil {
+		return
+	}
+	if c.modal {
+		scrim := widget.RGBA(0, 0, 0, scrimAlpha)
+		canvas.DrawRect(c.Bounds(), scrim)
+	}
+	if c.content != nil {
+		c.content.Draw(ctx, canvas)
+	}
+}
+
+// Event dispatches events. Content gets first chance. If content does not
+// consume the event, Escape key and mouse press outside content trigger
+// dismissal. Modal containers consume all remaining events.
+func (c *Container) Event(ctx widget.Context, e event.Event) bool {
+	// Give content first chance at the event.
+	if c.content != nil && c.content.Event(ctx, e) {
+		return true
+	}
+
+	// Escape key dismisses.
+	if ke, ok := e.(*event.KeyEvent); ok {
+		if ke.KeyType == event.KeyPress && ke.Key == event.KeyEscape {
+			c.Dismiss()
+			return true
+		}
+	}
+
+	// Mouse press outside content dismisses.
+	if c.handleMouseDismiss(e) {
+		return true
+	}
+
+	// Modal overlays consume all events to prevent interaction with content below.
+	return c.modal
+}
+
+// handleMouseDismiss checks if a mouse press event occurred outside the
+// content bounds and dismisses if so. Returns true if the event was handled.
+func (c *Container) handleMouseDismiss(e event.Event) bool {
+	me, ok := e.(*event.MouseEvent)
+	if !ok || me.MouseType != event.MousePress {
+		return false
+	}
+
+	if c.content == nil {
+		c.Dismiss()
+		return true
+	}
+
+	boundsGetter, ok := c.content.(interface{ Bounds() geometry.Rect })
+	if !ok {
+		return false
+	}
+
+	if !boundsGetter.Bounds().Contains(me.Position) {
+		c.Dismiss()
+		return true
+	}
+	return false
+}
+
+// Dismiss triggers the dismissal callback.
+func (c *Container) Dismiss() {
+	if c.onDismiss != nil {
+		c.onDismiss()
+	}
+}
+
+// Modal returns true if this container blocks interaction with content below.
+func (c *Container) Modal() bool {
+	return c.modal
+}
+
+// Children returns the content widget as the sole child.
+func (c *Container) Children() []widget.Widget {
+	if c.content == nil {
+		return nil
+	}
+	return []widget.Widget{c.content}
+}
+
+// Content returns the wrapped content widget.
+func (c *Container) Content() widget.Widget {
+	return c.content
+}
+
+// SetWindowSize updates the backdrop size. Call this when the window is resized.
+func (c *Container) SetWindowSize(size geometry.Size) {
+	c.windowSize = size
+}
+
+// Compile-time interface checks.
+var _ Overlay = (*Container)(nil)

--- a/overlay/container_test.go
+++ b/overlay/container_test.go
@@ -1,0 +1,197 @@
+package overlay_test
+
+import (
+	"testing"
+
+	"github.com/gogpu/ui/event"
+	"github.com/gogpu/ui/geometry"
+	"github.com/gogpu/ui/overlay"
+	"github.com/gogpu/ui/widget"
+)
+
+// mockContent is a widget that tracks events and has configurable bounds.
+type mockContent struct {
+	widget.WidgetBase
+	consumeEvents bool
+	lastEvent     event.Event
+}
+
+func (m *mockContent) Layout(_ widget.Context, c geometry.Constraints) geometry.Size {
+	return c.Constrain(geometry.Sz(200, 100))
+}
+func (m *mockContent) Draw(_ widget.Context, _ widget.Canvas) {}
+func (m *mockContent) Event(_ widget.Context, e event.Event) bool {
+	m.lastEvent = e
+	return m.consumeEvents
+}
+func (m *mockContent) Children() []widget.Widget { return nil }
+
+func newMockContent(bounds geometry.Rect) *mockContent {
+	m := &mockContent{}
+	m.SetVisible(true)
+	m.SetEnabled(true)
+	m.SetBounds(bounds)
+	return m
+}
+
+func TestContainerDismissOnEscape(t *testing.T) {
+	dismissed := false
+	content := newMockContent(geometry.NewRect(100, 100, 200, 100))
+	c := overlay.NewContainer(content, geometry.Sz(800, 600),
+		overlay.WithOnDismiss(func() { dismissed = true }),
+	)
+
+	ctx := widget.NewContext()
+	esc := event.NewKeyEvent(event.KeyPress, event.KeyEscape, 0, 0)
+
+	consumed := c.Event(ctx, esc)
+	if !consumed {
+		t.Error("Escape should be consumed")
+	}
+	if !dismissed {
+		t.Error("Escape should trigger dismiss")
+	}
+}
+
+func TestContainerDismissOnClickOutside(t *testing.T) {
+	dismissed := false
+	content := newMockContent(geometry.NewRect(100, 100, 200, 100))
+	c := overlay.NewContainer(content, geometry.Sz(800, 600),
+		overlay.WithOnDismiss(func() { dismissed = true }),
+	)
+
+	ctx := widget.NewContext()
+
+	// Click outside content bounds.
+	outsideClick := event.NewMouseEvent(
+		event.MousePress, event.ButtonLeft, 0,
+		geometry.Pt(50, 50), geometry.Pt(50, 50), 0,
+	)
+	consumed := c.Event(ctx, outsideClick)
+	if !consumed {
+		t.Error("click outside should be consumed")
+	}
+	if !dismissed {
+		t.Error("click outside content should trigger dismiss")
+	}
+}
+
+func TestContainerContentConsumesEvent(t *testing.T) {
+	dismissed := false
+	content := newMockContent(geometry.NewRect(100, 100, 200, 100))
+	content.consumeEvents = true
+
+	c := overlay.NewContainer(content, geometry.Sz(800, 600),
+		overlay.WithOnDismiss(func() { dismissed = true }),
+	)
+
+	ctx := widget.NewContext()
+	me := event.NewMouseEvent(
+		event.MousePress, event.ButtonLeft, 0,
+		geometry.Pt(150, 150), geometry.Pt(150, 150), 0,
+	)
+	consumed := c.Event(ctx, me)
+	if !consumed {
+		t.Error("event consumed by content should be reported as consumed")
+	}
+	if dismissed {
+		t.Error("should not dismiss when content consumes the event")
+	}
+}
+
+func TestContainerModalConsumesAll(t *testing.T) {
+	content := newMockContent(geometry.NewRect(100, 100, 200, 100))
+	c := overlay.NewContainer(content, geometry.Sz(800, 600),
+		overlay.WithModal(true),
+	)
+
+	ctx := widget.NewContext()
+
+	// A mouse move event that content does not consume.
+	move := event.NewMouseEvent(
+		event.MouseMove, event.ButtonNone, 0,
+		geometry.Pt(500, 500), geometry.Pt(500, 500), 0,
+	)
+	consumed := c.Event(ctx, move)
+	if !consumed {
+		t.Error("modal container should consume events not handled by content")
+	}
+}
+
+func TestContainerNonModalPassthrough(t *testing.T) {
+	content := newMockContent(geometry.NewRect(100, 100, 200, 100))
+	c := overlay.NewContainer(content, geometry.Sz(800, 600))
+
+	ctx := widget.NewContext()
+
+	// A mouse move that content does not consume and is not a click.
+	move := event.NewMouseEvent(
+		event.MouseMove, event.ButtonNone, 0,
+		geometry.Pt(500, 500), geometry.Pt(500, 500), 0,
+	)
+	consumed := c.Event(ctx, move)
+	if consumed {
+		t.Error("non-modal container should not consume unhandled non-click events")
+	}
+}
+
+func TestContainerLayout(t *testing.T) {
+	content := newMockContent(geometry.NewRect(0, 0, 200, 100))
+	c := overlay.NewContainer(content, geometry.Sz(800, 600))
+
+	ctx := widget.NewContext()
+	size := c.Layout(ctx, geometry.Tight(geometry.Sz(800, 600)))
+
+	if size.Width != 800 || size.Height != 600 {
+		t.Errorf("Layout size = %v, want (800, 600)", size)
+	}
+}
+
+func TestContainerModal(t *testing.T) {
+	c := overlay.NewContainer(nil, geometry.Sz(800, 600))
+	if c.Modal() {
+		t.Error("default container should not be modal")
+	}
+
+	c2 := overlay.NewContainer(nil, geometry.Sz(800, 600), overlay.WithModal(true))
+	if !c2.Modal() {
+		t.Error("container with WithModal(true) should be modal")
+	}
+}
+
+func TestContainerChildren(t *testing.T) {
+	c := overlay.NewContainer(nil, geometry.Sz(800, 600))
+	if c.Children() != nil {
+		t.Error("container with nil content should return nil children")
+	}
+
+	content := newMockContent(geometry.NewRect(0, 0, 100, 100))
+	c2 := overlay.NewContainer(content, geometry.Sz(800, 600))
+	children := c2.Children()
+	if len(children) != 1 {
+		t.Fatalf("Children length = %d, want 1", len(children))
+	}
+	if children[0] != content {
+		t.Error("Children[0] should be the content widget")
+	}
+}
+
+func TestContainerNilContent(t *testing.T) {
+	dismissed := false
+	c := overlay.NewContainer(nil, geometry.Sz(800, 600),
+		overlay.WithOnDismiss(func() { dismissed = true }),
+	)
+
+	ctx := widget.NewContext()
+	click := event.NewMouseEvent(
+		event.MousePress, event.ButtonLeft, 0,
+		geometry.Pt(100, 100), geometry.Pt(100, 100), 0,
+	)
+	consumed := c.Event(ctx, click)
+	if !consumed {
+		t.Error("click on container with nil content should be consumed (dismiss)")
+	}
+	if !dismissed {
+		t.Error("click on container with nil content should trigger dismiss")
+	}
+}

--- a/overlay/overlay.go
+++ b/overlay/overlay.go
@@ -1,0 +1,157 @@
+// Package overlay provides an overlay stack for displaying content above the
+// normal widget tree. Overlays are used by dropdowns, tooltips, dialogs, and
+// any widget that needs to float above the main UI.
+//
+// The core abstraction is [Stack], owned by the Window, which manages a
+// last-in-first-out collection of [Overlay] widgets. Events are dispatched to
+// the top overlay before reaching the regular widget tree, and overlays are
+// drawn after (on top of) the regular tree.
+//
+// Widgets push overlays via the [widget.OverlayManager] interface obtained from
+// [widget.Context], and never import the overlay package directly. This avoids
+// circular dependencies.
+package overlay
+
+import (
+	"github.com/gogpu/ui/event"
+	"github.com/gogpu/ui/geometry"
+	"github.com/gogpu/ui/widget"
+)
+
+// Overlay represents content displayed above the normal widget tree.
+// It extends widget.Widget with dismissal and modality support.
+type Overlay interface {
+	widget.Widget
+
+	// Dismiss is called when the overlay should close (e.g. click outside, Escape key).
+	Dismiss()
+
+	// Modal returns true if the overlay blocks interaction with content below.
+	// A modal overlay consumes all events that are not handled by its content.
+	Modal() bool
+}
+
+// Stack manages a last-in-first-out collection of overlays for a window.
+//
+// The stack supports push, pop, and targeted removal. When an overlay is
+// removed, all overlays above it in the stack are also removed (maintaining
+// stack semantics). An optional onChange callback is invoked whenever the
+// stack is modified, which typically triggers a redraw.
+//
+// Stack is NOT safe for concurrent access. All operations must occur on the
+// main/UI thread.
+type Stack struct {
+	overlays []Overlay
+	onChange func()
+}
+
+// NewStack creates an empty overlay stack. The onChange callback, if non-nil,
+// is called whenever the stack contents change (push, pop, or remove).
+func NewStack(onChange func()) *Stack {
+	return &Stack{onChange: onChange}
+}
+
+// Push adds an overlay to the top of the stack.
+func (s *Stack) Push(o Overlay) {
+	if o == nil {
+		return
+	}
+	s.overlays = append(s.overlays, o)
+	s.notify()
+}
+
+// Pop removes and returns the top overlay. Returns nil if the stack is empty.
+func (s *Stack) Pop() Overlay {
+	if len(s.overlays) == 0 {
+		return nil
+	}
+	top := s.overlays[len(s.overlays)-1]
+	s.overlays[len(s.overlays)-1] = nil // clear reference for GC
+	s.overlays = s.overlays[:len(s.overlays)-1]
+	s.notify()
+	return top
+}
+
+// Remove removes the given overlay and all overlays above it in the stack.
+// This maintains stack semantics: you cannot remove an overlay from the
+// middle without also removing everything on top of it.
+func (s *Stack) Remove(o Overlay) {
+	for i, existing := range s.overlays {
+		if existing == o {
+			// Clear references for GC.
+			for j := i; j < len(s.overlays); j++ {
+				s.overlays[j] = nil
+			}
+			s.overlays = s.overlays[:i]
+			s.notify()
+			return
+		}
+	}
+}
+
+// Top returns the topmost overlay, or nil if the stack is empty.
+func (s *Stack) Top() Overlay {
+	if len(s.overlays) == 0 {
+		return nil
+	}
+	return s.overlays[len(s.overlays)-1]
+}
+
+// IsEmpty returns true if the stack contains no overlays.
+func (s *Stack) IsEmpty() bool {
+	return len(s.overlays) == 0
+}
+
+// Len returns the number of overlays in the stack.
+func (s *Stack) Len() int {
+	return len(s.overlays)
+}
+
+// List returns the overlay slice in bottom-to-top order.
+// The returned slice should not be modified by the caller.
+func (s *Stack) List() []Overlay {
+	return s.overlays
+}
+
+// HandleEvent dispatches an event to the overlay stack. Events are sent to
+// the top overlay first. If the top overlay is modal and does not consume
+// the event, the event is still blocked from reaching the normal widget tree.
+//
+// Returns true if the event was consumed or blocked by a modal overlay.
+func (s *Stack) HandleEvent(ctx widget.Context, e event.Event) bool {
+	if len(s.overlays) == 0 {
+		return false
+	}
+	top := s.overlays[len(s.overlays)-1]
+	if top.Event(ctx, e) {
+		return true
+	}
+	// Modal overlays block all events from reaching the widget tree,
+	// even if they did not explicitly consume the event.
+	return top.Modal()
+}
+
+// Layout lays out all overlays with the given window-sized constraints.
+func (s *Stack) Layout(ctx widget.Context, windowSize geometry.Size) {
+	constraints := geometry.Tight(windowSize)
+	for _, o := range s.overlays {
+		size := o.Layout(ctx, constraints)
+		if setter, ok := o.(interface{ SetBounds(geometry.Rect) }); ok {
+			setter.SetBounds(geometry.NewRect(0, 0, size.Width, size.Height))
+		}
+	}
+}
+
+// Draw draws all overlays in bottom-to-top order.
+func (s *Stack) Draw(ctx widget.Context, canvas widget.Canvas) {
+	for _, o := range s.overlays {
+		o.Draw(ctx, canvas)
+	}
+}
+
+// notify calls the onChange callback if set.
+func (s *Stack) notify() {
+	if s.onChange != nil {
+		s.onChange()
+	}
+}

--- a/overlay/overlay_test.go
+++ b/overlay/overlay_test.go
@@ -1,0 +1,201 @@
+package overlay_test
+
+import (
+	"testing"
+
+	"github.com/gogpu/ui/event"
+	"github.com/gogpu/ui/geometry"
+	"github.com/gogpu/ui/overlay"
+	"github.com/gogpu/ui/widget"
+)
+
+// stubOverlay is a minimal Overlay implementation for testing.
+type stubOverlay struct {
+	widget.WidgetBase
+	dismissed bool
+	modal     bool
+	consumed  bool
+}
+
+func (s *stubOverlay) Layout(_ widget.Context, c geometry.Constraints) geometry.Size {
+	return c.Constrain(geometry.Sz(100, 100))
+}
+func (s *stubOverlay) Draw(_ widget.Context, _ widget.Canvas) {}
+func (s *stubOverlay) Event(_ widget.Context, _ event.Event) bool {
+	return s.consumed
+}
+func (s *stubOverlay) Children() []widget.Widget { return nil }
+func (s *stubOverlay) Dismiss()                  { s.dismissed = true }
+func (s *stubOverlay) Modal() bool               { return s.modal }
+
+func newStubOverlay() *stubOverlay {
+	o := &stubOverlay{}
+	o.SetVisible(true)
+	o.SetEnabled(true)
+	return o
+}
+
+func TestStackPushPop(t *testing.T) {
+	changed := 0
+	s := overlay.NewStack(func() { changed++ })
+
+	if !s.IsEmpty() {
+		t.Error("new stack should be empty")
+	}
+	if s.Len() != 0 {
+		t.Errorf("new stack Len() = %d, want 0", s.Len())
+	}
+
+	o1 := newStubOverlay()
+	o2 := newStubOverlay()
+
+	s.Push(o1)
+	if s.IsEmpty() {
+		t.Error("stack should not be empty after push")
+	}
+	if s.Top() != o1 {
+		t.Error("Top should return o1")
+	}
+	if changed != 1 {
+		t.Errorf("onChange called %d times, want 1", changed)
+	}
+
+	s.Push(o2)
+	if s.Top() != o2 {
+		t.Error("Top should return o2")
+	}
+	if s.Len() != 2 {
+		t.Errorf("Len() = %d, want 2", s.Len())
+	}
+
+	popped := s.Pop()
+	if popped != o2 {
+		t.Error("Pop should return o2")
+	}
+	if s.Top() != o1 {
+		t.Error("Top should return o1 after pop")
+	}
+
+	popped = s.Pop()
+	if popped != o1 {
+		t.Error("Pop should return o1")
+	}
+	if !s.IsEmpty() {
+		t.Error("stack should be empty after popping all")
+	}
+}
+
+func TestStackPopEmpty(t *testing.T) {
+	s := overlay.NewStack(nil)
+	if s.Pop() != nil {
+		t.Error("Pop on empty stack should return nil")
+	}
+}
+
+func TestStackPushNil(t *testing.T) {
+	s := overlay.NewStack(nil)
+	s.Push(nil)
+	if !s.IsEmpty() {
+		t.Error("pushing nil should not add to stack")
+	}
+}
+
+func TestStackRemove(t *testing.T) {
+	s := overlay.NewStack(nil)
+	o1 := newStubOverlay()
+	o2 := newStubOverlay()
+	o3 := newStubOverlay()
+
+	s.Push(o1)
+	s.Push(o2)
+	s.Push(o3)
+
+	// Removing o2 should also remove o3 (everything above).
+	s.Remove(o2)
+	if s.Len() != 1 {
+		t.Errorf("Len() = %d, want 1 after removing o2 (and o3 above it)", s.Len())
+	}
+	if s.Top() != o1 {
+		t.Error("Top should be o1 after removing o2 and o3")
+	}
+}
+
+func TestStackRemoveNonExistent(t *testing.T) {
+	s := overlay.NewStack(nil)
+	o1 := newStubOverlay()
+	o2 := newStubOverlay()
+
+	s.Push(o1)
+	s.Remove(o2) // o2 not in stack, should be a no-op
+	if s.Len() != 1 {
+		t.Errorf("Len() = %d, want 1", s.Len())
+	}
+}
+
+func TestStackList(t *testing.T) {
+	s := overlay.NewStack(nil)
+	o1 := newStubOverlay()
+	o2 := newStubOverlay()
+
+	s.Push(o1)
+	s.Push(o2)
+
+	list := s.List()
+	if len(list) != 2 {
+		t.Fatalf("List() length = %d, want 2", len(list))
+	}
+	if list[0] != o1 || list[1] != o2 {
+		t.Error("List should return overlays in push order (bottom to top)")
+	}
+}
+
+func TestStackHandleEventModalBlocks(t *testing.T) {
+	s := overlay.NewStack(nil)
+	o := newStubOverlay()
+	o.modal = true
+	o.consumed = false // overlay does not consume, but it's modal
+
+	s.Push(o)
+
+	ctx := widget.NewContext()
+	me := event.NewMouseEvent(event.MousePress, event.ButtonLeft, 0, geometry.Pt(500, 500), geometry.Pt(500, 500), 0)
+
+	blocked := s.HandleEvent(ctx, me)
+	if !blocked {
+		t.Error("modal overlay should block events from reaching widget tree")
+	}
+}
+
+func TestStackHandleEventNonModalPassthrough(t *testing.T) {
+	s := overlay.NewStack(nil)
+	o := newStubOverlay()
+	o.modal = false
+	o.consumed = false
+
+	s.Push(o)
+
+	ctx := widget.NewContext()
+	me := event.NewMouseEvent(event.MousePress, event.ButtonLeft, 0, geometry.Pt(500, 500), geometry.Pt(500, 500), 0)
+
+	blocked := s.HandleEvent(ctx, me)
+	if blocked {
+		t.Error("non-modal overlay that does not consume should not block events")
+	}
+}
+
+func TestStackHandleEventEmpty(t *testing.T) {
+	s := overlay.NewStack(nil)
+	ctx := widget.NewContext()
+	me := event.NewMouseEvent(event.MousePress, event.ButtonLeft, 0, geometry.Pt(0, 0), geometry.Pt(0, 0), 0)
+
+	if s.HandleEvent(ctx, me) {
+		t.Error("empty stack should not handle events")
+	}
+}
+
+func TestStackTop(t *testing.T) {
+	s := overlay.NewStack(nil)
+	if s.Top() != nil {
+		t.Error("Top on empty stack should return nil")
+	}
+}

--- a/overlay/position.go
+++ b/overlay/position.go
@@ -1,0 +1,125 @@
+package overlay
+
+import "github.com/gogpu/ui/geometry"
+
+// Placement defines where an overlay appears relative to its anchor widget.
+type Placement uint8
+
+// Placement constants.
+const (
+	// PlacementBelow positions the overlay below the anchor (default for dropdowns).
+	PlacementBelow Placement = iota
+
+	// PlacementAbove positions the overlay above the anchor.
+	PlacementAbove
+
+	// PlacementLeft positions the overlay to the left of the anchor.
+	PlacementLeft
+
+	// PlacementRight positions the overlay to the right of the anchor.
+	PlacementRight
+)
+
+// Position calculates the overlay position relative to an anchor rectangle.
+//
+// Parameters:
+//   - placement: preferred placement direction
+//   - anchorGlobal: the anchor widget's bounds in window coordinates
+//   - overlaySize: the measured size of the overlay content
+//   - windowSize: the total window size for viewport clamping
+//   - gap: spacing between the anchor and overlay edges
+//
+// The function applies flip logic (tries the opposite side if the overlay
+// would go out of bounds) and then clamps to the viewport.
+func Position(
+	placement Placement,
+	anchorGlobal geometry.Rect,
+	overlaySize geometry.Size,
+	windowSize geometry.Size,
+	gap float32,
+) geometry.Point {
+	var x, y float32
+
+	switch placement {
+	case PlacementBelow:
+		x = anchorGlobal.Min.X
+		y = anchorGlobal.Max.Y + gap
+	case PlacementAbove:
+		x = anchorGlobal.Min.X
+		y = anchorGlobal.Min.Y - overlaySize.Height - gap
+	case PlacementRight:
+		x = anchorGlobal.Max.X + gap
+		y = anchorGlobal.Min.Y
+	case PlacementLeft:
+		x = anchorGlobal.Min.X - overlaySize.Width - gap
+		y = anchorGlobal.Min.Y
+	}
+
+	// Flip if the overlay goes out of viewport bounds.
+	x, y = flip(placement, x, y, anchorGlobal, overlaySize, windowSize, gap)
+
+	// Clamp to viewport.
+	x, y = clampToViewport(x, y, overlaySize, windowSize)
+
+	return geometry.Pt(x, y)
+}
+
+// flip tries the opposite placement direction if the overlay extends beyond
+// the viewport boundary.
+func flip(
+	placement Placement,
+	x, y float32,
+	anchor geometry.Rect,
+	overlaySize geometry.Size,
+	windowSize geometry.Size,
+	gap float32,
+) (float32, float32) {
+	switch placement {
+	case PlacementBelow:
+		if y+overlaySize.Height > windowSize.Height {
+			flipped := anchor.Min.Y - overlaySize.Height - gap
+			if flipped >= 0 {
+				y = flipped
+			}
+		}
+	case PlacementAbove:
+		if y < 0 {
+			flipped := anchor.Max.Y + gap
+			if flipped+overlaySize.Height <= windowSize.Height {
+				y = flipped
+			}
+		}
+	case PlacementRight:
+		if x+overlaySize.Width > windowSize.Width {
+			flipped := anchor.Min.X - overlaySize.Width - gap
+			if flipped >= 0 {
+				x = flipped
+			}
+		}
+	case PlacementLeft:
+		if x < 0 {
+			flipped := anchor.Max.X + gap
+			if flipped+overlaySize.Width <= windowSize.Width {
+				x = flipped
+			}
+		}
+	}
+	return x, y
+}
+
+// clampToViewport ensures the overlay stays within the window boundaries.
+func clampToViewport(x, y float32, overlaySize geometry.Size, windowSize geometry.Size) (float32, float32) {
+	if x+overlaySize.Width > windowSize.Width {
+		x = windowSize.Width - overlaySize.Width
+	}
+	if x < 0 {
+		x = 0
+	}
+	if y+overlaySize.Height > windowSize.Height {
+		y = windowSize.Height - overlaySize.Height
+	}
+	if y < 0 {
+		y = 0
+	}
+	return x, y
+}

--- a/overlay/position_test.go
+++ b/overlay/position_test.go
@@ -1,0 +1,151 @@
+package overlay_test
+
+import (
+	"testing"
+
+	"github.com/gogpu/ui/geometry"
+	"github.com/gogpu/ui/overlay"
+)
+
+func TestPositionBelow(t *testing.T) {
+	anchor := geometry.NewRect(100, 100, 200, 40) // x=100, y=100, w=200, h=40
+	overlaySize := geometry.Sz(200, 150)
+	windowSize := geometry.Sz(800, 600)
+
+	pos := overlay.Position(overlay.PlacementBelow, anchor, overlaySize, windowSize, 4)
+
+	if pos.X != 100 {
+		t.Errorf("X = %f, want 100", pos.X)
+	}
+	// anchor.Max.Y = 140, gap = 4 -> y = 144
+	if pos.Y != 144 {
+		t.Errorf("Y = %f, want 144", pos.Y)
+	}
+}
+
+func TestPositionAbove(t *testing.T) {
+	anchor := geometry.NewRect(100, 300, 200, 40)
+	overlaySize := geometry.Sz(200, 100)
+	windowSize := geometry.Sz(800, 600)
+
+	pos := overlay.Position(overlay.PlacementAbove, anchor, overlaySize, windowSize, 4)
+
+	if pos.X != 100 {
+		t.Errorf("X = %f, want 100", pos.X)
+	}
+	// anchor.Min.Y = 300, overlaySize.Height = 100, gap = 4 -> y = 196
+	if pos.Y != 196 {
+		t.Errorf("Y = %f, want 196", pos.Y)
+	}
+}
+
+func TestPositionRight(t *testing.T) {
+	anchor := geometry.NewRect(100, 100, 50, 40)
+	overlaySize := geometry.Sz(120, 80)
+	windowSize := geometry.Sz(800, 600)
+
+	pos := overlay.Position(overlay.PlacementRight, anchor, overlaySize, windowSize, 4)
+
+	// anchor.Max.X = 150, gap = 4 -> x = 154
+	if pos.X != 154 {
+		t.Errorf("X = %f, want 154", pos.X)
+	}
+	if pos.Y != 100 {
+		t.Errorf("Y = %f, want 100", pos.Y)
+	}
+}
+
+func TestPositionLeft(t *testing.T) {
+	anchor := geometry.NewRect(300, 100, 50, 40)
+	overlaySize := geometry.Sz(120, 80)
+	windowSize := geometry.Sz(800, 600)
+
+	pos := overlay.Position(overlay.PlacementLeft, anchor, overlaySize, windowSize, 4)
+
+	// anchor.Min.X = 300, overlaySize.Width = 120, gap = 4 -> x = 176
+	if pos.X != 176 {
+		t.Errorf("X = %f, want 176", pos.X)
+	}
+	if pos.Y != 100 {
+		t.Errorf("Y = %f, want 100", pos.Y)
+	}
+}
+
+func TestPositionFlipBelow(t *testing.T) {
+	// Anchor near the bottom, not enough room below -> flip above
+	anchor := geometry.NewRect(100, 500, 200, 40) // bottom at 540
+	overlaySize := geometry.Sz(200, 100)
+	windowSize := geometry.Sz(800, 600)
+
+	pos := overlay.Position(overlay.PlacementBelow, anchor, overlaySize, windowSize, 4)
+
+	// Should flip above: anchor.Min.Y = 500, overlaySize.Height = 100, gap = 4 -> y = 396
+	if pos.Y != 396 {
+		t.Errorf("Y = %f, want 396 (flipped above)", pos.Y)
+	}
+}
+
+func TestPositionFlipAbove(t *testing.T) {
+	// Anchor near the top, not enough room above -> flip below
+	anchor := geometry.NewRect(100, 20, 200, 40) // top at 20
+	overlaySize := geometry.Sz(200, 100)
+	windowSize := geometry.Sz(800, 600)
+
+	pos := overlay.Position(overlay.PlacementAbove, anchor, overlaySize, windowSize, 4)
+
+	// Cannot fit above (20 - 100 - 4 = -84), should flip below.
+	// anchor.Max.Y = 60, gap = 4 -> y = 64
+	if pos.Y != 64 {
+		t.Errorf("Y = %f, want 64 (flipped below)", pos.Y)
+	}
+}
+
+func TestPositionClampRight(t *testing.T) {
+	// Anchor near the right edge, overlay extends past window.
+	anchor := geometry.NewRect(700, 100, 80, 40)
+	overlaySize := geometry.Sz(200, 100)
+	windowSize := geometry.Sz(800, 600)
+
+	pos := overlay.Position(overlay.PlacementBelow, anchor, overlaySize, windowSize, 4)
+
+	// x = 700, but overlay would extend to 900 (> 800)
+	// Clamped: x = 800 - 200 = 600
+	if pos.X != 600 {
+		t.Errorf("X = %f, want 600 (clamped)", pos.X)
+	}
+}
+
+func TestPositionClampLeft(t *testing.T) {
+	// Anchor at left edge, placement Left would go negative.
+	anchor := geometry.NewRect(10, 100, 50, 40)
+	overlaySize := geometry.Sz(120, 80)
+	windowSize := geometry.Sz(800, 600)
+
+	pos := overlay.Position(overlay.PlacementLeft, anchor, overlaySize, windowSize, 4)
+
+	// anchor.Min.X = 10, overlaySize.Width = 120, gap = 4 -> x = -114
+	// Flip: anchor.Max.X = 60, gap = 4 -> x = 64
+	// Clamped: max(0, 64) = 64
+	if pos.X < 0 {
+		t.Errorf("X = %f, should be >= 0", pos.X)
+	}
+}
+
+func TestPositionClampBottom(t *testing.T) {
+	// Both flip and clamp needed.
+	anchor := geometry.NewRect(100, 550, 200, 40)
+	overlaySize := geometry.Sz(200, 200)
+	windowSize := geometry.Sz(800, 600)
+
+	pos := overlay.Position(overlay.PlacementBelow, anchor, overlaySize, windowSize, 4)
+
+	// Below: y = 594, extends to 794 (out of 600). Flip above: y = 550 - 200 - 4 = 346.
+	// 346 >= 0, so flip works.
+	// After clamp: y = max(0, min(400, 346)) = 346... but 346 + 200 = 546 <= 600, fine.
+	if pos.Y+overlaySize.Height > windowSize.Height {
+		t.Errorf("Y + height = %f, exceeds window height %f", pos.Y+overlaySize.Height, windowSize.Height)
+	}
+	if pos.Y < 0 {
+		t.Errorf("Y = %f, should be >= 0", pos.Y)
+	}
+}

--- a/primitives/themescope.go
+++ b/primitives/themescope.go
@@ -1,0 +1,195 @@
+package primitives
+
+import (
+	"time"
+
+	"github.com/gogpu/ui/event"
+	"github.com/gogpu/ui/geometry"
+	"github.com/gogpu/ui/widget"
+)
+
+// ThemeScopeWidget overrides the theme for a subtree of widgets.
+//
+// All descendants of a ThemeScopeWidget receive the scoped ThemeProvider
+// instead of the application-level theme. This enables use cases like a
+// dark dialog inside a light application, a branded section, or a
+// high-contrast widget region.
+//
+// ThemeScopeWidget is transparent to layout: it delegates sizing entirely
+// to its single child. If the scope has no child, it reports zero size.
+//
+// Nested ThemeScopeWidgets follow the "nearest wins" rule, matching the
+// Flutter InheritedWidget pattern. The priority chain is:
+//
+//	Widget override > Nearest ThemeScope > App theme > Default
+//
+// Create a ThemeScopeWidget with the [ThemeScope] constructor.
+//
+// Example:
+//
+//	darkTheme := material3.NewDark(widget.Hex(0x6750A4))
+//	scoped := primitives.ThemeScope(darkTheme,
+//	    primitives.Text("Dark text"),
+//	    primitives.Box(
+//	        primitives.Text("Also dark"),
+//	    ).Padding(8),
+//	)
+type ThemeScopeWidget struct {
+	widget.WidgetBase
+
+	theme widget.ThemeProvider
+	child widget.Widget
+}
+
+// ThemeScope creates a new ThemeScopeWidget that overrides the theme for
+// the given children.
+//
+// If multiple children are provided, they are wrapped in a Box container
+// for vertical layout. A single child is used directly. If no children
+// are provided, the scope has no child and reports zero size.
+//
+// The theme parameter must not be nil; passing nil causes ThemeScope to
+// behave as if no theme override is applied (the parent context theme
+// is used).
+func ThemeScope(theme widget.ThemeProvider, children ...widget.Widget) *ThemeScopeWidget {
+	ts := &ThemeScopeWidget{
+		theme: theme,
+	}
+	ts.SetVisible(true)
+	ts.SetEnabled(true)
+
+	switch len(children) {
+	case 0:
+		// No child.
+	case 1:
+		ts.child = children[0]
+	default:
+		ts.child = Box(children...)
+	}
+
+	return ts
+}
+
+// Theme returns the ThemeProvider set on this scope.
+func (ts *ThemeScopeWidget) Theme() widget.ThemeProvider {
+	return ts.theme
+}
+
+// SetTheme changes the scoped theme.
+func (ts *ThemeScopeWidget) SetTheme(theme widget.ThemeProvider) {
+	ts.theme = theme
+}
+
+// Layout delegates sizing to the child widget, passing a context with
+// the overridden theme.
+func (ts *ThemeScopeWidget) Layout(ctx widget.Context, constraints geometry.Constraints) geometry.Size {
+	scoped := ts.scopedContext(ctx)
+
+	if ts.child == nil {
+		size := constraints.Constrain(geometry.Sz(0, 0))
+		ts.SetBounds(geometry.FromPointSize(ts.Position(), size))
+		return size
+	}
+
+	size := ts.child.Layout(scoped, constraints)
+
+	// Position the child at origin (no offset).
+	ts.child.(interface{ SetBounds(geometry.Rect) }).SetBounds(
+		geometry.FromPointSize(geometry.Pt(0, 0), size),
+	)
+
+	ts.SetBounds(geometry.FromPointSize(ts.Position(), size))
+	return size
+}
+
+// Draw renders the child with the scoped theme context.
+func (ts *ThemeScopeWidget) Draw(ctx widget.Context, canvas widget.Canvas) {
+	if !ts.IsVisible() {
+		return
+	}
+
+	if ts.child == nil {
+		return
+	}
+
+	scoped := ts.scopedContext(ctx)
+	canvas.PushTransform(ts.Bounds().Min)
+	ts.child.Draw(scoped, canvas)
+	canvas.PopTransform()
+}
+
+// Event dispatches events to the child with the scoped theme context.
+func (ts *ThemeScopeWidget) Event(ctx widget.Context, e event.Event) bool {
+	if !ts.IsVisible() || !ts.IsEnabled() {
+		return false
+	}
+
+	if ts.child == nil {
+		return false
+	}
+
+	scoped := ts.scopedContext(ctx)
+
+	// Translate mouse events to local coordinates.
+	if me, ok := e.(*event.MouseEvent); ok {
+		local := *me
+		local.Position = me.Position.Sub(ts.Bounds().Min)
+		return ts.child.Event(scoped, &local)
+	}
+
+	return ts.child.Event(scoped, e)
+}
+
+// Children returns the child widget, or nil if none.
+func (ts *ThemeScopeWidget) Children() []widget.Widget {
+	if ts.child == nil {
+		return nil
+	}
+	return []widget.Widget{ts.child}
+}
+
+// scopedContext returns a context wrapper that overrides ThemeProvider.
+func (ts *ThemeScopeWidget) scopedContext(parent widget.Context) widget.Context {
+	if ts.theme == nil {
+		return parent
+	}
+	return &themeScopeContext{
+		parent: parent,
+		theme:  ts.theme,
+	}
+}
+
+// themeScopeContext wraps a parent Context and overrides ThemeProvider.
+//
+// All other methods delegate to the parent context unchanged.
+type themeScopeContext struct {
+	parent widget.Context
+	theme  widget.ThemeProvider
+}
+
+func (c *themeScopeContext) RequestFocus(w widget.Widget)       { c.parent.RequestFocus(w) }
+func (c *themeScopeContext) ReleaseFocus(w widget.Widget)       { c.parent.ReleaseFocus(w) }
+func (c *themeScopeContext) IsFocused(w widget.Widget) bool     { return c.parent.IsFocused(w) }
+func (c *themeScopeContext) FocusedWidget() widget.Widget       { return c.parent.FocusedWidget() }
+func (c *themeScopeContext) Now() time.Time                     { return c.parent.Now() }
+func (c *themeScopeContext) DeltaTime() time.Duration           { return c.parent.DeltaTime() }
+func (c *themeScopeContext) Invalidate()                        { c.parent.Invalidate() }
+func (c *themeScopeContext) InvalidateRect(r geometry.Rect)     { c.parent.InvalidateRect(r) }
+func (c *themeScopeContext) Cursor() widget.CursorType          { return c.parent.Cursor() }
+func (c *themeScopeContext) SetCursor(cursor widget.CursorType) { c.parent.SetCursor(cursor) }
+func (c *themeScopeContext) Scale() float32                     { return c.parent.Scale() }
+func (c *themeScopeContext) OverlayManager() widget.OverlayManager {
+	return c.parent.OverlayManager()
+}
+func (c *themeScopeContext) WindowSize() geometry.Size { return c.parent.WindowSize() }
+
+// ThemeProvider returns the overridden theme instead of the parent's theme.
+func (c *themeScopeContext) ThemeProvider() widget.ThemeProvider {
+	return c.theme
+}
+
+// Compile-time interface checks.
+var (
+	_ widget.Widget  = (*ThemeScopeWidget)(nil)
+	_ widget.Context = (*themeScopeContext)(nil)
+)

--- a/primitives/themescope_test.go
+++ b/primitives/themescope_test.go
@@ -1,0 +1,389 @@
+package primitives_test
+
+import (
+	"testing"
+
+	"github.com/gogpu/ui/event"
+	"github.com/gogpu/ui/geometry"
+	"github.com/gogpu/ui/primitives"
+	"github.com/gogpu/ui/widget"
+)
+
+// --- Construction ---
+
+func TestThemeScopeNoChildren(t *testing.T) {
+	ts := primitives.ThemeScope(&darkThemeMock{})
+	if ts.Children() != nil {
+		t.Errorf("expected nil children, got %d", len(ts.Children()))
+	}
+}
+
+func TestThemeScopeSingleChild(t *testing.T) {
+	child := primitives.Text("Hello")
+	ts := primitives.ThemeScope(&darkThemeMock{}, child)
+	children := ts.Children()
+	if len(children) != 1 {
+		t.Fatalf("expected 1 child, got %d", len(children))
+	}
+}
+
+func TestThemeScopeMultipleChildrenWrapsInBox(t *testing.T) {
+	c1 := primitives.Text("A")
+	c2 := primitives.Text("B")
+	ts := primitives.ThemeScope(&darkThemeMock{}, c1, c2)
+
+	children := ts.Children()
+	if len(children) != 1 {
+		t.Fatalf("expected 1 child (wrapped Box), got %d", len(children))
+	}
+
+	// The single child should be a Box that contains c1 and c2.
+	box := children[0]
+	boxChildren := box.Children()
+	if len(boxChildren) != 2 {
+		t.Errorf("expected wrapped Box to have 2 children, got %d", len(boxChildren))
+	}
+}
+
+func TestThemeScopeIsVisibleAndEnabled(t *testing.T) {
+	ts := primitives.ThemeScope(&darkThemeMock{})
+	if !ts.IsVisible() {
+		t.Error("ThemeScope should be visible by default")
+	}
+	if !ts.IsEnabled() {
+		t.Error("ThemeScope should be enabled by default")
+	}
+}
+
+func TestThemeScopeGetSetTheme(t *testing.T) {
+	dark := &darkThemeMock{}
+	light := &lightThemeMock{}
+
+	ts := primitives.ThemeScope(dark)
+	if ts.Theme() != dark {
+		t.Error("Theme() should return the initial theme")
+	}
+
+	ts.SetTheme(light)
+	if ts.Theme() != light {
+		t.Error("Theme() should return the updated theme after SetTheme")
+	}
+}
+
+// --- Theme Override ---
+
+func TestThemeScopeOverridesThemeInLayout(t *testing.T) {
+	dark := &darkThemeMock{}
+	recorder := &themeRecorderWidget{}
+
+	ts := primitives.ThemeScope(dark, recorder)
+	ctx := widget.NewContext()
+	ctx.SetThemeProvider(&lightThemeMock{})
+
+	_ = ts.Layout(ctx, geometry.Loose(geometry.Sz(300, 300)))
+
+	if recorder.lastTheme == nil {
+		t.Fatal("child did not receive a theme")
+	}
+	if !recorder.lastTheme.IsDark() {
+		t.Error("child should receive the dark scoped theme, not the app-level light theme")
+	}
+}
+
+func TestThemeScopeOverridesThemeInDraw(t *testing.T) {
+	dark := &darkThemeMock{}
+	recorder := &themeRecorderWidget{}
+
+	ts := primitives.ThemeScope(dark, recorder)
+	ctx := widget.NewContext()
+	ctx.SetThemeProvider(&lightThemeMock{})
+
+	_ = ts.Layout(ctx, geometry.Loose(geometry.Sz(300, 300)))
+	ts.Draw(ctx, &mockCanvas{})
+
+	if recorder.drawTheme == nil {
+		t.Fatal("child did not receive a theme during Draw")
+	}
+	if !recorder.drawTheme.IsDark() {
+		t.Error("child should receive the dark scoped theme during Draw")
+	}
+}
+
+func TestThemeScopeOverridesThemeInEvent(t *testing.T) {
+	dark := &darkThemeMock{}
+	recorder := &themeRecorderWidget{}
+
+	ts := primitives.ThemeScope(dark, recorder)
+	ctx := widget.NewContext()
+	ctx.SetThemeProvider(&lightThemeMock{})
+
+	_ = ts.Layout(ctx, geometry.Loose(geometry.Sz(300, 300)))
+	_ = ts.Event(ctx, &event.Base{})
+
+	if recorder.eventTheme == nil {
+		t.Fatal("child did not receive a theme during Event")
+	}
+	if !recorder.eventTheme.IsDark() {
+		t.Error("child should receive the dark scoped theme during Event")
+	}
+}
+
+func TestThemeScopeNilThemePassesParent(t *testing.T) {
+	recorder := &themeRecorderWidget{}
+	ts := primitives.ThemeScope(nil, recorder)
+
+	ctx := widget.NewContext()
+	light := &lightThemeMock{}
+	ctx.SetThemeProvider(light)
+
+	_ = ts.Layout(ctx, geometry.Loose(geometry.Sz(300, 300)))
+
+	if recorder.lastTheme == nil {
+		t.Fatal("child did not receive a theme")
+	}
+	if recorder.lastTheme.IsDark() {
+		t.Error("nil scope theme should pass through the parent context theme (light)")
+	}
+}
+
+// --- Nested Scopes (inner wins) ---
+
+func TestThemeScopeNestedInnerWins(t *testing.T) {
+	outerTheme := &darkThemeMock{}
+	innerTheme := &lightThemeMock{}
+	recorder := &themeRecorderWidget{}
+
+	inner := primitives.ThemeScope(innerTheme, recorder)
+	outer := primitives.ThemeScope(outerTheme, inner)
+
+	ctx := widget.NewContext()
+	_ = outer.Layout(ctx, geometry.Loose(geometry.Sz(300, 300)))
+
+	if recorder.lastTheme == nil {
+		t.Fatal("deepest child did not receive a theme")
+	}
+	if recorder.lastTheme.IsDark() {
+		t.Error("inner ThemeScope should override outer (inner is light, got dark)")
+	}
+}
+
+// --- Widgets Outside ThemeScope Use App Theme ---
+
+func TestThemeScopeWidgetsOutsideScopeUseAppTheme(t *testing.T) {
+	appTheme := &lightThemeMock{}
+	scopeTheme := &darkThemeMock{}
+
+	insideRecorder := &themeRecorderWidget{}
+	outsideRecorder := &themeRecorderWidget{}
+
+	scoped := primitives.ThemeScope(scopeTheme, insideRecorder)
+
+	ctx := widget.NewContext()
+	ctx.SetThemeProvider(appTheme)
+
+	// Layout the scoped widget.
+	_ = scoped.Layout(ctx, geometry.Loose(geometry.Sz(300, 300)))
+
+	// Layout the outside widget directly with the app context.
+	_ = outsideRecorder.Layout(ctx, geometry.Loose(geometry.Sz(300, 300)))
+
+	if !insideRecorder.lastTheme.IsDark() {
+		t.Error("widget inside ThemeScope should receive dark theme")
+	}
+	if outsideRecorder.lastTheme.IsDark() {
+		t.Error("widget outside ThemeScope should receive app-level light theme")
+	}
+}
+
+// --- Layout Delegation ---
+
+func TestThemeScopeLayoutDelegatesSize(t *testing.T) {
+	child := primitives.Box(primitives.Text("Hello")).Width(100).Height(50)
+	ts := primitives.ThemeScope(&darkThemeMock{}, child)
+
+	ctx := widget.NewContext()
+	size := ts.Layout(ctx, geometry.Loose(geometry.Sz(300, 300)))
+
+	if size.Width != 100 || size.Height != 50 {
+		t.Errorf("expected 100x50, got %s", size)
+	}
+}
+
+func TestThemeScopeLayoutNoChildZeroSize(t *testing.T) {
+	ts := primitives.ThemeScope(&darkThemeMock{})
+	ctx := widget.NewContext()
+	size := ts.Layout(ctx, geometry.Loose(geometry.Sz(300, 300)))
+
+	if size.Width != 0 || size.Height != 0 {
+		t.Errorf("expected 0x0 for no child, got %s", size)
+	}
+}
+
+// --- Draw ---
+
+func TestThemeScopeDrawNoPanicEmpty(t *testing.T) {
+	ts := primitives.ThemeScope(&darkThemeMock{})
+	ctx := widget.NewContext()
+	canvas := &mockCanvas{}
+	_ = ts.Layout(ctx, geometry.Loose(geometry.Sz(100, 100)))
+	ts.Draw(ctx, canvas) // Should not panic.
+}
+
+func TestThemeScopeDrawInvisibleSkips(t *testing.T) {
+	recorder := &themeRecorderWidget{}
+	ts := primitives.ThemeScope(&darkThemeMock{}, recorder)
+	ts.SetVisible(false)
+
+	ctx := widget.NewContext()
+	canvas := &mockCanvas{}
+	_ = ts.Layout(ctx, geometry.Loose(geometry.Sz(100, 100)))
+	ts.Draw(ctx, canvas)
+
+	if recorder.drawTheme != nil {
+		t.Error("invisible ThemeScope should not draw child")
+	}
+}
+
+func TestThemeScopeDrawUsesTransform(t *testing.T) {
+	child := primitives.Text("Hi")
+	ts := primitives.ThemeScope(&darkThemeMock{}, child)
+
+	ctx := widget.NewContext()
+	canvas := &mockCanvas{}
+	_ = ts.Layout(ctx, geometry.Loose(geometry.Sz(300, 300)))
+	ts.Draw(ctx, canvas)
+
+	if canvas.pushTransformCount == 0 || canvas.popTransformCount == 0 {
+		t.Error("expected PushTransform/PopTransform for child drawing")
+	}
+}
+
+// --- Event ---
+
+func TestThemeScopeEventDispatchesToChild(t *testing.T) {
+	consumed := false
+	child := &eventConsumer{consume: true, called: &consumed}
+	ts := primitives.ThemeScope(&darkThemeMock{}, child)
+
+	ctx := widget.NewContext()
+	_ = ts.Layout(ctx, geometry.Loose(geometry.Sz(100, 100)))
+
+	result := ts.Event(ctx, &event.Base{})
+	if !result || !consumed {
+		t.Error("event should be dispatched to and consumed by child")
+	}
+}
+
+func TestThemeScopeEventNoChildReturnsFalse(t *testing.T) {
+	ts := primitives.ThemeScope(&darkThemeMock{})
+	ctx := widget.NewContext()
+	if ts.Event(ctx, &event.Base{}) {
+		t.Error("ThemeScope with no child should not consume events")
+	}
+}
+
+func TestThemeScopeEventDisabledSkips(t *testing.T) {
+	consumed := false
+	child := &eventConsumer{consume: true, called: &consumed}
+	ts := primitives.ThemeScope(&darkThemeMock{}, child)
+	ts.SetEnabled(false)
+
+	ctx := widget.NewContext()
+	if ts.Event(ctx, &event.Base{}) {
+		t.Error("disabled ThemeScope should not consume events")
+	}
+	if consumed {
+		t.Error("children should not receive events when ThemeScope is disabled")
+	}
+}
+
+func TestThemeScopeEventInvisibleSkips(t *testing.T) {
+	consumed := false
+	child := &eventConsumer{consume: true, called: &consumed}
+	ts := primitives.ThemeScope(&darkThemeMock{}, child)
+	ts.SetVisible(false)
+
+	ctx := widget.NewContext()
+	if ts.Event(ctx, &event.Base{}) {
+		t.Error("invisible ThemeScope should not consume events")
+	}
+}
+
+// --- Context delegation ---
+
+func TestThemeScopeContextDelegatesFocus(t *testing.T) {
+	recorder := &themeRecorderWidget{}
+	ts := primitives.ThemeScope(&darkThemeMock{}, recorder)
+
+	ctx := widget.NewContext()
+	_ = ts.Layout(ctx, geometry.Loose(geometry.Sz(300, 300)))
+
+	// Request focus through the scoped context — should reach the real context.
+	if ctx.FocusedWidget() != nil {
+		t.Error("should start with no focused widget")
+	}
+
+	// The recorder's Layout calls RequestFocus if instructed.
+	// For this test, just verify the context chain works.
+	ctx.RequestFocus(recorder)
+	if !ctx.IsFocused(recorder) {
+		t.Error("focus should be set via parent context")
+	}
+}
+
+func TestThemeScopeContextDelegatesScale(t *testing.T) {
+	recorder := &themeRecorderWidget{}
+	ts := primitives.ThemeScope(&darkThemeMock{}, recorder)
+
+	ctx := widget.NewContext()
+	ctx.SetScale(2.0)
+	_ = ts.Layout(ctx, geometry.Loose(geometry.Sz(300, 300)))
+
+	if recorder.lastScale != 2.0 {
+		t.Errorf("expected scale 2.0, got %f", recorder.lastScale)
+	}
+}
+
+// --- Test helpers ---
+
+// darkThemeMock implements widget.ThemeProvider with IsDark() = true.
+type darkThemeMock struct{}
+
+func (d *darkThemeMock) IsDark() bool            { return true }
+func (d *darkThemeMock) OnSurface() widget.Color { return widget.ColorWhite }
+
+// lightThemeMock implements widget.ThemeProvider with IsDark() = false.
+type lightThemeMock struct{}
+
+func (l *lightThemeMock) IsDark() bool            { return false }
+func (l *lightThemeMock) OnSurface() widget.Color { return widget.ColorBlack }
+
+// themeRecorderWidget records the ThemeProvider it receives during
+// Layout, Draw, and Event calls.
+type themeRecorderWidget struct {
+	widget.WidgetBase
+
+	lastTheme  widget.ThemeProvider
+	drawTheme  widget.ThemeProvider
+	eventTheme widget.ThemeProvider
+	lastScale  float32
+}
+
+func (w *themeRecorderWidget) Layout(ctx widget.Context, c geometry.Constraints) geometry.Size {
+	w.lastTheme = ctx.ThemeProvider()
+	w.lastScale = ctx.Scale()
+	size := c.Constrain(geometry.Sz(10, 10))
+	w.SetBounds(geometry.FromPointSize(w.Position(), size))
+	return size
+}
+
+func (w *themeRecorderWidget) Draw(ctx widget.Context, _ widget.Canvas) {
+	w.drawTheme = ctx.ThemeProvider()
+}
+
+func (w *themeRecorderWidget) Event(ctx widget.Context, _ event.Event) bool {
+	w.eventTheme = ctx.ThemeProvider()
+	return false
+}
+
+func (w *themeRecorderWidget) Children() []widget.Widget { return nil }

--- a/theme/material3/dropdown.go
+++ b/theme/material3/dropdown.go
@@ -1,0 +1,259 @@
+package material3
+
+import (
+	"github.com/gogpu/ui/core/dropdown"
+	"github.com/gogpu/ui/geometry"
+	"github.com/gogpu/ui/widget"
+)
+
+// DropdownPainter renders dropdowns using Material 3 design tokens.
+// It implements the outlined dropdown variant with theme-derived colors.
+//
+// If Theme is nil, DropdownPainter falls back to the default M3 purple palette.
+type DropdownPainter struct {
+	Theme *Theme // nil uses default M3 purple fallback
+}
+
+// resolveColors returns the DropdownColorScheme derived from the painter's Theme.
+// If Theme is nil, it returns the default M3 dropdown color scheme.
+func (p DropdownPainter) resolveColors() dropdown.DropdownColorScheme {
+	if p.Theme == nil {
+		return m3DefaultDropdownColors
+	}
+	cs := p.Theme.Colors
+	return dropdown.DropdownColorScheme{
+		Background:      cs.Surface,
+		Border:          cs.Outline,
+		FocusBorder:     cs.Primary,
+		TextColor:       cs.OnSurface,
+		PlaceholderText: cs.OnSurfaceVariant,
+		DisabledBg:      cs.OnSurface.WithAlpha(0.04),
+		DisabledFg:      cs.OnSurface.WithAlpha(0.38),
+		MenuBg:          cs.Surface,
+		MenuBorder:      cs.OutlineVariant,
+		ItemHover:       cs.Primary.WithAlpha(0.08),
+		ItemSelected:    cs.Primary.WithAlpha(0.12),
+		ItemDisabled:    cs.OnSurface.WithAlpha(0.38),
+		ChevronColor:    cs.OnSurfaceVariant,
+		FocusRing:       cs.Primary.WithAlpha(0.7),
+	}
+}
+
+// PaintTrigger renders a dropdown trigger according to Material 3 specifications.
+func (p DropdownPainter) PaintTrigger(canvas widget.Canvas, st *dropdown.TriggerPaintState) {
+	if st.Bounds.IsEmpty() {
+		return
+	}
+
+	colors := st.ColorScheme
+	if colors == (dropdown.DropdownColorScheme{}) {
+		colors = p.resolveColors()
+	}
+
+	m3DDPaintTriggerBg(canvas, st, colors)
+	m3DDPaintTriggerBorder(canvas, st, colors)
+	m3DDPaintTriggerText(canvas, st, colors)
+	m3DDPaintTriggerChevron(canvas, st, colors)
+
+	if st.Focused && !st.Disabled {
+		m3DDDrawFocusIndicator(canvas, st.Bounds, colors)
+	}
+}
+
+// PaintMenu renders a dropdown menu according to Material 3 specifications.
+func (p DropdownPainter) PaintMenu(canvas widget.Canvas, st *dropdown.MenuPaintState) {
+	if st.Bounds.IsEmpty() {
+		return
+	}
+
+	colors := st.ColorScheme
+	if colors == (dropdown.DropdownColorScheme{}) {
+		colors = p.resolveColors()
+	}
+
+	// Menu background with elevation shadow (M3 surface tint).
+	canvas.DrawRoundRect(st.Bounds, colors.MenuBg, m3DDMenuRadius)
+	canvas.StrokeRoundRect(st.Bounds, colors.MenuBorder, m3DDMenuRadius, m3DDBorderWidth)
+
+	// Clip to menu bounds for items.
+	canvas.PushClip(st.Bounds)
+	defer canvas.PopClip()
+
+	// Draw visible items.
+	endIndex := st.ScrollOffset + st.VisibleCount
+	if endIndex > len(st.Items) {
+		endIndex = len(st.Items)
+	}
+
+	for i := st.ScrollOffset; i < endIndex; i++ {
+		item := st.Items[i]
+		row := i - st.ScrollOffset
+		itemRect := geometry.Rect{
+			Min: geometry.Pt(st.Bounds.Min.X, st.Bounds.Min.Y+float32(row)*st.ItemHeight),
+			Max: geometry.Pt(st.Bounds.Max.X, st.Bounds.Min.Y+float32(row+1)*st.ItemHeight),
+		}
+
+		m3DDPaintMenuItem(canvas, itemRect, item, i, st.HighlightedIndex, st.SelectedIndex, colors)
+	}
+}
+
+// m3DDPaintTriggerBg draws the trigger background.
+func m3DDPaintTriggerBg(canvas widget.Canvas, st *dropdown.TriggerPaintState, colors dropdown.DropdownColorScheme) {
+	bg := colors.Background
+	if st.Disabled {
+		bg = colors.DisabledBg
+	}
+	canvas.DrawRoundRect(st.Bounds, bg, m3DDTriggerRadius)
+}
+
+// m3DDPaintTriggerBorder draws the trigger outline.
+func m3DDPaintTriggerBorder(canvas widget.Canvas, st *dropdown.TriggerPaintState, colors dropdown.DropdownColorScheme) {
+	borderColor := colors.Border
+	strokeWidth := m3DDBorderWidth
+
+	switch {
+	case st.Disabled:
+		borderColor = colors.DisabledFg
+	case st.Focused:
+		borderColor = colors.FocusBorder
+		strokeWidth = m3DDFocusBorderWidth
+	case st.Hovered:
+		borderColor = colors.TextColor
+	}
+
+	canvas.StrokeRoundRect(st.Bounds, borderColor, m3DDTriggerRadius, strokeWidth)
+}
+
+// m3DDPaintTriggerText draws the selected text or placeholder.
+func m3DDPaintTriggerText(canvas widget.Canvas, st *dropdown.TriggerPaintState, colors dropdown.DropdownColorScheme) {
+	textColor := colors.TextColor
+	if st.IsPlaceholder {
+		textColor = colors.PlaceholderText
+	}
+	if st.Disabled {
+		textColor = colors.DisabledFg
+	}
+
+	textBounds := geometry.Rect{
+		Min: geometry.Pt(st.Bounds.Min.X+m3DDContentPaddingH, st.Bounds.Min.Y),
+		Max: geometry.Pt(st.Bounds.Max.X-m3DDChevronWidth-m3DDContentPaddingH, st.Bounds.Max.Y),
+	}
+	canvas.DrawText(st.SelectedText, textBounds, m3DDFontSize, textColor, false, m3DDTextAlignLeft)
+}
+
+// m3DDPaintTriggerChevron draws the chevron indicator.
+func m3DDPaintTriggerChevron(canvas widget.Canvas, st *dropdown.TriggerPaintState, colors dropdown.DropdownColorScheme) {
+	chevronColor := colors.ChevronColor
+	if st.Disabled {
+		chevronColor = colors.DisabledFg
+	}
+
+	chevronX := st.Bounds.Max.X - m3DDChevronWidth - m3DDContentPaddingH/2
+	chevronY := st.Bounds.Center().Y
+	m3DDDrawChevron(canvas, geometry.Pt(chevronX, chevronY), st.Open, chevronColor)
+}
+
+// m3DDDrawChevron draws an M3 up/down chevron indicator.
+func m3DDDrawChevron(canvas widget.Canvas, center geometry.Point, open bool, color widget.Color) {
+	size := m3DDChevronSize
+	if open {
+		// Up chevron.
+		canvas.DrawLine(
+			geometry.Pt(center.X-size, center.Y+size/2),
+			geometry.Pt(center.X, center.Y-size/2),
+			color, m3DDChevronStroke,
+		)
+		canvas.DrawLine(
+			geometry.Pt(center.X, center.Y-size/2),
+			geometry.Pt(center.X+size, center.Y+size/2),
+			color, m3DDChevronStroke,
+		)
+	} else {
+		// Down chevron.
+		canvas.DrawLine(
+			geometry.Pt(center.X-size, center.Y-size/2),
+			geometry.Pt(center.X, center.Y+size/2),
+			color, m3DDChevronStroke,
+		)
+		canvas.DrawLine(
+			geometry.Pt(center.X, center.Y+size/2),
+			geometry.Pt(center.X+size, center.Y-size/2),
+			color, m3DDChevronStroke,
+		)
+	}
+}
+
+// m3DDPaintMenuItem draws a single menu item.
+func m3DDPaintMenuItem(
+	canvas widget.Canvas,
+	itemRect geometry.Rect,
+	item dropdown.ItemDef,
+	index int,
+	highlightedIndex int,
+	selectedIndex int,
+	colors dropdown.DropdownColorScheme,
+) {
+	// Highlight or selection background.
+	switch index {
+	case highlightedIndex:
+		canvas.DrawRect(itemRect, colors.ItemHover)
+	case selectedIndex:
+		canvas.DrawRect(itemRect, colors.ItemSelected)
+	}
+
+	// Item text.
+	textColor := colors.TextColor
+	if item.Disabled {
+		textColor = colors.ItemDisabled
+	}
+
+	textRect := geometry.Rect{
+		Min: geometry.Pt(itemRect.Min.X+m3DDContentPaddingH, itemRect.Min.Y),
+		Max: geometry.Pt(itemRect.Max.X-m3DDContentPaddingH, itemRect.Max.Y),
+	}
+	canvas.DrawText(item.DisplayText(), textRect, m3DDFontSize, textColor, false, m3DDTextAlignLeft)
+}
+
+// m3DDDrawFocusIndicator draws a focus ring around the trigger.
+func m3DDDrawFocusIndicator(canvas widget.Canvas, bounds geometry.Rect, colors dropdown.DropdownColorScheme) {
+	ringBounds := bounds.Expand(m3DDFocusRingOffset)
+	ringRadius := m3DDTriggerRadius + m3DDFocusRingOffset
+	canvas.StrokeRoundRect(ringBounds, colors.FocusRing, ringRadius, m3DDFocusRingStroke)
+}
+
+// m3DefaultDropdownColors holds the default M3 dropdown color scheme.
+var m3DefaultDropdownColors = dropdown.DropdownColorScheme{
+	Background:      widget.ColorWhite,                   // M3 surface
+	Border:          widget.Hex(0x79747E),                // M3 outline
+	FocusBorder:     widget.Hex(0x6750A4),                // M3 primary
+	TextColor:       widget.Hex(0x1C1B1F),                // M3 on-surface
+	PlaceholderText: widget.Hex(0x49454F),                // M3 on-surface-variant
+	DisabledBg:      widget.RGBA(0.12, 0.12, 0.13, 0.04), // M3 disabled surface
+	DisabledFg:      widget.RGBA(0.12, 0.12, 0.13, 0.38), // M3 disabled fg
+	MenuBg:          widget.ColorWhite,                   // M3 surface
+	MenuBorder:      widget.Hex(0xCAC4D0),                // M3 outline-variant
+	ItemHover:       widget.RGBA(0.4, 0.31, 0.64, 0.08),  // M3 primary 8%
+	ItemSelected:    widget.RGBA(0.4, 0.31, 0.64, 0.12),  // M3 primary 12%
+	ItemDisabled:    widget.RGBA(0.12, 0.12, 0.13, 0.38), // M3 disabled fg
+	ChevronColor:    widget.Hex(0x49454F),                // M3 on-surface-variant
+	FocusRing:       widget.Hex(0x6750A4).WithAlpha(0.7), // M3 primary 70%
+}
+
+// M3 dropdown drawing constants.
+const (
+	m3DDTriggerRadius    float32 = 4
+	m3DDMenuRadius       float32 = 4
+	m3DDBorderWidth      float32 = 1
+	m3DDFocusBorderWidth float32 = 2
+	m3DDContentPaddingH  float32 = 16
+	m3DDFontSize         float32 = 16
+	m3DDTextAlignLeft    float32 = 0
+	m3DDChevronWidth     float32 = 24
+	m3DDChevronSize      float32 = 5
+	m3DDChevronStroke    float32 = 1.5
+	m3DDFocusRingOffset  float32 = 2
+	m3DDFocusRingStroke  float32 = 2
+)
+
+// Compile-time check that DropdownPainter implements Painter.
+var _ dropdown.Painter = DropdownPainter{}

--- a/widget/context.go
+++ b/widget/context.go
@@ -94,6 +94,32 @@ type Context interface {
 	// Returns nil if no theme is set (headless mode without a theme).
 	// Widgets should check for nil before using the returned provider.
 	ThemeProvider() ThemeProvider
+
+	// OverlayManager returns the overlay manager for pushing/removing overlays.
+	//
+	// Returns nil if no overlay manager is set (headless mode without a window).
+	// Widgets should check for nil before calling overlay methods.
+	OverlayManager() OverlayManager
+
+	// WindowSize returns the current window size in logical pixels.
+	WindowSize() geometry.Size
+}
+
+// OverlayManager provides methods for pushing and removing overlays from the
+// window's overlay stack. This interface lives in the widget package to avoid
+// circular imports: the overlay package imports widget, so widget cannot
+// import overlay. Instead, widgets call OverlayManager methods on the Context
+// without needing to know the concrete overlay.Stack type.
+type OverlayManager interface {
+	// PushOverlay pushes a widget as an overlay. The onDismiss callback is
+	// called when the overlay should be closed (e.g. click outside, Escape key).
+	PushOverlay(w Widget, onDismiss func())
+
+	// PopOverlay removes the topmost overlay from the stack.
+	PopOverlay()
+
+	// RemoveOverlay removes a specific overlay widget from the stack.
+	RemoveOverlay(w Widget)
 }
 
 // CursorType represents the type of mouse cursor to display.
@@ -209,6 +235,12 @@ type ContextImpl struct {
 
 	// Callback for invalidate rect (called when InvalidateRect is called)
 	onInvalidateRect func(geometry.Rect)
+
+	// Overlay manager
+	overlayManager OverlayManager
+
+	// Window size
+	windowSize geometry.Size
 }
 
 // NewContext creates a new ContextImpl with default settings.
@@ -434,6 +466,34 @@ func (c *ContextImpl) SetOnInvalidateRect(callback func(geometry.Rect)) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.onInvalidateRect = callback
+}
+
+// OverlayManager returns the overlay manager, or nil if none is set.
+func (c *ContextImpl) OverlayManager() OverlayManager {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.overlayManager
+}
+
+// SetOverlayManager sets the overlay manager for this context.
+func (c *ContextImpl) SetOverlayManager(om OverlayManager) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.overlayManager = om
+}
+
+// WindowSize returns the current window size in logical pixels.
+func (c *ContextImpl) WindowSize() geometry.Size {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.windowSize
+}
+
+// SetWindowSize sets the current window size.
+func (c *ContextImpl) SetWindowSize(size geometry.Size) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.windowSize = size
 }
 
 // Verify ContextImpl implements Context.


### PR DESCRIPTION
## Summary

- **Overlay infrastructure** (`overlay/` package) — window-level overlay stack for popups, dropdowns, tooltips, and modals. Stack with push/pop/remove, Container with dismiss-on-click-outside and Escape key, Position helper with viewport clamping and flip logic
- **Dropdown/Select widget** (`core/dropdown/`) — full-featured dropdown with trigger, floating menu overlay, keyboard navigation (Up/Down/Enter/Escape/Home/End), mouse hover highlight, mouse wheel scrolling, max visible items with clipping, signal two-way binding, accessibility (role=combobox)
- **ThemeScope widget** (`primitives/themescope.go`) — overrides theme for widget subtree with nested scoping (inner wins), nil passthrough, context wrapper pattern
- **M3 DropdownPainter** — outlined trigger with chevron indicator, menu with hover/selected highlights, theme-derived colors
- **Context extensions** — `OverlayManager` interface and `WindowSize()` method on `widget.Context`
- **Window integration** — overlay-first event dispatch, post-tree overlay rendering

## New packages

| Package | Lines | Tests |
|---------|-------|-------|
| `overlay/` | 451 | 30+ |
| `core/dropdown/` | 1,040 | 55 |
| `primitives/themescope.go` | 195 | 22 |
| **Total** | ~4,000 | 107 |

## Test plan

- [x] `go build ./...` — clean (26 packages)
- [x] `go test -count=1 ./...` — all 24 suites pass
- [x] `golangci-lint run --timeout=5m` — 0 issues
- [x] `go fmt ./...` — no changes needed
