### PR TITLE
chore(deps): update gg v0.38.0 → v0.38.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.5] — 2026-03-23
+
+### Changed (Dependencies)
+- **gg** v0.38.0 → **v0.38.1** (SVG renderer fixes, first-frame rendering improvements)
+
 ## [0.1.4] — 2026-03-21
 
 ### Added

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/coregx/signals v0.1.0
-	github.com/gogpu/gg v0.38.0
+	github.com/gogpu/gg v0.38.1
 	github.com/gogpu/gogpu v0.25.0
 	github.com/gogpu/gpucontext v0.11.0
 	golang.org/x/image v0.37.0

--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,8 @@ github.com/go-webgpu/goffi v0.4.2 h1:cwSiwro2ndP7jfXYlsz3kbOk8mNaFsHGZ0Q0cszC9cU
 github.com/go-webgpu/goffi v0.4.2/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
 github.com/go-webgpu/webgpu v0.4.2 h1:phQCeD5zY8jTgNjkrs090JYUMpqNPO7a9DMXvnHcQ2A=
 github.com/go-webgpu/webgpu v0.4.2/go.mod h1:+gz9PjcckFCZ/Gv1vJXXEDrf7fqo7VHH6uV0nJrSuRk=
-github.com/gogpu/gg v0.38.0 h1:/3k6wL7W2lP2KpglQn3HwEla8o2+Ci/HsuhkbpCs+Uc=
-github.com/gogpu/gg v0.38.0/go.mod h1:9VyXwq9obVbqirgqA3tPa/w4qSCzpsX8WO1zIhI0lpA=
+github.com/gogpu/gg v0.38.1 h1:gyuckit81ztA0CKjXFhbnk39C7v9zATsZzxEVgCYZSM=
+github.com/gogpu/gg v0.38.1/go.mod h1:9VyXwq9obVbqirgqA3tPa/w4qSCzpsX8WO1zIhI0lpA=
 github.com/gogpu/gogpu v0.25.0 h1:T8njD9R4FpNb89eGjl0voFSybga36VAv0QVoUuu6iR4=
 github.com/gogpu/gogpu v0.25.0/go.mod h1:5HcgkODt1hNea1GsUmVGH/JtGgucr5tPC7FUV/KmwlU=
 github.com/gogpu/gpucontext v0.11.0 h1:dm+u3+Sl0Xgh7iZiRRUb36GDpSi8RpNk8n3NPmd5sGw=


### PR DESCRIPTION
## Summary

- **gg** v0.38.0 → **v0.38.1** (SVG renderer fixes, first-frame rendering improvements)

## Test plan

- [x] `go build ./...` — clean
- [x] `go test ./... -count=1` — all pass
- [ ] CI: Ubuntu, macOS, Windows