### PR TITLE
chore: update gg v0.35.1, gogpu v0.23.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed (Dependencies)
+- **gg** v0.34.0 → v0.35.1 (scene.TextRenderer GlyphCache integration)
+- **gogpu** v0.23.0 → v0.23.1 (macOS Retina CAMetalLayer fix) — examples only
+
 ### Added (Retained-Mode Rendering — TASK-UI-057 Sub-Phase 1)
 - **Draw tree traversal with statistics** — `widget.DrawTree()` draws the root widget
   and collects per-widget dirty/clean statistics via `widget.DrawStats`

--- a/examples/hello/go.mod
+++ b/examples/hello/go.mod
@@ -5,8 +5,8 @@ go 1.25.0
 replace github.com/gogpu/ui => ../..
 
 require (
-	github.com/gogpu/gg v0.34.0
-	github.com/gogpu/gogpu v0.23.0
+	github.com/gogpu/gg v0.35.1
+	github.com/gogpu/gogpu v0.23.1
 	github.com/gogpu/ui v0.0.0-00010101000000-000000000000
 )
 

--- a/examples/hello/go.sum
+++ b/examples/hello/go.sum
@@ -8,10 +8,10 @@ github.com/go-webgpu/goffi v0.4.2 h1:cwSiwro2ndP7jfXYlsz3kbOk8mNaFsHGZ0Q0cszC9cU
 github.com/go-webgpu/goffi v0.4.2/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
 github.com/go-webgpu/webgpu v0.4.2 h1:phQCeD5zY8jTgNjkrs090JYUMpqNPO7a9DMXvnHcQ2A=
 github.com/go-webgpu/webgpu v0.4.2/go.mod h1:+gz9PjcckFCZ/Gv1vJXXEDrf7fqo7VHH6uV0nJrSuRk=
-github.com/gogpu/gg v0.34.0 h1:jRgiG6h3aBBy6Lfw7C5oJxv5Fzp9kdFYqfzfFwbbT6A=
-github.com/gogpu/gg v0.34.0/go.mod h1:LSLwWMR36rt7F6jIGAnwIQgqo/b/rFVKvvfZUqQor78=
-github.com/gogpu/gogpu v0.23.0 h1:2gIovi+tRoeGm4gtfL0WUsQe077QLH3NRiUH6Odda/U=
-github.com/gogpu/gogpu v0.23.0/go.mod h1:cRElQjIvz0rGcUvYdn1dHhCs7voVQgKLevs64swNyW4=
+github.com/gogpu/gg v0.35.1 h1:WE9JC9YekYIkR5DScFcOR3UAFKZnmkwYlgg/n4Kbnck=
+github.com/gogpu/gg v0.35.1/go.mod h1:LSLwWMR36rt7F6jIGAnwIQgqo/b/rFVKvvfZUqQor78=
+github.com/gogpu/gogpu v0.23.1 h1:lVdU9/18a1Td3ej66ng3l10MAVuQdaDA50ATHEHfzJw=
+github.com/gogpu/gogpu v0.23.1/go.mod h1:cRElQjIvz0rGcUvYdn1dHhCs7voVQgKLevs64swNyW4=
 github.com/gogpu/gpucontext v0.9.0 h1:RCM3oXtxR/i7YZrbH68zBjieE4j0TF731MrPnnD2Los=
 github.com/gogpu/gpucontext v0.9.0/go.mod h1:d+6V6OVk81cFRpsJcl+9Qnd8qCDLTQGelMVMEzjPTUg=
 github.com/gogpu/gputypes v0.3.0 h1:gcwxsBrcoCX19GqqqiV55wLv2iFwaybiOluKCb0hVrs=

--- a/examples/signals/go.mod
+++ b/examples/signals/go.mod
@@ -5,8 +5,8 @@ go 1.25.0
 replace github.com/gogpu/ui => ../..
 
 require (
-	github.com/gogpu/gg v0.34.0
-	github.com/gogpu/gogpu v0.23.0
+	github.com/gogpu/gg v0.35.1
+	github.com/gogpu/gogpu v0.23.1
 	github.com/gogpu/ui v0.0.0-00010101000000-000000000000
 )
 

--- a/examples/signals/go.sum
+++ b/examples/signals/go.sum
@@ -8,10 +8,10 @@ github.com/go-webgpu/goffi v0.4.2 h1:cwSiwro2ndP7jfXYlsz3kbOk8mNaFsHGZ0Q0cszC9cU
 github.com/go-webgpu/goffi v0.4.2/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
 github.com/go-webgpu/webgpu v0.4.2 h1:phQCeD5zY8jTgNjkrs090JYUMpqNPO7a9DMXvnHcQ2A=
 github.com/go-webgpu/webgpu v0.4.2/go.mod h1:+gz9PjcckFCZ/Gv1vJXXEDrf7fqo7VHH6uV0nJrSuRk=
-github.com/gogpu/gg v0.34.0 h1:jRgiG6h3aBBy6Lfw7C5oJxv5Fzp9kdFYqfzfFwbbT6A=
-github.com/gogpu/gg v0.34.0/go.mod h1:LSLwWMR36rt7F6jIGAnwIQgqo/b/rFVKvvfZUqQor78=
-github.com/gogpu/gogpu v0.23.0 h1:2gIovi+tRoeGm4gtfL0WUsQe077QLH3NRiUH6Odda/U=
-github.com/gogpu/gogpu v0.23.0/go.mod h1:cRElQjIvz0rGcUvYdn1dHhCs7voVQgKLevs64swNyW4=
+github.com/gogpu/gg v0.35.1 h1:WE9JC9YekYIkR5DScFcOR3UAFKZnmkwYlgg/n4Kbnck=
+github.com/gogpu/gg v0.35.1/go.mod h1:LSLwWMR36rt7F6jIGAnwIQgqo/b/rFVKvvfZUqQor78=
+github.com/gogpu/gogpu v0.23.1 h1:lVdU9/18a1Td3ej66ng3l10MAVuQdaDA50ATHEHfzJw=
+github.com/gogpu/gogpu v0.23.1/go.mod h1:cRElQjIvz0rGcUvYdn1dHhCs7voVQgKLevs64swNyW4=
 github.com/gogpu/gpucontext v0.9.0 h1:RCM3oXtxR/i7YZrbH68zBjieE4j0TF731MrPnnD2Los=
 github.com/gogpu/gpucontext v0.9.0/go.mod h1:d+6V6OVk81cFRpsJcl+9Qnd8qCDLTQGelMVMEzjPTUg=
 github.com/gogpu/gputypes v0.3.0 h1:gcwxsBrcoCX19GqqqiV55wLv2iFwaybiOluKCb0hVrs=

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/coregx/signals v0.1.0
-	github.com/gogpu/gg v0.34.0
+	github.com/gogpu/gg v0.35.1
 	github.com/gogpu/gpucontext v0.9.0
 	golang.org/x/image v0.36.0
 )

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/go-text/typesetting v0.3.3 h1:ihGNJU9KzdK2QRDy1Bm7FT5RFQoYb+3n3EIhI/4
 github.com/go-text/typesetting v0.3.3/go.mod h1:vIRUT25mLQaSh4C8H/lIsKppQz/Gdb8Pu/tNwpi52ts=
 github.com/go-text/typesetting-utils v0.0.0-20250618110550-c820a94c77b8 h1:4KCscI9qYWMGTuz6BpJtbUSRzcBrUSSE0ENMJbNSrFs=
 github.com/go-text/typesetting-utils v0.0.0-20250618110550-c820a94c77b8/go.mod h1:3/62I4La/HBRX9TcTpBj4eipLiwzf+vhI+7whTc9V7o=
-github.com/gogpu/gg v0.34.0 h1:jRgiG6h3aBBy6Lfw7C5oJxv5Fzp9kdFYqfzfFwbbT6A=
-github.com/gogpu/gg v0.34.0/go.mod h1:LSLwWMR36rt7F6jIGAnwIQgqo/b/rFVKvvfZUqQor78=
+github.com/gogpu/gg v0.35.1 h1:WE9JC9YekYIkR5DScFcOR3UAFKZnmkwYlgg/n4Kbnck=
+github.com/gogpu/gg v0.35.1/go.mod h1:LSLwWMR36rt7F6jIGAnwIQgqo/b/rFVKvvfZUqQor78=
 github.com/gogpu/gpucontext v0.9.0 h1:RCM3oXtxR/i7YZrbH68zBjieE4j0TF731MrPnnD2Los=
 github.com/gogpu/gpucontext v0.9.0/go.mod h1:d+6V6OVk81cFRpsJcl+9Qnd8qCDLTQGelMVMEzjPTUg=
 github.com/gogpu/gputypes v0.3.0 h1:gcwxsBrcoCX19GqqqiV55wLv2iFwaybiOluKCb0hVrs=


### PR DESCRIPTION
## Summary

- **gg** v0.34.0 → v0.35.1: scene.TextRenderer GlyphCache integration
- **gogpu** v0.23.0 → v0.23.1: macOS Retina CAMetalLayer fix (examples only)

## Test plan
- [x] `go build ./...`
- [x] `go test ./... -count=1` — 25 packages pass
- [x] `golangci-lint run` — 0 issues