### PR TITLE
chore(deps): update gg v0.47.1, gogpu v0.36.0 (v0.1.28)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.28] — 2026-05-16
+
+### Dependencies
+
+- gg v0.47.0 → v0.47.1 (text batch coalescing perf + HiDPI warning — ADR-031, gg#322, gg#324)
+- gogpu v0.35.0 → v0.36.0 (unified XKB text input, AltGr/Level3 international layouts — gogpu#233, ADR-029)
+
 ## [0.1.27] — 2026-05-16
 
 ### Dependencies

--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,8 @@ go 1.25.0
 
 require (
 	github.com/coregx/signals v0.1.0
-	github.com/gogpu/gg v0.47.0
-	github.com/gogpu/gogpu v0.35.0
+	github.com/gogpu/gg v0.47.1
+	github.com/gogpu/gogpu v0.36.0
 	github.com/gogpu/gpucontext v0.18.0
 	github.com/gogpu/gputypes v0.5.0
 	github.com/gogpu/wgpu v0.28.1

--- a/go.sum
+++ b/go.sum
@@ -8,10 +8,10 @@ github.com/go-webgpu/goffi v0.5.1 h1:RSPR+YKT0tmbp5Uon+xwhN1veC9cehmqMptMkQuopok
 github.com/go-webgpu/goffi v0.5.1/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
 github.com/go-webgpu/webgpu v0.4.3 h1:dIBf7WgO/7VL2Cj7IFcq151rWqvSknsFe6k/+ZEEXEE=
 github.com/go-webgpu/webgpu v0.4.3/go.mod h1:HNIBiaMJNdPeQd6hmHdQsXg4t4R99xVQybnoDGOShe0=
-github.com/gogpu/gg v0.47.0 h1:bh08GbBvTSeKlSTNorn+d55aMSgZQyrf49iT3hHzP0w=
-github.com/gogpu/gg v0.47.0/go.mod h1:GhTdx4C5FC7l2aEKvSryO0GVh5EYs5KHEQrEXulkLB4=
-github.com/gogpu/gogpu v0.35.0 h1:8EUZLWu+JLt8UlnQkYk2JAWudHLf30ufwqRNXREJDTA=
-github.com/gogpu/gogpu v0.35.0/go.mod h1:Y7o4T464KMcuQWqhy8A5YKqUrx1Jlmkavu44073EVvk=
+github.com/gogpu/gg v0.47.1 h1:V+wx0jBAIk2Os/IpMWKRs7UAVPC0c/NzKsmkmu9kPjY=
+github.com/gogpu/gg v0.47.1/go.mod h1:GhTdx4C5FC7l2aEKvSryO0GVh5EYs5KHEQrEXulkLB4=
+github.com/gogpu/gogpu v0.36.0 h1:5OY92a58qYLftxD6QSRIwIiRKlfta1aupakUOc0TNnI=
+github.com/gogpu/gogpu v0.36.0/go.mod h1:Y7o4T464KMcuQWqhy8A5YKqUrx1Jlmkavu44073EVvk=
 github.com/gogpu/gpucontext v0.18.0 h1:Y48ScE0cNPevoqZEhT8CxWGh9C86TeCjtLu5eFU+Grw=
 github.com/gogpu/gpucontext v0.18.0/go.mod h1:6zwdmYXH5GQltoiHbb3WXVS/UJ5bFsCux0mXCVqGlzY=
 github.com/gogpu/gputypes v0.5.0 h1:i2ED/9w6m6yLxf8XJT69/NIMSNTLO2y5F1LqvugCKIE=


### PR DESCRIPTION
## Summary

- gg v0.47.0 → v0.47.1 (text batch coalescing perf + HiDPI warning — ADR-031, gg#322, gg#324)
- gogpu v0.35.0 → v0.36.0 (unified XKB text input, AltGr/Level3 international layouts — gogpu#233, ADR-029)

## Test plan

- [x] `go build ./...` — PASS
- [x] `go test ./... -count=1` — 56 packages, 0 FAIL
- [x] `golangci-lint run --timeout=5m` — 0 issues
- [ ] CI green (Ubuntu/macOS/Windows)