### PR TITLE
chore: update gg v0.29.3

### DIFF
--- a/examples/hello/go.mod
+++ b/examples/hello/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 replace github.com/gogpu/ui => ../..
 
 require (
-	github.com/gogpu/gg v0.29.2
+	github.com/gogpu/gg v0.29.3
 	github.com/gogpu/gogpu v0.20.3
 	github.com/gogpu/ui v0.0.0-00010101000000-000000000000
 )

--- a/examples/hello/go.sum
+++ b/examples/hello/go.sum
@@ -8,8 +8,8 @@ github.com/go-webgpu/goffi v0.3.9 h1:dD1F7GZQV54ET6Fdcb+4776W1/OfbSb9DOJADVZEQLc
 github.com/go-webgpu/goffi v0.3.9/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
 github.com/go-webgpu/webgpu v0.3.1 h1:GxaJ3Cz2FGzHZ3adAYvuRFTdCMcwrENLbuilyIxSH0o=
 github.com/go-webgpu/webgpu v0.3.1/go.mod h1:lPa1+DhNDB3jb97/KI2ivW+ewK1V9x4k58fObvWBhR4=
-github.com/gogpu/gg v0.29.2 h1:2+j9tNN9duZCcLQb9EBq7CdeIFVKDWCIE2503rN9eBg=
-github.com/gogpu/gg v0.29.2/go.mod h1:mc7AMO5Aoz/lubmOlnf7EJO8uRA5H/hjZMW3Y9zVUKo=
+github.com/gogpu/gg v0.29.3 h1:i25wjxl6SnUOKkKs5K/69ulmIcLCPOx+rabaxWOCa6s=
+github.com/gogpu/gg v0.29.3/go.mod h1:saGMVwuWcqce1D7lnkeDYHEaZ8/7dVTXsh1X3qFqrfw=
 github.com/gogpu/gogpu v0.20.3 h1:7RRQEeDrkXKkqaBIMROBa65HHbTuh4vZ3wigDJ8FE44=
 github.com/gogpu/gogpu v0.20.3/go.mod h1:c11IvfQz18xu22VY6S5n89jNT27ocNfY0duCBmorE4w=
 github.com/gogpu/gpucontext v0.9.0 h1:RCM3oXtxR/i7YZrbH68zBjieE4j0TF731MrPnnD2Los=

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/coregx/signals v0.1.0
-	github.com/gogpu/gg v0.29.2
+	github.com/gogpu/gg v0.29.3
 	github.com/gogpu/gpucontext v0.9.0
 	golang.org/x/image v0.36.0
 )

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/go-text/typesetting v0.3.3 h1:ihGNJU9KzdK2QRDy1Bm7FT5RFQoYb+3n3EIhI/4
 github.com/go-text/typesetting v0.3.3/go.mod h1:vIRUT25mLQaSh4C8H/lIsKppQz/Gdb8Pu/tNwpi52ts=
 github.com/go-text/typesetting-utils v0.0.0-20250618110550-c820a94c77b8 h1:4KCscI9qYWMGTuz6BpJtbUSRzcBrUSSE0ENMJbNSrFs=
 github.com/go-text/typesetting-utils v0.0.0-20250618110550-c820a94c77b8/go.mod h1:3/62I4La/HBRX9TcTpBj4eipLiwzf+vhI+7whTc9V7o=
-github.com/gogpu/gg v0.29.2 h1:2+j9tNN9duZCcLQb9EBq7CdeIFVKDWCIE2503rN9eBg=
-github.com/gogpu/gg v0.29.2/go.mod h1:mc7AMO5Aoz/lubmOlnf7EJO8uRA5H/hjZMW3Y9zVUKo=
+github.com/gogpu/gg v0.29.3 h1:i25wjxl6SnUOKkKs5K/69ulmIcLCPOx+rabaxWOCa6s=
+github.com/gogpu/gg v0.29.3/go.mod h1:saGMVwuWcqce1D7lnkeDYHEaZ8/7dVTXsh1X3qFqrfw=
 github.com/gogpu/gpucontext v0.9.0 h1:RCM3oXtxR/i7YZrbH68zBjieE4j0TF731MrPnnD2Los=
 github.com/gogpu/gpucontext v0.9.0/go.mod h1:d+6V6OVk81cFRpsJcl+9Qnd8qCDLTQGelMVMEzjPTUg=
 github.com/gogpu/gputypes v0.2.0 h1:Quv3ekiU12zK4ZhBZsSZmalHYc+zj2gr9ZWRyzKgkKk=


### PR DESCRIPTION
- gg v0.29.2 → v0.29.3
- examples/hello: gg v0.29.2 → v0.29.3