### PR TITLE
fix(docs): correct frame skip example in RENDER-PIPELINE.md

### DIFF
--- a/docs/RENDER-PIPELINE.md
+++ b/docs/RENDER-PIPELINE.md
@@ -24,7 +24,8 @@ User interaction (click, hover, signal change)
 Before doing any work, the render loop checks:
 
 ```go
-if !w.HasDirtyBoundaries() && !w.NeedsRedraw() && !w.NeedsAnimationFrame() {
+needsAnyWork := rl.fullRedrawNeeded || win.NeedsRedraw() || win.HasDirtyBoundaries() || win.NeedsAnimationFrame()
+if !needsAnyWork {
     return  // nothing changed — 0% GPU
 }
 ```


### PR DESCRIPTION
Add missing fullRedrawNeeded condition to frame skip code example. Matches actual code at desktop/desktop.go:191-194.