### PR TITLE
chore(deps): gg v0.48.11, thin stroke GPU fix (v0.1.32)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.32] — 2026-06-16
+
+### Dependencies
+
+- gg v0.48.10 → v0.48.11 (fix #369 @TimLai666: thin strokes solid fill on GPU compute)
+
 ## [0.1.31] — 2026-06-15
 
 ### Dependencies

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -337,7 +337,7 @@ All releases must follow this cascade. Breaking changes in lower layers require 
 
 | Dependency | Version | Purpose |
 |------------|---------|---------|
-| gogpu/gg | v0.48.10 | 2D rendering + scene.Scene |
+| gogpu/gg | v0.48.11 | 2D rendering + scene.Scene |
 | gogpu/gogpu | v0.42.0 | Windowing, input (examples) |
 | gogpu/gpucontext | v0.21.0 | Shared interfaces (opaque struct tokens) |
 | coregx/signals | v0.1.0 | Reactive state management |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1441,7 +1441,7 @@ The `registry/` package provides a global registry for widget factories:
 
 | Dependency | Purpose | Version |
 |------------|---------|---------|
-| `github.com/gogpu/gg` | 2D graphics + scene.Scene tile-parallel rendering | v0.48.10 |
+| `github.com/gogpu/gg` | 2D graphics + scene.Scene tile-parallel rendering | v0.48.11 |
 | `github.com/gogpu/gpucontext` | Shared GPU interfaces (opaque struct tokens) | v0.21.0 |
 | `github.com/gogpu/gogpu` | Application framework, windowing, Browser/WASM (examples only) | v0.42.0 |
 | `github.com/coregx/signals` | Reactive state management | v0.1.0 |

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/coregx/signals v0.1.0
-	github.com/gogpu/gg v0.48.10
+	github.com/gogpu/gg v0.48.11
 	github.com/gogpu/gogpu v0.42.0
 	github.com/gogpu/gpucontext v0.21.0
 	github.com/gogpu/gputypes v0.5.0

--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,8 @@ github.com/go-webgpu/goffi v0.5.3 h1:Ckc94SdHO42bIb0oEapRIcv+jKjhjGJfb9zPEvNKC7U
 github.com/go-webgpu/goffi v0.5.3/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
 github.com/go-webgpu/webgpu v0.5.2 h1:E+yKCbRw/Dgn77pb/CX3kXatwwROGX7/B4ZFbRPaRbQ=
 github.com/go-webgpu/webgpu v0.5.2/go.mod h1:d2RR3tI2kUtcMfpC+qJt46IRkDslRhftjCfQvnprGkY=
-github.com/gogpu/gg v0.48.10 h1:zkRTdf/QLdY405uRj+WNbTV7aQq7G14t1ZtmnWRhFfw=
-github.com/gogpu/gg v0.48.10/go.mod h1:WTL0lwwKNBeUf3xNeloJyRQJeRE1TFnIkKPfwROcIDQ=
+github.com/gogpu/gg v0.48.11 h1:wkCc/DMDQDyy7ty/afEeoJ/8hOpSqyTfJJvAqAe+l58=
+github.com/gogpu/gg v0.48.11/go.mod h1:WTL0lwwKNBeUf3xNeloJyRQJeRE1TFnIkKPfwROcIDQ=
 github.com/gogpu/gogpu v0.42.0 h1:sTk+ZSmRpWzy7+4wJAo8CkQdYP0aEJ2Sn9uChZjuX6Q=
 github.com/gogpu/gogpu v0.42.0/go.mod h1:1r0Nj+PtCyKTAPhJF2ONJON/MNuY7czQer6Nij6CIOo=
 github.com/gogpu/gpucontext v0.21.0 h1:O1SnXBiednIyVP4Zx5SASh0svYiG6g/wF1igNZVo1Pc=


### PR DESCRIPTION
## Summary

- gg v0.48.10 → v0.48.11 (fix gg#369 @TimLai666: thin strokes solid fill on GPU compute, PR gg#372)
- CHANGELOG.md, ROADMAP.md, ARCHITECTURE.md updated

## Test plan

- [x] `go build ./...` — PASS
- [x] `go test ./... -count=1` — 56 packages, 0 FAIL
- [x] `golangci-lint run --timeout=5m` — 0 issues