### PR TITLE
chore: update gg v0.32.0 (smart rasterizer selection)

### DIFF
--- a/examples/hello/go.mod
+++ b/examples/hello/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 replace github.com/gogpu/ui => ../..
 
 require (
-	github.com/gogpu/gg v0.31.1
+	github.com/gogpu/gg v0.32.0
 	github.com/gogpu/gogpu v0.22.1
 	github.com/gogpu/ui v0.0.0-00010101000000-000000000000
 )

--- a/examples/hello/go.sum
+++ b/examples/hello/go.sum
@@ -8,8 +8,8 @@ github.com/go-webgpu/goffi v0.4.0 h1:KX/p9hd2n5uqTfDrsiQOU9dOPIsVl/RViY2foFq4r34
 github.com/go-webgpu/goffi v0.4.0/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
 github.com/go-webgpu/webgpu v0.4.0 h1:ydg61863nHMCvwP/FuAVlf5fwYJIKGhkIprmJJN8aGw=
 github.com/go-webgpu/webgpu v0.4.0/go.mod h1:eyFh3WTUYDDu2Xv+4F9k+wP6nNoe4rMe28sfIJ20OG4=
-github.com/gogpu/gg v0.31.1 h1:Bh0ZooeEBokAeX8y9O4KvLrgvC3mqDZu/wxWTKf5Vyk=
-github.com/gogpu/gg v0.31.1/go.mod h1:2VIFORCUsBjyxR2G3qJMuvMawyOCH17iwoZjytUEtIM=
+github.com/gogpu/gg v0.32.0 h1:B1TIVP1beA5iUVZGSAdVeG42T+D8b1qkMpqJp/gyWmY=
+github.com/gogpu/gg v0.32.0/go.mod h1:2VIFORCUsBjyxR2G3qJMuvMawyOCH17iwoZjytUEtIM=
 github.com/gogpu/gogpu v0.22.1 h1:6eT6NtOFft17MYWe8uGEvBD+XXbKwcaLlKwXGbPvT2Y=
 github.com/gogpu/gogpu v0.22.1/go.mod h1:lEcQcAHDrgSGot9ou2E/DGU349s++hnlesCBo9hOX/g=
 github.com/gogpu/gpucontext v0.9.0 h1:RCM3oXtxR/i7YZrbH68zBjieE4j0TF731MrPnnD2Los=

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/coregx/signals v0.1.0
-	github.com/gogpu/gg v0.31.1
+	github.com/gogpu/gg v0.32.0
 	github.com/gogpu/gpucontext v0.9.0
 	golang.org/x/image v0.36.0
 )

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/go-text/typesetting v0.3.3 h1:ihGNJU9KzdK2QRDy1Bm7FT5RFQoYb+3n3EIhI/4
 github.com/go-text/typesetting v0.3.3/go.mod h1:vIRUT25mLQaSh4C8H/lIsKppQz/Gdb8Pu/tNwpi52ts=
 github.com/go-text/typesetting-utils v0.0.0-20250618110550-c820a94c77b8 h1:4KCscI9qYWMGTuz6BpJtbUSRzcBrUSSE0ENMJbNSrFs=
 github.com/go-text/typesetting-utils v0.0.0-20250618110550-c820a94c77b8/go.mod h1:3/62I4La/HBRX9TcTpBj4eipLiwzf+vhI+7whTc9V7o=
-github.com/gogpu/gg v0.31.1 h1:Bh0ZooeEBokAeX8y9O4KvLrgvC3mqDZu/wxWTKf5Vyk=
-github.com/gogpu/gg v0.31.1/go.mod h1:2VIFORCUsBjyxR2G3qJMuvMawyOCH17iwoZjytUEtIM=
+github.com/gogpu/gg v0.32.0 h1:B1TIVP1beA5iUVZGSAdVeG42T+D8b1qkMpqJp/gyWmY=
+github.com/gogpu/gg v0.32.0/go.mod h1:2VIFORCUsBjyxR2G3qJMuvMawyOCH17iwoZjytUEtIM=
 github.com/gogpu/gpucontext v0.9.0 h1:RCM3oXtxR/i7YZrbH68zBjieE4j0TF731MrPnnD2Los=
 github.com/gogpu/gpucontext v0.9.0/go.mod h1:d+6V6OVk81cFRpsJcl+9Qnd8qCDLTQGelMVMEzjPTUg=
 github.com/gogpu/gputypes v0.2.0 h1:Quv3ekiU12zK4ZhBZsSZmalHYc+zj2gr9ZWRyzKgkKk=


### PR DESCRIPTION
## Summary
- Update gg dependency v0.31.1 → v0.32.0
- Includes smart multi-engine rasterizer selection (5 algorithms)
- Updated root go.mod and examples/hello/go.mod

## Test plan
- [x] Build passes locally
- [x] examples/hello runs correctly with new gg version