### PR TITLE
feat(badge): add notification badge widget (count + dot)

### DIFF
--- a/core/badge/badge.go
+++ b/core/badge/badge.go
@@ -1,0 +1,247 @@
+package badge
+
+import (
+	"strconv"
+
+	"github.com/gogpu/ui/event"
+	"github.com/gogpu/ui/geometry"
+	"github.com/gogpu/ui/state"
+	"github.com/gogpu/ui/widget"
+)
+
+// Widget implements a small notification badge displaying a count or a dot.
+//
+// A badge is created with [New] using functional options:
+//
+//	b := badge.New(
+//	    badge.Count(5),
+//	    badge.Max(99),
+//	)
+//
+// Fluent styling methods may be chained after construction:
+//
+//	b.Padding(2)
+type Widget struct {
+	widget.WidgetBase
+	cfg     config
+	painter Painter
+
+	// Styling overrides set via fluent methods.
+	padding float32
+
+	// lastDrawnCount caches the count from the most recent Draw call.
+	// Signal bindings compare against this to suppress redundant redraws
+	// when the signal fires with an unchanged value.
+	lastDrawnCount    int
+	lastDrawnCountSet bool
+}
+
+// New creates a new badge Widget with the given options.
+//
+// The returned widget is visible and enabled by default. It is not focusable
+// because badges are display-only widgets.
+func New(opts ...Option) *Widget {
+	w := &Widget{
+		painter: DefaultPainter{},
+	}
+	w.SetVisible(true)
+	w.SetEnabled(true)
+
+	for _, opt := range opts {
+		opt(&w.cfg)
+	}
+
+	// Apply painter from config if set.
+	if w.cfg.painter != nil {
+		w.painter = w.cfg.painter
+	}
+
+	return w
+}
+
+// Default sizing values.
+const (
+	defaultBadgeHeight float32 = 16
+	defaultDotDiameter float32 = 8
+	defaultFontSize    float32 = 10
+	// labelPaddingX is the inner horizontal padding on each side of the
+	// count label within the pill.
+	labelPaddingX float32 = 5
+	// charWidthRatio approximates digit width as a fraction of the font size
+	// for layout estimation (digits are slightly wider than this average).
+	charWidthRatio float32 = 0.6
+)
+
+// SetCount updates the badge's static count. Negative values are treated as
+// zero. The widget is marked for redraw when the value changes.
+func (w *Widget) SetCount(n int) {
+	if n < 0 {
+		n = 0
+	}
+	if w.cfg.count != n {
+		w.cfg.count = n
+		w.SetNeedsRedraw(true)
+	}
+}
+
+// Count returns the current resolved count (always non-negative).
+func (w *Widget) Count() int {
+	return w.cfg.ResolvedCount()
+}
+
+// IsHidden reports whether the badge currently renders nothing.
+// A count badge is hidden when its count is non-positive and [ShowZero] is
+// not set. Dot badges are never hidden.
+func (w *Widget) IsHidden() bool {
+	if w.cfg.dot {
+		return false
+	}
+	return w.cfg.ResolvedCount() <= 0 && !w.cfg.showZero
+}
+
+// label returns the formatted count label for the current count, or the empty
+// string in dot mode.
+func (w *Widget) label() string {
+	if w.cfg.dot {
+		return ""
+	}
+	return formatCount(w.cfg.ResolvedCount(), w.cfg.ResolvedMax())
+}
+
+// formatCount formats count, rendering values greater than limit as "limit+".
+func formatCount(count, limit int) string {
+	if count > limit {
+		return strconv.Itoa(limit) + "+"
+	}
+	return strconv.Itoa(count)
+}
+
+// Layout calculates the badge's preferred size within the given constraints.
+func (w *Widget) Layout(_ widget.Context, constraints geometry.Constraints) geometry.Size {
+	if w.IsHidden() {
+		return constraints.Constrain(geometry.Sz(0, 0))
+	}
+
+	var contentW, contentH float32
+	if w.cfg.dot {
+		contentW = defaultDotDiameter
+		contentH = defaultDotDiameter
+	} else {
+		contentH = defaultBadgeHeight
+		text := w.label()
+		textWidth := float32(len(text)) * defaultFontSize * charWidthRatio
+		contentW = textWidth + labelPaddingX*2
+		// Keep a single digit circular by enforcing a minimum width.
+		if contentW < contentH {
+			contentW = contentH
+		}
+	}
+
+	preferred := geometry.Sz(
+		contentW+w.padding*2,
+		contentH+w.padding*2,
+	)
+	return constraints.Constrain(preferred)
+}
+
+// Draw renders the badge to the canvas.
+func (w *Widget) Draw(_ widget.Context, canvas widget.Canvas) {
+	count := w.cfg.ResolvedCount()
+	w.lastDrawnCount = count
+	w.lastDrawnCountSet = true
+
+	if w.IsHidden() {
+		return
+	}
+
+	bounds := w.contentBounds()
+
+	w.painter.PaintBadge(canvas, PaintState{
+		Bounds:      bounds,
+		Dot:         w.cfg.dot,
+		Label:       w.label(),
+		Disabled:    w.cfg.ResolvedDisabled(),
+		ColorScheme: w.cfg.colorScheme,
+	})
+}
+
+// contentBounds returns the badge bounds inset by the outer padding.
+func (w *Widget) contentBounds() geometry.Rect {
+	b := w.Bounds()
+	if w.padding == 0 {
+		return b
+	}
+	return geometry.NewRect(
+		b.Min.X+w.padding,
+		b.Min.Y+w.padding,
+		b.Width()-w.padding*2,
+		b.Height()-w.padding*2,
+	)
+}
+
+// Event handles an input event. Badges are display-only and always return
+// false (events are never consumed).
+func (w *Widget) Event(_ widget.Context, _ event.Event) bool {
+	return false
+}
+
+// Children returns nil because a badge is a leaf widget.
+func (w *Widget) Children() []widget.Widget {
+	return nil
+}
+
+// Mount creates signal bindings for push-based invalidation.
+// Implements [widget.Lifecycle].
+//
+// The count signal binding deduplicates notifications: if the signal fires
+// with the same count that was last drawn, the widget is not marked dirty.
+func (w *Widget) Mount(ctx widget.Context) {
+	sched := ctx.Scheduler()
+	if sched == nil {
+		return
+	}
+	if w.cfg.readonlyCountSignal != nil {
+		w.AddBinding(w.bindCountSignal(w.cfg.readonlyCountSignal, sched))
+	} else if w.cfg.countSignal != nil {
+		w.AddBinding(w.bindCountSignal(w.cfg.countSignal, sched))
+	}
+	if w.cfg.readonlyDisabledSignal != nil {
+		w.AddBinding(state.BindToScheduler(w.cfg.readonlyDisabledSignal, w, sched))
+	} else if w.cfg.disabledSignal != nil {
+		w.AddBinding(state.BindToScheduler(w.cfg.disabledSignal, w, sched))
+	}
+}
+
+// bindCountSignal creates a deduplicating binding for an int count signal.
+// MarkDirty is only called when the clamped count differs from the last drawn
+// count, preventing redundant redraws.
+func (w *Widget) bindCountSignal(sig state.ReadonlySignal[int], sched widget.SchedulerRef) *state.Binding {
+	return state.BindToSchedulerFunc(sig, func(newVal int) bool {
+		if newVal < 0 {
+			newVal = 0
+		}
+		if w.lastDrawnCountSet && newVal == w.lastDrawnCount {
+			return false // suppress: count unchanged
+		}
+		return true
+	}, w, sched)
+}
+
+// Unmount is called when the badge is removed from the widget tree.
+// Implements [widget.Lifecycle].
+func (w *Widget) Unmount() {
+	// Bindings are cleaned up automatically by WidgetBase.CleanupBindings().
+}
+
+// Padding sets the outer padding around the badge content.
+// Returns the widget for method chaining.
+func (w *Widget) Padding(v float32) *Widget {
+	w.padding = v
+	return w
+}
+
+// Verify Widget implements required interfaces at compile time.
+var (
+	_ widget.Widget    = (*Widget)(nil)
+	_ widget.Lifecycle = (*Widget)(nil)
+)

--- a/core/badge/badge_test.go
+++ b/core/badge/badge_test.go
@@ -1,0 +1,506 @@
+package badge_test
+
+import (
+	"testing"
+
+	"github.com/gogpu/ui/core/badge"
+	"github.com/gogpu/ui/geometry"
+	"github.com/gogpu/ui/state"
+	"github.com/gogpu/ui/uitest"
+	"github.com/gogpu/ui/widget"
+)
+
+// --- Construction & Defaults ---
+
+func TestNew_Defaults(t *testing.T) {
+	b := badge.New()
+
+	if !b.IsVisible() {
+		t.Error("new badge should be visible")
+	}
+	if !b.IsEnabled() {
+		t.Error("new badge should be enabled")
+	}
+	if b.Count() != 0 {
+		t.Errorf("default count = %d, want 0", b.Count())
+	}
+}
+
+func TestNew_AppliesOptions(t *testing.T) {
+	b := badge.New(badge.Count(7))
+	if b.Count() != 7 {
+		t.Errorf("Count() = %d, want 7", b.Count())
+	}
+}
+
+// --- Count resolution & priority ---
+
+func TestResolvedCount_Priority(t *testing.T) {
+	roSig := state.NewSignal[int](100)
+	rwSig := state.NewSignal[int](50)
+
+	tests := []struct {
+		name string
+		opts []badge.Option
+		want int
+	}{
+		{"static", []badge.Option{badge.Count(3)}, 3},
+		{"fn over static", []badge.Option{badge.Count(3), badge.CountFn(func() int { return 9 })}, 9},
+		{"signal over fn", []badge.Option{badge.CountFn(func() int { return 9 }), badge.CountSignal(rwSig)}, 50},
+		{"readonly over signal", []badge.Option{badge.CountSignal(rwSig), badge.CountReadonlySignal(roSig)}, 100},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := badge.New(tt.opts...)
+			if got := b.Count(); got != tt.want {
+				t.Errorf("Count() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResolvedCount_NegativeClamped(t *testing.T) {
+	if got := badge.New(badge.Count(-5)).Count(); got != 0 {
+		t.Errorf("negative count = %d, want clamped to 0", got)
+	}
+	if got := badge.New(badge.CountFn(func() int { return -1 })).Count(); got != 0 {
+		t.Errorf("negative fn count = %d, want clamped to 0", got)
+	}
+}
+
+func TestSetCount(t *testing.T) {
+	b := badge.New()
+	b.SetCount(4)
+	if b.Count() != 4 {
+		t.Errorf("Count() = %d, want 4", b.Count())
+	}
+	b.SetCount(-2)
+	if b.Count() != 0 {
+		t.Errorf("Count() after negative = %d, want 0", b.Count())
+	}
+}
+
+// --- Hidden logic ---
+
+func TestIsHidden(t *testing.T) {
+	tests := []struct {
+		name string
+		opts []badge.Option
+		want bool
+	}{
+		{"zero count hidden", []badge.Option{badge.Count(0)}, true},
+		{"positive count visible", []badge.Option{badge.Count(1)}, false},
+		{"zero with ShowZero visible", []badge.Option{badge.Count(0), badge.ShowZero(true)}, false},
+		{"dot always visible", []badge.Option{badge.Dot(true), badge.Count(0)}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := badge.New(tt.opts...).IsHidden(); got != tt.want {
+				t.Errorf("IsHidden() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// --- Layout ---
+
+func TestLayout_HiddenIsZeroSize(t *testing.T) {
+	b := badge.New(badge.Count(0))
+	size := uitest.LayoutWidget(b, 100, 100)
+	if size.Width != 0 || size.Height != 0 {
+		t.Errorf("hidden badge size = %v, want 0x0", size)
+	}
+}
+
+func TestLayout_DotIsSquare(t *testing.T) {
+	b := badge.New(badge.Dot(true))
+	size := uitest.LayoutWidget(b, 100, 100)
+	if size.Width != size.Height {
+		t.Errorf("dot size = %v, want square", size)
+	}
+	if size.Width <= 0 {
+		t.Errorf("dot width = %v, want > 0", size.Width)
+	}
+}
+
+func TestLayout_SingleDigitIsCircular(t *testing.T) {
+	b := badge.New(badge.Count(5))
+	size := uitest.LayoutWidget(b, 100, 100)
+	if size.Width != size.Height {
+		t.Errorf("single-digit size = %v, want square (circular)", size)
+	}
+}
+
+func TestLayout_MultiDigitIsWiderThanTall(t *testing.T) {
+	b := badge.New(badge.Count(100), badge.Max(99)) // renders "99+"
+	size := uitest.LayoutWidget(b, 100, 100)
+	if size.Width <= size.Height {
+		t.Errorf("multi-digit size = %v, want width > height", size)
+	}
+}
+
+func TestLayout_PaddingAddsSize(t *testing.T) {
+	base := uitest.LayoutWidget(badge.New(badge.Dot(true)), 100, 100)
+	padded := uitest.LayoutWidget(badge.New(badge.Dot(true)).Padding(4), 100, 100)
+	if padded.Width != base.Width+8 || padded.Height != base.Height+8 {
+		t.Errorf("padded size = %v, want base %v + 8 each axis", padded, base)
+	}
+}
+
+func TestLayout_RespectsConstraints(t *testing.T) {
+	b := badge.New(badge.Count(100000)) // very wide label
+	size := uitest.LayoutWidget(b, 10, 10)
+	if size.Width > 10 || size.Height > 10 {
+		t.Errorf("size = %v, want constrained to 10x10", size)
+	}
+}
+
+// --- Draw ---
+
+func drawAt(b *badge.Widget, w, h float32) *uitest.MockCanvas {
+	b.SetBounds(geometry.NewRect(0, 0, w, h))
+	return uitest.DrawWidget(b)
+}
+
+func TestDraw_DotDrawsCircle(t *testing.T) {
+	b := badge.New(badge.Dot(true))
+	canvas := drawAt(b, 8, 8)
+
+	if len(canvas.Circles) != 1 {
+		t.Fatalf("dot draw circles = %d, want 1", len(canvas.Circles))
+	}
+	if len(canvas.Texts) != 0 {
+		t.Errorf("dot draw should not draw text, got %d", len(canvas.Texts))
+	}
+	if canvas.Circles[0].Radius != 4 {
+		t.Errorf("dot radius = %v, want 4 (min(8,8)/2)", canvas.Circles[0].Radius)
+	}
+}
+
+func TestDraw_DotRadiusUsesSmallerDimension(t *testing.T) {
+	b := badge.New(badge.Dot(true))
+	canvas := drawAt(b, 20, 8) // non-square bounds set directly
+	if len(canvas.Circles) != 1 {
+		t.Fatalf("circles = %d, want 1", len(canvas.Circles))
+	}
+	if canvas.Circles[0].Radius != 4 {
+		t.Errorf("radius = %v, want 4 (min(20,8)/2)", canvas.Circles[0].Radius)
+	}
+}
+
+func TestDraw_CountDrawsPillAndText(t *testing.T) {
+	b := badge.New(badge.Count(5))
+	canvas := drawAt(b, 16, 16)
+
+	if len(canvas.RoundRects) != 1 {
+		t.Fatalf("count draw round rects = %d, want 1", len(canvas.RoundRects))
+	}
+	if canvas.RoundRects[0].Radius != 8 {
+		t.Errorf("pill radius = %v, want 8 (height/2)", canvas.RoundRects[0].Radius)
+	}
+	uitest.AssertDrawnText(t, canvas, "5")
+}
+
+func TestDraw_CountOverMaxRendersPlus(t *testing.T) {
+	b := badge.New(badge.Count(250), badge.Max(99))
+	canvas := drawAt(b, 30, 16)
+	uitest.AssertDrawnText(t, canvas, "99+")
+}
+
+func TestDraw_DefaultMaxIs99(t *testing.T) {
+	b := badge.New(badge.Count(100)) // no Max option
+	canvas := drawAt(b, 30, 16)
+	uitest.AssertDrawnText(t, canvas, "99+")
+}
+
+func TestDraw_MaxNonPositiveIgnored(t *testing.T) {
+	b := badge.New(badge.Count(100), badge.Max(0)) // Max(0) ignored -> default 99
+	canvas := drawAt(b, 30, 16)
+	uitest.AssertDrawnText(t, canvas, "99+")
+}
+
+func TestDraw_ShowZeroDrawsZero(t *testing.T) {
+	b := badge.New(badge.Count(0), badge.ShowZero(true))
+	canvas := drawAt(b, 16, 16)
+	uitest.AssertDrawnText(t, canvas, "0")
+}
+
+func TestDraw_HiddenDrawsNothing(t *testing.T) {
+	b := badge.New(badge.Count(0))
+	canvas := drawAt(b, 16, 16)
+	if canvas.TotalDrawCalls() != 0 {
+		t.Errorf("hidden badge draw calls = %d, want 0", canvas.TotalDrawCalls())
+	}
+}
+
+func TestDraw_DisabledUsesDisabledColors(t *testing.T) {
+	enabled := drawAt(badge.New(badge.Count(3)), 16, 16)
+	disabled := drawAt(badge.New(badge.Count(3), badge.Disabled(true)), 16, 16)
+
+	if enabled.RoundRects[0].Color == disabled.RoundRects[0].Color {
+		t.Error("disabled badge should use a different background color")
+	}
+}
+
+func TestDraw_ColorSchemeOverridesDefaults(t *testing.T) {
+	scheme := badge.BadgeColorScheme{
+		Background: widget.Hex(0x00FF00),
+		Label:      widget.Hex(0x000000),
+	}
+	canvas := drawAt(badge.New(badge.Count(3), badge.ColorSchemeOpt(scheme)), 16, 16)
+	uitest.AssertColorEqual(t, canvas.RoundRects[0].Color, widget.Hex(0x00FF00))
+}
+
+func TestDraw_PaddingInsetsContent(t *testing.T) {
+	b := badge.New(badge.Dot(true)).Padding(3)
+	b.SetBounds(geometry.NewRect(0, 0, 14, 14)) // 8 content + 3 padding each side
+	canvas := uitest.DrawWidget(b)
+	if len(canvas.Circles) != 1 {
+		t.Fatalf("circles = %d, want 1", len(canvas.Circles))
+	}
+	// Content bounds are inset by padding: 14 - 6 = 8 -> radius 4, centered at 7,7.
+	center := canvas.Circles[0].Center
+	if center.X != 7 || center.Y != 7 {
+		t.Errorf("circle center = %v, want (7,7)", center)
+	}
+}
+
+// --- Custom painter ---
+
+type recordPainter struct{ called bool }
+
+func (p *recordPainter) PaintBadge(_ widget.Canvas, _ badge.PaintState) { p.called = true }
+
+func TestPainterOpt_UsesCustomPainter(t *testing.T) {
+	p := &recordPainter{}
+	b := badge.New(badge.Count(1), badge.PainterOpt(p))
+	drawAt(b, 16, 16)
+	if !p.called {
+		t.Error("custom painter PaintBadge was not called")
+	}
+}
+
+// --- DefaultPainter edge cases ---
+
+func TestDefaultPainter_EmptyBoundsNoOp(t *testing.T) {
+	canvas := &uitest.MockCanvas{}
+	badge.DefaultPainter{}.PaintBadge(canvas, badge.PaintState{
+		Bounds: geometry.Rect{},
+		Label:  "5",
+	})
+	if canvas.TotalDrawCalls() != 0 {
+		t.Errorf("empty bounds draw calls = %d, want 0", canvas.TotalDrawCalls())
+	}
+}
+
+func TestDraw_DotRadiusUsesSmallerHeight(t *testing.T) {
+	b := badge.New(badge.Dot(true))
+	canvas := drawAt(b, 8, 20) // height > width: radius driven by width
+	if len(canvas.Circles) != 1 {
+		t.Fatalf("circles = %d, want 1", len(canvas.Circles))
+	}
+	if canvas.Circles[0].Radius != 4 {
+		t.Errorf("radius = %v, want 4 (min(8,20)/2)", canvas.Circles[0].Radius)
+	}
+}
+
+// --- Leaf widget behavior ---
+
+func TestEvent_NeverConsumed(t *testing.T) {
+	b := badge.New(badge.Count(1))
+	if uitest.SimulateClick(b, 5, 5) {
+		t.Error("badge should never consume events")
+	}
+}
+
+func TestChildren_Nil(t *testing.T) {
+	if badge.New().Children() != nil {
+		t.Error("badge should have no children")
+	}
+}
+
+// --- Mount / signal bindings ---
+
+type mockScheduler struct{ dirtyCount int }
+
+func (s *mockScheduler) MarkDirty(_ widget.Widget) { s.dirtyCount++ }
+
+func TestMount_CountSignalNotifies(t *testing.T) {
+	sig := state.NewSignal[int](1)
+	b := badge.New(badge.CountSignal(sig))
+
+	sched := &mockScheduler{}
+	ctx := widget.NewContext()
+	ctx.SetScheduler(sched)
+	b.Mount(ctx)
+
+	sig.Set(2)
+	if sched.dirtyCount == 0 {
+		t.Error("scheduler should be notified after count change")
+	}
+}
+
+func TestMount_ReadonlyCountSignalNotifies(t *testing.T) {
+	sig := state.NewSignal[int](1)
+	b := badge.New(badge.CountReadonlySignal(sig))
+
+	sched := &mockScheduler{}
+	ctx := widget.NewContext()
+	ctx.SetScheduler(sched)
+	b.Mount(ctx)
+
+	sig.Set(2)
+	if sched.dirtyCount == 0 {
+		t.Error("scheduler should be notified after readonly count change")
+	}
+}
+
+func TestMount_DisabledSignalNotifies(t *testing.T) {
+	sig := state.NewSignal(false)
+	b := badge.New(badge.Count(1), badge.DisabledSignal(sig))
+
+	sched := &mockScheduler{}
+	ctx := widget.NewContext()
+	ctx.SetScheduler(sched)
+	b.Mount(ctx)
+
+	sig.Set(true)
+	if sched.dirtyCount == 0 {
+		t.Error("scheduler should be notified after disabled change")
+	}
+}
+
+func TestMount_ReadonlyDisabledSignalNotifies(t *testing.T) {
+	sig := state.NewSignal(false)
+	b := badge.New(badge.Count(1), badge.DisabledReadonlySignal(sig))
+
+	sched := &mockScheduler{}
+	ctx := widget.NewContext()
+	ctx.SetScheduler(sched)
+	b.Mount(ctx)
+
+	sig.Set(true)
+	if sched.dirtyCount == 0 {
+		t.Error("scheduler should be notified after readonly disabled change")
+	}
+}
+
+func TestMount_CountSignalDedupesUnchanged(t *testing.T) {
+	sig := state.NewSignal[int](3)
+	b := badge.New(badge.CountSignal(sig))
+
+	// Draw once so lastDrawnCount is populated.
+	drawAt(b, 16, 16)
+
+	sched := &mockScheduler{}
+	ctx := widget.NewContext()
+	ctx.SetScheduler(sched)
+	b.Mount(ctx)
+
+	sig.Set(3) // same value -> should be suppressed
+	if sched.dirtyCount != 0 {
+		t.Errorf("dirtyCount = %d, want 0 for unchanged count", sched.dirtyCount)
+	}
+
+	sig.Set(4) // changed -> should notify
+	if sched.dirtyCount == 0 {
+		t.Error("scheduler should be notified after count actually changes")
+	}
+}
+
+func TestMount_NilSchedulerNoPanic(t *testing.T) {
+	b := badge.New(badge.CountSignal(state.NewSignal[int](1)))
+	ctx := widget.NewContext()
+	b.Mount(ctx) // scheduler is nil; must not panic
+}
+
+func TestUnmount_CleanupStopsNotifications(t *testing.T) {
+	sig := state.NewSignal[int](1)
+	b := badge.New(badge.CountSignal(sig))
+
+	sched := &mockScheduler{}
+	ctx := widget.NewContext()
+	ctx.SetScheduler(sched)
+	b.Mount(ctx)
+	b.CleanupBindings()
+	b.Unmount()
+
+	sched.dirtyCount = 0
+	sig.Set(99)
+	if sched.dirtyCount > 0 {
+		t.Error("scheduler should not be notified after cleanup")
+	}
+}
+
+// --- Fluent & interface compliance ---
+
+func TestPadding_Chaining(t *testing.T) {
+	b := badge.New()
+	if b.Padding(2) != b {
+		t.Error("Padding should return the same widget for chaining")
+	}
+}
+
+func TestWidget_ImplementsInterfaces(t *testing.T) {
+	var _ widget.Widget = badge.New()
+	var _ widget.Lifecycle = badge.New()
+}
+
+// --- DisabledFn / CountFn resolution coverage ---
+
+func TestResolvedDisabled_Priority(t *testing.T) {
+	tests := []struct {
+		name string
+		opts []badge.Option
+		want bool
+	}{
+		{"static", []badge.Option{badge.Disabled(true)}, true},
+		{"fn over static", []badge.Option{badge.Disabled(false), badge.DisabledFn(func() bool { return true })}, true},
+		{"signal over fn", []badge.Option{badge.DisabledFn(func() bool { return false }), badge.DisabledSignal(state.NewSignal(true))}, true},
+		{"readonly over signal", []badge.Option{badge.DisabledSignal(state.NewSignal(false)), badge.DisabledReadonlySignal(state.NewSignal(true))}, true},
+	}
+	enabled := drawAt(badge.New(badge.Count(1)), 16, 16)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := badge.New(append(tt.opts, badge.Count(1))...)
+			canvas := drawAt(b, 16, 16)
+			// When disabled, background differs from the enabled default.
+			gotDisabled := canvas.RoundRects[0].Color != enabled.RoundRects[0].Color
+			if gotDisabled != tt.want {
+				t.Errorf("disabled rendering = %v, want %v", gotDisabled, tt.want)
+			}
+		})
+	}
+}
+
+func TestDraw_DisabledColorSchemeOverrides(t *testing.T) {
+	scheme := badge.BadgeColorScheme{
+		Background:         widget.Hex(0x00FF00),
+		Label:              widget.Hex(0x111111),
+		DisabledBackground: widget.Hex(0x0000FF),
+		DisabledLabel:      widget.Hex(0x222222),
+	}
+	canvas := drawAt(badge.New(badge.Count(3), badge.Disabled(true), badge.ColorSchemeOpt(scheme)), 16, 16)
+	uitest.AssertColorEqual(t, canvas.RoundRects[0].Color, widget.Hex(0x0000FF))
+	if len(canvas.Texts) != 1 {
+		t.Fatalf("texts = %d, want 1", len(canvas.Texts))
+	}
+	uitest.AssertColorEqual(t, canvas.Texts[0].Color, widget.Hex(0x222222))
+}
+
+func TestMount_CountSignalNegativeClamped(t *testing.T) {
+	sig := state.NewSignal[int](2)
+	b := badge.New(badge.CountSignal(sig))
+	drawAt(b, 16, 16) // populate lastDrawnCount = 2
+
+	sched := &mockScheduler{}
+	ctx := widget.NewContext()
+	ctx.SetScheduler(sched)
+	b.Mount(ctx)
+
+	sig.Set(-5) // clamps to 0, differs from 2 -> should notify
+	if sched.dirtyCount == 0 {
+		t.Error("scheduler should be notified when negative count clamps to a new value")
+	}
+}

--- a/core/badge/config.go
+++ b/core/badge/config.go
@@ -1,0 +1,77 @@
+package badge
+
+import (
+	"github.com/gogpu/ui/state"
+	"github.com/gogpu/ui/widget"
+)
+
+// config holds the badge's configuration, set at construction time via options.
+type config struct {
+	count                  int
+	countFn                func() int
+	countSignal            state.Signal[int]
+	readonlyCountSignal    state.ReadonlySignal[int]
+	dot                    bool
+	max                    int
+	maxSet                 bool // true if max was explicitly set via option
+	showZero               bool
+	disabled               bool
+	disabledFn             func() bool
+	disabledSignal         state.Signal[bool]
+	readonlyDisabledSignal state.ReadonlySignal[bool]
+	colorScheme            BadgeColorScheme
+	painter                Painter
+}
+
+// ResolvedCount returns the current count, clamped to be non-negative.
+// Priority: ReadonlySignal > Signal > Fn > Static.
+func (c *config) ResolvedCount() int {
+	var v int
+	switch {
+	case c.readonlyCountSignal != nil:
+		v = c.readonlyCountSignal.Get()
+	case c.countSignal != nil:
+		v = c.countSignal.Get()
+	case c.countFn != nil:
+		v = c.countFn()
+	default:
+		v = c.count
+	}
+	if v < 0 {
+		return 0
+	}
+	return v
+}
+
+// ResolvedMax returns the count threshold above which the badge renders "N+".
+// When max was not explicitly set, the default is used.
+func (c *config) ResolvedMax() int {
+	if !c.maxSet || c.max <= 0 {
+		return defaultMax
+	}
+	return c.max
+}
+
+// ResolvedDisabled returns the current disabled state.
+// Priority: ReadonlySignal > Signal > Fn > Static.
+func (c *config) ResolvedDisabled() bool {
+	if c.readonlyDisabledSignal != nil {
+		return c.readonlyDisabledSignal.Get()
+	}
+	if c.disabledSignal != nil {
+		return c.disabledSignal.Get()
+	}
+	if c.disabledFn != nil {
+		return c.disabledFn()
+	}
+	return c.disabled
+}
+
+// BadgeColorScheme provides theme-derived colors for badge painting.
+// Zero value means the painter should use its built-in defaults.
+type BadgeColorScheme struct {
+	Background         widget.Color // pill/dot fill color
+	Label              widget.Color // count text color
+	DisabledBackground widget.Color // fill color when disabled
+	DisabledLabel      widget.Color // text color when disabled
+}

--- a/core/badge/doc.go
+++ b/core/badge/doc.go
@@ -1,0 +1,63 @@
+// Package badge provides a small notification badge widget that displays a
+// count or a status dot.
+//
+// A badge is typically overlaid on another widget (an icon, an avatar, a tab)
+// to draw attention to unread items, pending notifications, or status. Because
+// gogpu/ui favors composition, the badge itself is a self-contained leaf
+// widget: position it over another widget using a stacking container rather
+// than attaching it directly.
+//
+// Construction uses functional options for immutable configuration, while
+// fluent methods handle mutable styling:
+//
+//	b := badge.New(
+//	    badge.Count(5),
+//	    badge.Max(99),
+//	).Padding(2)
+//
+// # Modes
+//
+// A badge renders in one of two modes:
+//
+//   - Count mode (default): displays a number inside a pill shape. A single
+//     digit renders as a circle; multiple digits widen into a pill. Counts
+//     greater than [Max] are shown as "N+" (for example "99+").
+//   - Dot mode (enabled via [Dot]): displays a small filled circle with no
+//     text, used as a lightweight "has updates" indicator.
+//
+// # Visibility
+//
+// In count mode, a badge with a non-positive count is hidden (it reports a
+// zero size and draws nothing) unless [ShowZero] is set. Dot badges are always
+// visible.
+//
+// # Visual Style
+//
+// The visual rendering is provided by a [Painter] implementation. Each design
+// system (Material 3, Fluent, Cupertino) may supply its own painter to render
+// badges in the appropriate visual style.
+//
+// If no painter is set, [DefaultPainter] is used, which draws a minimal badge
+// suitable for testing and prototyping.
+//
+// # Signal Binding
+//
+// Badge properties can be bound to reactive signals from the [state] package.
+// When a signal value changes, the badge automatically reflects the new state.
+//
+//   - [CountSignal] / [CountReadonlySignal] -- one-way read binding for the count
+//   - [CountFn] -- dynamic function evaluated on each draw
+//   - [DisabledSignal] / [DisabledReadonlySignal] -- one-way read binding for disabled state
+//
+// Example:
+//
+//	unread := state.NewSignal[int](0)
+//	b := badge.New(badge.CountSignal(unread))
+//	unread.Set(3) // badge updates to show "3"
+//
+// # Accessibility
+//
+// Badges are display-only widgets. They do not accept focus or handle input
+// events. Screen readers should announce the badge's meaning via the
+// accessibility tree of the widget the badge annotates.
+package badge

--- a/core/badge/options.go
+++ b/core/badge/options.go
@@ -1,0 +1,121 @@
+package badge
+
+import (
+	"github.com/gogpu/ui/state"
+)
+
+// Option configures a badge during construction.
+type Option func(*config)
+
+// Count sets the badge's initial static count.
+// Negative values are treated as zero.
+func Count(n int) Option {
+	return func(c *config) {
+		c.count = n
+	}
+}
+
+// CountFn sets a dynamic count function that is evaluated on each draw.
+// When set, this takes precedence over the static count but not over
+// a signal set via [CountSignal] or [CountReadonlySignal].
+func CountFn(fn func() int) Option {
+	return func(c *config) {
+		c.countFn = fn
+	}
+}
+
+// CountSignal binds the badge's count to a reactive signal.
+// This is a one-way read binding: the widget reads the value from the signal.
+// When set, the signal value takes precedence over both [CountFn] and [Count]
+// but not over [CountReadonlySignal].
+func CountSignal(sig state.Signal[int]) Option {
+	return func(c *config) {
+		c.countSignal = sig
+	}
+}
+
+// CountReadonlySignal binds the badge's count to a read-only signal.
+// This is useful for computed signals created via [state.NewComputed].
+// When set, this takes highest precedence over all other count sources.
+func CountReadonlySignal(sig state.ReadonlySignal[int]) Option {
+	return func(c *config) {
+		c.readonlyCountSignal = sig
+	}
+}
+
+// Dot enables dot mode, rendering a small filled circle with no text.
+// In dot mode the count is ignored and the badge is always visible.
+func Dot(enabled bool) Option {
+	return func(c *config) {
+		c.dot = enabled
+	}
+}
+
+// Max sets the count threshold above which the badge renders "N+".
+// For example, with Max(99) a count of 100 displays as "99+".
+// The default is 99. Values <= 0 are ignored.
+func Max(n int) Option {
+	return func(c *config) {
+		c.max = n
+		c.maxSet = true
+	}
+}
+
+// ShowZero forces the badge to remain visible when the count is zero.
+// By default a count badge with a non-positive count is hidden.
+// This option has no effect in dot mode.
+func ShowZero(show bool) Option {
+	return func(c *config) {
+		c.showZero = show
+	}
+}
+
+// ColorSchemeOpt sets the color scheme for painting.
+// This overrides the painter's built-in defaults.
+func ColorSchemeOpt(cs BadgeColorScheme) Option {
+	return func(c *config) {
+		c.colorScheme = cs
+	}
+}
+
+// Disabled sets the badge's disabled state, which dims its colors.
+func Disabled(d bool) Option {
+	return func(c *config) {
+		c.disabled = d
+	}
+}
+
+// DisabledFn sets a dynamic function for the disabled state.
+// When set, this takes precedence over the static value but not
+// over a signal set via [DisabledSignal].
+func DisabledFn(fn func() bool) Option {
+	return func(c *config) {
+		c.disabledFn = fn
+	}
+}
+
+// DisabledSignal binds the disabled state to a reactive signal.
+// When set, the signal value takes precedence over both [DisabledFn]
+// and [Disabled] but not over [DisabledReadonlySignal].
+func DisabledSignal(sig state.Signal[bool]) Option {
+	return func(c *config) {
+		c.disabledSignal = sig
+	}
+}
+
+// DisabledReadonlySignal binds the disabled state to a read-only signal.
+// When set, this takes highest precedence over all other disabled sources.
+func DisabledReadonlySignal(sig state.ReadonlySignal[bool]) Option {
+	return func(c *config) {
+		c.readonlyDisabledSignal = sig
+	}
+}
+
+// PainterOpt sets the painter used to render the badge.
+// Each design system provides its own painter. If not set,
+// [DefaultPainter] is used.
+func PainterOpt(p Painter) Option {
+	return func(c *config) {
+		c.painter = p
+	}
+}

--- a/core/badge/painter.go
+++ b/core/badge/painter.go
@@ -45,7 +45,7 @@ func (p DefaultPainter) PaintBadge(canvas widget.Canvas, ps PaintState) {
 
 	if ps.Dot {
 		// Bounds is non-empty here, so both dimensions are positive.
-		radius := minF32(bounds.Width(), bounds.Height()) / 2
+		radius := min(bounds.Width(), bounds.Height()) / 2
 		center := geometry.Pt(
 			bounds.Min.X+bounds.Width()/2,
 			bounds.Min.Y+bounds.Height()/2,
@@ -90,13 +90,6 @@ func resolveLabelColor(ps PaintState, hasScheme bool) widget.Color {
 		return ps.ColorScheme.Label
 	}
 	return defaultLabel
-}
-
-func minF32(a, b float32) float32 {
-	if a < b {
-		return a
-	}
-	return b
 }
 
 // defaultMax is the count threshold above which the badge renders "N+".

--- a/core/badge/painter.go
+++ b/core/badge/painter.go
@@ -1,0 +1,111 @@
+package badge
+
+import (
+	"github.com/gogpu/ui/geometry"
+	"github.com/gogpu/ui/widget"
+)
+
+// Painter draws the visual representation of a badge.
+// Each design system (Material 3, Fluent, Cupertino) provides its own
+// Painter implementation to render the badge in its visual style.
+//
+// If no Painter is set, the badge uses [DefaultPainter].
+type Painter interface {
+	PaintBadge(canvas widget.Canvas, state PaintState)
+}
+
+// PaintState provides the current badge state to the painter.
+type PaintState struct {
+	Bounds      geometry.Rect    // total widget bounds (excludes outer padding)
+	Dot         bool             // true for dot mode (no label)
+	Label       string           // pre-formatted count label (empty in dot mode)
+	Disabled    bool             // widget is disabled
+	ColorScheme BadgeColorScheme // theme-derived colors (zero = use defaults)
+}
+
+// DefaultPainter provides a minimal fallback painter with no design system
+// styling. It draws a red pill (or dot) with a centered count label -- useful
+// for testing and as a base reference.
+type DefaultPainter struct{}
+
+// PaintBadge renders the badge. In dot mode it draws a small filled circle.
+// In count mode it draws a pill (a rounded rectangle whose radius is half its
+// height) with the count label centered inside.
+//
+// If state.ColorScheme is non-zero, its colors are used instead of the
+// built-in defaults.
+func (p DefaultPainter) PaintBadge(canvas widget.Canvas, ps PaintState) {
+	if ps.Bounds.IsEmpty() {
+		return
+	}
+
+	hasScheme := ps.ColorScheme != (BadgeColorScheme{})
+	bg := resolveBackgroundColor(ps, hasScheme)
+	bounds := ps.Bounds
+
+	if ps.Dot {
+		// Bounds is non-empty here, so both dimensions are positive.
+		radius := minF32(bounds.Width(), bounds.Height()) / 2
+		center := geometry.Pt(
+			bounds.Min.X+bounds.Width()/2,
+			bounds.Min.Y+bounds.Height()/2,
+		)
+		canvas.DrawCircle(center, radius, bg)
+		return
+	}
+
+	// Count mode: pill background.
+	radius := bounds.Height() / 2
+	canvas.DrawRoundRect(bounds, bg, radius)
+
+	if ps.Label != "" {
+		labelColor := resolveLabelColor(ps, hasScheme)
+		canvas.DrawText(ps.Label, bounds, defaultFontSize, labelColor, true, widget.TextAlignCenter)
+	}
+}
+
+// Color resolution helpers.
+
+func resolveBackgroundColor(ps PaintState, hasScheme bool) widget.Color {
+	if ps.Disabled {
+		if hasScheme {
+			return ps.ColorScheme.DisabledBackground
+		}
+		return defaultDisabledBackground
+	}
+	if hasScheme {
+		return ps.ColorScheme.Background
+	}
+	return defaultBackground
+}
+
+func resolveLabelColor(ps PaintState, hasScheme bool) widget.Color {
+	if ps.Disabled {
+		if hasScheme {
+			return ps.ColorScheme.DisabledLabel
+		}
+		return defaultDisabledLabel
+	}
+	if hasScheme {
+		return ps.ColorScheme.Label
+	}
+	return defaultLabel
+}
+
+func minF32(a, b float32) float32 {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+// defaultMax is the count threshold above which the badge renders "N+".
+const defaultMax = 99
+
+// Default colors for DefaultPainter.
+var (
+	defaultBackground         = widget.Hex(0xB3261E) // Material 3 error
+	defaultLabel              = widget.ColorWhite
+	defaultDisabledBackground = widget.RGBA(0.70, 0.70, 0.70, 1.0)
+	defaultDisabledLabel      = widget.RGBA(0.96, 0.96, 0.96, 1.0)
+)


### PR DESCRIPTION
## Summary

Implements the **Badge** widget listed in `ROADMAP.md` → Phase 5 (Low complexity):

> **Badge** — Notification badge (dot or count) on any widget

A small, display-only widget that shows a notification count or a status dot. It follows the existing core-widget conventions (functional options + pluggable `Painter` + `DefaultPainter`), mirroring `core/progressbar` as the structural reference.

## Behavior

- **Count mode (default)**: pill with a centered count. A single digit renders circular; values above `Max` render as `"N+"` (default `Max` = 99).
- **Dot mode** (`badge.Dot(true)`): a minimal status dot, always visible.
- **Visibility**: a count badge with count ≤ 0 is hidden (zero size, no draw) unless `ShowZero(true)`.
- **Reactive**: `Count`/`Disabled` support static / `Fn` / `Signal` / `ReadonlySignal` sources (priority: ReadonlySignal > Signal > Fn > Static), with redraw deduplication when the count is unchanged.
- **Theming**: `DefaultPainter` ships sensible defaults; `BadgeColorScheme` lets design-system painters override colors.
- Leaf widget: not focusable, never consumes events.

## API sketch

```go
b := badge.New(
    badge.Count(5),
    badge.Max(99),
).Padding(2)

unread := state.NewSignal[int](0)
dot := badge.New(badge.Dot(true), badge.CountSignal(unread))
```

## Files

`core/badge/`: `doc.go`, `config.go`, `options.go`, `painter.go`, `badge.go`, `badge_test.go`.

## Verification

- `go build ./...` — OK
- `go test ./core/badge/ -cover` — **99.3%** statement coverage
- `golangci-lint run ./core/badge/` — **0 issues**
- `gofmt` clean

## Notes

- `CONTRIBUTING.md` suggests opening an issue first for new widgets — happy to convert this to a discussion if preferred. Opening as a PR since the widget is already on the roadmap and self-contained.
- Theme-system painters (Material 3 / DevTools / Fluent / Cupertino) are intentionally **not** included here to keep the PR focused; the widget is fully functional via `DefaultPainter`. I can follow up with per-theme painters in a separate PR.
- a11y is left at parity with existing leaf widgets (progressbar/progress do not implement an a11y node at the widget layer).