### PR TITLE
fix(examples): hello ListView white background for macOS P3 (v0.1.34)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.34] — 2026-06-16
+
+### Fixed
+
+- **Hello example gray ListView items on macOS Retina** — ListView container background was `#FAFAFA` (250,250,250), visually gray on P3 Retina displays. Changed to `#FFFFFF` (255,255,255) to match card background. Invisible on Windows sRGB, noticeable on macOS P3.
+
 ## [0.1.33] — 2026-06-16
 
 ### Fixed

--- a/examples/hello/main.go
+++ b/examples/hello/main.go
@@ -124,7 +124,7 @@ func buildUI(m3 *material3.Theme) *primitives.BoxWidget {
 		primitives.Box(buildListView(m3)).
 			Height(300).
 			Rounded(8).
-			Background(widget.RGBA8(250, 250, 250, 255)).
+			Background(widget.RGBA8(255, 255, 255, 255)).
 			BorderStyle(1, widget.RGBA8(218, 218, 218, 255)),
 	).
 		Padding(32).


### PR DESCRIPTION
## Summary

ListView container background was `#FAFAFA` (250,250,250) — visually gray on macOS Retina P3 displays. Changed to `#FFFFFF` to match card background.

Invisible on Windows sRGB, noticeable on macOS P3 color profile.

## Test plan

- [x] `go build ./...` — PASS
- [x] `go test ./... -count=1` — 56 packages, 0 FAIL
- [x] `golangci-lint run --timeout=5m` — 0 issues
- [x] Visual check on Windows Vulkan — white ListView items