### PR TITLE
fix(desktop): allocate per-boundary GPU textures in physical pixels (HiDPI 2x content)

### DIFF
--- a/desktop/desktop.go
+++ b/desktop/desktop.go
@@ -614,15 +614,34 @@ func isBoundaryLayerVisible(pic *compositor.PictureLayerImpl, bw, bh int) bool {
 	return screenRect.Intersects(clip)
 }
 
+// scaleToPhysical converts logical pixel dimensions to physical pixels for the
+// given device scale, rounding to the nearest pixel. A scale <= 0 is treated as
+// 1.0 (headless / non-HiDPI).
+func scaleToPhysical(w, h int, scale float64) (int, int) {
+	if scale <= 0 {
+		scale = 1.0
+	}
+	return int(float64(w)*scale + 0.5), int(float64(h)*scale + 0.5)
+}
+
 // ensureBoundaryTexture allocates or resizes the offscreen texture for a boundary.
+//
+// HiDPI: bw/bh are LOGICAL widget bounds, but an offscreen texture is a GPU
+// surface that must be allocated in PHYSICAL pixels. The gg context renders at
+// DeviceScale, so a logical-sized texture clips the scene to its top-left
+// fraction and then gets upscaled at composite time — the "content rendered at
+// 2x" symptom on HiDPI/Retina displays (#129). Size to physical = logical *
+// DeviceScale; the composite step still positions in logical space (the gg
+// context applies the scale), so only allocation and flush need physical extents.
 func (rl *renderLoop) ensureBoundaryTexture(key uint64, bw, bh int, cc *gg.Context) *boundaryTexEntry {
+	pw, ph := scaleToPhysical(bw, bh, cc.DeviceScale())
 	entry := rl.boundaryTextures[key]
-	if entry == nil || entry.width != bw || entry.height != bh {
+	if entry == nil || entry.width != pw || entry.height != ph {
 		if entry != nil && entry.release != nil {
 			entry.release()
 		}
-		tex, release := cc.CreateOffscreenTexture(bw, bh)
-		entry = &boundaryTexEntry{texture: tex, release: release, width: bw, height: bh}
+		tex, release := cc.CreateOffscreenTexture(pw, ph)
+		entry = &boundaryTexEntry{texture: tex, release: release, width: pw, height: ph}
 		rl.boundaryTextures[key] = entry
 		rl.fullRedrawNeeded = true
 	}
@@ -649,7 +668,11 @@ func (rl *renderLoop) flushBoundaryToTexture(pic *compositor.PictureLayerImpl, e
 
 	renderer := scene.NewGPUSceneRenderer(cc)
 	_ = renderer.RenderScene(cachedScene)
-	w, h := uint32(max(bw, 0)), uint32(max(bh, 0)) //nolint:gosec // bw/bh checked > 0 above
+	// The flush viewport must match the PHYSICAL texture extent (logical *
+	// DeviceScale), else the scene — rendered at DeviceScale — is clipped to the
+	// logical-sized region and upscaled on composite (#129). See ensureBoundaryTexture.
+	pw, ph := scaleToPhysical(bw, bh, cc.DeviceScale())
+	w, h := uint32(max(pw, 0)), uint32(max(ph, 0)) //nolint:gosec // pw/ph derived from bw/bh checked > 0 above
 	if err := cc.FlushGPUWithView(entry.texture, w, h); err != nil {
 		log.Printf("desktop: FlushGPUWithView boundary %d: %v", pic.BoundaryCacheKey(), err)
 	}

--- a/desktop/hidpi_texture_test.go
+++ b/desktop/hidpi_texture_test.go
@@ -1,0 +1,32 @@
+package desktop
+
+import "testing"
+
+// TestScaleToPhysical pins the logical→physical conversion used to size
+// per-boundary offscreen textures. Allocating these textures in logical pixels
+// while the gg context renders at DeviceScale clips the scene and upscales it on
+// composite — the "content rendered at 2x" symptom on HiDPI/Retina (#129).
+func TestScaleToPhysical(t *testing.T) {
+	tests := []struct {
+		name         string
+		w, h         int
+		scale        float64
+		wantW, wantH int
+	}{
+		{"1x is identity", 1100, 879, 1.0, 1100, 879},
+		{"2x retina doubles", 1100, 879, 2.0, 2200, 1758},
+		{"1.5x rounds to nearest", 100, 100, 1.5, 150, 150},
+		{"fractional rounds up at .5", 3, 3, 1.5, 5, 5},
+		{"zero scale treated as 1x", 640, 480, 0, 640, 480},
+		{"negative scale treated as 1x", 640, 480, -2, 640, 480},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotW, gotH := scaleToPhysical(tt.w, tt.h, tt.scale)
+			if gotW != tt.wantW || gotH != tt.wantH {
+				t.Errorf("scaleToPhysical(%d, %d, %v) = (%d, %d), want (%d, %d)",
+					tt.w, tt.h, tt.scale, gotW, gotH, tt.wantW, tt.wantH)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

On HiDPI / Retina displays the entire UI renders at **2× the correct size** (only the top-left quarter of content is visible, scaled up). This fixes it by allocating per-boundary offscreen GPU textures in **physical** pixels instead of logical.

This is the rendering half of the HiDPI story exposed after gogpu/gogpu v0.41.14 corrected `ScaleFactor()` (the window frame is now correct, but `desktop` mis-sized its boundary textures).

## Root cause

`desktop/desktop.go` builds one offscreen GPU texture per `RepaintBoundary`:

- `ensureBoundaryTexture` → `cc.CreateOffscreenTexture(bw, bh)`
- `flushBoundaryToTexture` → `cc.FlushGPUWithView(tex, bw, bh)`

…where `bw, bh = pic.Size()` are **logical** widget bounds. But the `gg.Context` (`cc`) renders at `DeviceScale` (2.0 on a 2× display), and `CreateOffscreenTexture` / `FlushGPUWithView` take **physical** pixel extents. So on a 2× display the texture is allocated at half the required size: the scene is rasterized at 2× into a 1× viewport (clipped to the top-left), then the undersized texture is stretched back up to the boundary's logical rect at composite time → content appears doubled.

At `scale == 1.0` logical == physical, which is why this was latent until `ScaleFactor()` started returning the true 2.0.

## Reproduction

Run any `desktop.Run` app on a display scaled > 100% (Windows 200%, macOS Retina). Everything is ~2× oversized; clicks appear offset because the visible position no longer matches the logical hit-box.

## Fix

Size the texture allocation and the flush viewport to physical pixels = `logical * DeviceScale` (new `scaleToPhysical` helper). Compositing is unchanged — it still positions boundaries in logical space, because the `gg.Context` already applies the device scale to the destination rect; only allocation and the flush viewport need physical extents.

## Verification

Windows 11 @ 200% (gogpu v0.41.14, gg v0.48.9), via gg's `INFO` logging:

| | before | after |
|---|---|---|
| `created surface textures` (root boundary) | `1100x879` (logical) | `2200x1758` (physical) |

Confirmed by screen capture: before, only the title + one line filled the whole window; after, the full sheet renders at correct size and clicking a button triggers its handler at the expected location (hit-testing aligns once the render is correct).

Pointer coordinates were already correct — `gogpu` delivers logical coords (`createPointerEvent` divides by `scaleFactor`) and layout is logical — so no event-path change is needed.

## Tests

Added `TestScaleToPhysical` (pure, no GPU) covering 1×, 2×, fractional rounding, and the `scale <= 0 → 1.0` guard. `go test ./desktop/`, `go vet`, and `gofmt` pass.

## Notes / scope

- Platform-agnostic; this likely resolves the Retina 2× report in #129.
- This PR only covers the main boundary texture path. While verifying, I noticed modal **overlay** content (e.g. a Dialog) can still mis-position its nested boundary at HiDPI (content drawn near the window origin while the card draws empty). That looks like a separate issue in the overlay-content boundary's scene→texture origin handling; happy to open a follow-up issue with a repro if useful.