### PR TITLE
feat(chip): add Material 3 chip widget (action + filter)

### DIFF
--- a/core/chip/chip.go
+++ b/core/chip/chip.go
@@ -82,15 +82,31 @@ func (w *Widget) Selected() bool {
 	return w.cfg.ResolvedSelected()
 }
 
-// SetSelected updates the chip's selected state (uncontrolled mode).
-// It has no effect when the selected state is bound to a function or signal.
+// SetSelected updates the chip's selected state.
+//
+// If a writable [SelectedSignal] is bound, the new value is written back to it
+// (two-way binding). With only a static value, the chip's own state is updated.
+// When the selected state is driven by a read-only source ([SelectedFn] or
+// [SelectedReadonlySignal]), this is a no-op: the owner controls that source.
 func (w *Widget) SetSelected(sel bool) {
-	if w.cfg.selectedIsDynamic() {
+	if w.cfg.ResolvedSelected() == sel {
 		return
 	}
-	if w.cfg.selected != sel {
+	w.applySelected(sel)
+	w.SetNeedsRedraw(true)
+}
+
+// applySelected writes the new selected state to the appropriate writable
+// source: the bound [SelectedSignal] if present, otherwise the static field.
+// A [SelectedFn] or [SelectedReadonlySignal] source is read-only, so the chip
+// leaves it untouched and relies on the owner to update it.
+func (w *Widget) applySelected(sel bool) {
+	if w.cfg.selectedSignal != nil {
+		w.cfg.selectedSignal.Set(sel)
+		return
+	}
+	if w.cfg.selectedFn == nil && w.cfg.readonlySelectedSignal == nil {
 		w.cfg.selected = sel
-		w.SetNeedsRedraw(true)
 	}
 }
 
@@ -117,6 +133,7 @@ func (w *Widget) Draw(_ widget.Context, canvas widget.Canvas) {
 		Label:       w.cfg.ResolvedLabel(),
 		Bounds:      w.contentBounds(),
 		Radius:      defaultChipRadius,
+		FontSize:    defaultFontSize,
 		Selectable:  w.cfg.selectable,
 		Selected:    w.cfg.ResolvedSelected(),
 		Hovered:     w.state == stateHover,

--- a/core/chip/chip.go
+++ b/core/chip/chip.go
@@ -1,0 +1,196 @@
+package chip
+
+import (
+	"github.com/gogpu/ui/event"
+	"github.com/gogpu/ui/geometry"
+	"github.com/gogpu/ui/state"
+	"github.com/gogpu/ui/widget"
+)
+
+// interactionState represents the current user interaction state.
+type interactionState uint8
+
+const (
+	stateNormal  interactionState = iota
+	stateHover                    // pointer is over the chip
+	statePressed                  // chip is held down
+)
+
+// Widget implements a compact, interactive chip.
+//
+// A chip is created with [New] using functional options:
+//
+//	c := chip.New(
+//	    chip.Label("Tag"),
+//	    chip.OnClick(handleTag),
+//	)
+//
+// Fluent styling methods may be chained after construction:
+//
+//	c.Padding(2)
+type Widget struct {
+	widget.WidgetBase
+	cfg     config
+	state   interactionState
+	painter Painter
+
+	// Styling overrides set via fluent methods.
+	padding float32
+}
+
+// New creates a new chip Widget with the given options.
+//
+// The returned widget is visible, enabled, and focusable by default.
+func New(opts ...Option) *Widget {
+	w := &Widget{
+		painter: DefaultPainter{},
+	}
+	w.SetVisible(true)
+	w.SetEnabled(true)
+
+	for _, opt := range opts {
+		opt(&w.cfg)
+	}
+
+	if w.cfg.painter != nil {
+		w.painter = w.cfg.painter
+	}
+
+	return w
+}
+
+// Default sizing values.
+const (
+	defaultChipHeight float32 = 32
+	defaultChipRadius float32 = 8
+	defaultFontSize   float32 = 14
+	labelPaddingX     float32 = 12
+	// charWidthRatio approximates character width as a fraction of font size
+	// for layout estimation.
+	charWidthRatio float32 = 0.55
+	minChipWidth   float32 = 32
+)
+
+// IsFocusable reports whether the chip can currently receive focus.
+// Implements [widget.Focusable].
+func (w *Widget) IsFocusable() bool {
+	return w.IsVisible() && w.IsEnabled() && !w.cfg.ResolvedDisabled()
+}
+
+// Selected returns the chip's current resolved selected state.
+func (w *Widget) Selected() bool {
+	return w.cfg.ResolvedSelected()
+}
+
+// SetSelected updates the chip's selected state (uncontrolled mode).
+// It has no effect when the selected state is bound to a function or signal.
+func (w *Widget) SetSelected(sel bool) {
+	if w.cfg.selectedIsDynamic() {
+		return
+	}
+	if w.cfg.selected != sel {
+		w.cfg.selected = sel
+		w.SetNeedsRedraw(true)
+	}
+}
+
+// Layout calculates the chip's preferred size within the given constraints.
+func (w *Widget) Layout(_ widget.Context, constraints geometry.Constraints) geometry.Size {
+	text := w.cfg.ResolvedLabel()
+	textWidth := float32(len(text)) * defaultFontSize * charWidthRatio
+
+	contentW := textWidth + labelPaddingX*2
+	if contentW < minChipWidth {
+		contentW = minChipWidth
+	}
+
+	preferred := geometry.Sz(
+		contentW+w.padding*2,
+		defaultChipHeight+w.padding*2,
+	)
+	return constraints.Constrain(preferred)
+}
+
+// Draw renders the chip to the canvas.
+func (w *Widget) Draw(_ widget.Context, canvas widget.Canvas) {
+	w.painter.PaintChip(canvas, PaintState{
+		Label:       w.cfg.ResolvedLabel(),
+		Bounds:      w.contentBounds(),
+		Radius:      defaultChipRadius,
+		Selectable:  w.cfg.selectable,
+		Selected:    w.cfg.ResolvedSelected(),
+		Hovered:     w.state == stateHover,
+		Pressed:     w.state == statePressed,
+		Focused:     w.IsFocused(),
+		Disabled:    w.cfg.ResolvedDisabled(),
+		ColorScheme: w.cfg.colorScheme,
+	})
+}
+
+// contentBounds returns the chip bounds inset by the outer padding.
+func (w *Widget) contentBounds() geometry.Rect {
+	b := w.Bounds()
+	if w.padding == 0 {
+		return b
+	}
+	return geometry.NewRect(
+		b.Min.X+w.padding,
+		b.Min.Y+w.padding,
+		b.Width()-w.padding*2,
+		b.Height()-w.padding*2,
+	)
+}
+
+// Event handles an input event and returns true if consumed.
+func (w *Widget) Event(ctx widget.Context, e event.Event) bool {
+	return handleEvent(w, ctx, e)
+}
+
+// Children returns nil because a chip is a leaf widget.
+func (w *Widget) Children() []widget.Widget {
+	return nil
+}
+
+// Mount creates signal bindings for push-based invalidation.
+// Implements [widget.Lifecycle].
+func (w *Widget) Mount(ctx widget.Context) {
+	sched := ctx.Scheduler()
+	if sched == nil {
+		return
+	}
+	if w.cfg.readonlyLabelSignal != nil {
+		w.AddBinding(state.BindToScheduler(w.cfg.readonlyLabelSignal, w, sched))
+	} else if w.cfg.labelSignal != nil {
+		w.AddBinding(state.BindToScheduler(w.cfg.labelSignal, w, sched))
+	}
+	if w.cfg.readonlySelectedSignal != nil {
+		w.AddBinding(state.BindToScheduler(w.cfg.readonlySelectedSignal, w, sched))
+	} else if w.cfg.selectedSignal != nil {
+		w.AddBinding(state.BindToScheduler(w.cfg.selectedSignal, w, sched))
+	}
+	if w.cfg.readonlyDisabledSignal != nil {
+		w.AddBinding(state.BindToScheduler(w.cfg.readonlyDisabledSignal, w, sched))
+	} else if w.cfg.disabledSignal != nil {
+		w.AddBinding(state.BindToScheduler(w.cfg.disabledSignal, w, sched))
+	}
+}
+
+// Unmount is called when the chip is removed from the widget tree.
+// Implements [widget.Lifecycle].
+func (w *Widget) Unmount() {
+	// Bindings are cleaned up automatically by WidgetBase.CleanupBindings().
+}
+
+// Padding sets the outer padding around the chip content.
+// Returns the widget for method chaining.
+func (w *Widget) Padding(v float32) *Widget {
+	w.padding = v
+	return w
+}
+
+// Verify Widget implements required interfaces at compile time.
+var (
+	_ widget.Widget    = (*Widget)(nil)
+	_ widget.Focusable = (*Widget)(nil)
+	_ widget.Lifecycle = (*Widget)(nil)
+)

--- a/core/chip/chip_test.go
+++ b/core/chip/chip_test.go
@@ -233,12 +233,38 @@ func TestSetSelected_Uncontrolled(t *testing.T) {
 	}
 }
 
-func TestSetSelected_ControlledNoOp(t *testing.T) {
+func TestSetSelected_WritesBackToSignal(t *testing.T) {
 	sig := state.NewSignal(false)
 	c := chip.New(chip.Selectable(true), chip.SelectedSignal(sig))
 	c.SetSelected(true)
+	if !sig.Get() {
+		t.Error("SetSelected should write back to a bound SelectedSignal")
+	}
+	if !c.Selected() {
+		t.Error("Selected() should reflect the written-back signal value")
+	}
+}
+
+func TestSetSelected_SameValueNoOp(t *testing.T) {
+	c := chip.New(chip.Selectable(true))
+	c.SetSelected(false) // already false -> early return, no change
 	if c.Selected() {
-		t.Error("SetSelected should be a no-op when selection is signal-controlled")
+		t.Error("SetSelected(false) on an unselected chip should be a no-op")
+	}
+}
+
+func TestSetSelected_ReadonlySourceNoOp(t *testing.T) {
+	roSig := state.NewSignal(false)
+	c := chip.New(chip.Selectable(true), chip.SelectedReadonlySignal(roSig))
+	c.SetSelected(true)
+	if c.Selected() {
+		t.Error("SetSelected must not change a read-only selected source")
+	}
+
+	cFn := chip.New(chip.Selectable(true), chip.SelectedFn(func() bool { return false }))
+	cFn.SetSelected(true)
+	if cFn.Selected() {
+		t.Error("SetSelected must not change a function-driven selected source")
 	}
 }
 
@@ -280,20 +306,40 @@ func TestClick_FilterChipTogglesAndNotifies(t *testing.T) {
 	}
 }
 
-func TestClick_FilterControlledDoesNotMutateLocal(t *testing.T) {
+func TestClick_FilterSignalWriteBack(t *testing.T) {
 	sig := state.NewSignal(false)
+	c := chip.New(chip.Selectable(true), chip.SelectedSignal(sig))
+	c.SetBounds(geometry.NewRect(0, 0, 80, 32))
+
+	uitest.SimulateClick(c, 10, 10)
+	if !sig.Get() {
+		t.Error("clicking a SelectedSignal-bound chip should write back to the signal")
+	}
+	if !c.Selected() {
+		t.Error("chip should render as selected after write-back")
+	}
+
+	uitest.SimulateClick(c, 10, 10)
+	if sig.Get() {
+		t.Error("a second click should toggle the signal back to false")
+	}
+}
+
+func TestClick_FilterReadonlyControlled(t *testing.T) {
+	// A read-only source: the chip cannot write, but must still report the
+	// intended new value via OnSelectedChanged so the owner can update state.
+	roSig := state.NewSignal(false)
 	var notified bool
-	c := chip.New(chip.Selectable(true), chip.SelectedSignal(sig),
+	c := chip.New(chip.Selectable(true), chip.SelectedReadonlySignal(roSig),
 		chip.OnSelectedChanged(func(sel bool) { notified = sel }))
 	c.SetBounds(geometry.NewRect(0, 0, 80, 32))
 
 	uitest.SimulateClick(c, 10, 10)
 	if !notified {
-		t.Error("OnSelectedChanged should report new state true")
+		t.Error("OnSelectedChanged should report the intended new state (true)")
 	}
-	// Controlled: local state stays in sync with the (unchanged) signal.
 	if c.Selected() {
-		t.Error("controlled chip should not flip local state; owner updates the signal")
+		t.Error("read-only controlled chip must not flip its own state")
 	}
 }
 
@@ -396,6 +442,46 @@ func TestDefaultPainter_EmptyBoundsNoOp(t *testing.T) {
 	chip.DefaultPainter{}.PaintChip(canvas, chip.PaintState{Label: "x"})
 	if canvas.TotalDrawCalls() != 0 {
 		t.Errorf("empty bounds draw calls = %d, want 0", canvas.TotalDrawCalls())
+	}
+}
+
+func TestDraw_UsesDefaultFontSize(t *testing.T) {
+	canvas := drawAt(chip.New(chip.Label("Tag")))
+	if len(canvas.Texts) != 1 {
+		t.Fatalf("texts = %d, want 1", len(canvas.Texts))
+	}
+	if canvas.Texts[0].FontSize != 14 {
+		t.Errorf("font size = %v, want 14 (default)", canvas.Texts[0].FontSize)
+	}
+}
+
+func TestDefaultPainter_RespectsFontSize(t *testing.T) {
+	canvas := &uitest.MockCanvas{}
+	chip.DefaultPainter{}.PaintChip(canvas, chip.PaintState{
+		Label:    "x",
+		Bounds:   geometry.NewRect(0, 0, 40, 20),
+		FontSize: 22,
+	})
+	if len(canvas.Texts) != 1 {
+		t.Fatalf("texts = %d, want 1", len(canvas.Texts))
+	}
+	if canvas.Texts[0].FontSize != 22 {
+		t.Errorf("font size = %v, want 22 (explicit)", canvas.Texts[0].FontSize)
+	}
+}
+
+func TestDefaultPainter_FontSizeFallback(t *testing.T) {
+	canvas := &uitest.MockCanvas{}
+	chip.DefaultPainter{}.PaintChip(canvas, chip.PaintState{
+		Label:  "x",
+		Bounds: geometry.NewRect(0, 0, 40, 20),
+		// FontSize left 0 -> painter falls back to its default.
+	})
+	if len(canvas.Texts) != 1 {
+		t.Fatalf("texts = %d, want 1", len(canvas.Texts))
+	}
+	if canvas.Texts[0].FontSize != 14 {
+		t.Errorf("font size = %v, want 14 (fallback)", canvas.Texts[0].FontSize)
 	}
 }
 

--- a/core/chip/chip_test.go
+++ b/core/chip/chip_test.go
@@ -1,0 +1,579 @@
+package chip_test
+
+import (
+	"testing"
+
+	"github.com/gogpu/ui/core/chip"
+	"github.com/gogpu/ui/event"
+	"github.com/gogpu/ui/geometry"
+	"github.com/gogpu/ui/state"
+	"github.com/gogpu/ui/uitest"
+	"github.com/gogpu/ui/widget"
+)
+
+// --- Construction & defaults ---
+
+func TestNew_Defaults(t *testing.T) {
+	c := chip.New()
+	if !c.IsVisible() {
+		t.Error("new chip should be visible")
+	}
+	if !c.IsEnabled() {
+		t.Error("new chip should be enabled")
+	}
+	if !c.IsFocusable() {
+		t.Error("new chip should be focusable")
+	}
+	if c.Selected() {
+		t.Error("new chip should not be selected")
+	}
+}
+
+func TestIsFocusable_DisabledNotFocusable(t *testing.T) {
+	if chip.New(chip.Disabled(true)).IsFocusable() {
+		t.Error("disabled chip should not be focusable")
+	}
+}
+
+// --- Resolution priority ---
+
+func TestResolvedLabel_Priority(t *testing.T) {
+	roSig := state.NewSignal("ro")
+	rwSig := state.NewSignal("rw")
+	tests := []struct {
+		name string
+		opts []chip.Option
+		want string
+	}{
+		{"static", []chip.Option{chip.Label("s")}, "s"},
+		{"fn over static", []chip.Option{chip.Label("s"), chip.LabelFn(func() string { return "f" })}, "f"},
+		{"signal over fn", []chip.Option{chip.LabelFn(func() string { return "f" }), chip.LabelSignal(rwSig)}, "rw"},
+		{"readonly over signal", []chip.Option{chip.LabelSignal(rwSig), chip.LabelReadonlySignal(roSig)}, "ro"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := chip.New(tt.opts...)
+			canvas := drawAt(c)
+			uitest.AssertDrawnText(t, canvas, tt.want)
+		})
+	}
+}
+
+func TestResolvedSelected_Priority(t *testing.T) {
+	tests := []struct {
+		name string
+		opts []chip.Option
+		want bool
+	}{
+		{"static", []chip.Option{chip.Selected(true)}, true},
+		{"fn over static", []chip.Option{chip.Selected(false), chip.SelectedFn(func() bool { return true })}, true},
+		{"signal over fn", []chip.Option{chip.SelectedFn(func() bool { return false }), chip.SelectedSignal(state.NewSignal(true))}, true},
+		{"readonly over signal", []chip.Option{chip.SelectedSignal(state.NewSignal(false)), chip.SelectedReadonlySignal(state.NewSignal(true))}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := chip.New(tt.opts...).Selected(); got != tt.want {
+				t.Errorf("Selected() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResolvedDisabled_Priority(t *testing.T) {
+	// ResolvedDisabled is unexported; assert its effect via IsFocusable
+	// (a disabled chip is not focusable).
+	tests := []struct {
+		name      string
+		opts      []chip.Option
+		wantFocus bool
+	}{
+		{"static disabled", []chip.Option{chip.Disabled(true)}, false},
+		{"fn over static", []chip.Option{chip.Disabled(false), chip.DisabledFn(func() bool { return true })}, false},
+		{"signal over fn", []chip.Option{chip.DisabledFn(func() bool { return false }), chip.DisabledSignal(state.NewSignal(true))}, false},
+		{"readonly over signal", []chip.Option{chip.DisabledSignal(state.NewSignal(false)), chip.DisabledReadonlySignal(state.NewSignal(true))}, false},
+		{"enabled", []chip.Option{chip.Disabled(false)}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := chip.New(tt.opts...).IsFocusable(); got != tt.wantFocus {
+				t.Errorf("IsFocusable() = %v, want %v", got, tt.wantFocus)
+			}
+		})
+	}
+}
+
+// --- Layout ---
+
+func TestLayout_WidthGrowsWithLabel(t *testing.T) {
+	short := uitest.LayoutWidget(chip.New(chip.Label("a")), 500, 100)
+	long := uitest.LayoutWidget(chip.New(chip.Label("a much longer label")), 500, 100)
+	if long.Width <= short.Width {
+		t.Errorf("long width %v should exceed short width %v", long.Width, short.Width)
+	}
+}
+
+func TestLayout_MinWidth(t *testing.T) {
+	size := uitest.LayoutWidget(chip.New(chip.Label("")), 500, 100)
+	if size.Width < 32 {
+		t.Errorf("width = %v, want >= 32 (min)", size.Width)
+	}
+}
+
+func TestLayout_Height(t *testing.T) {
+	size := uitest.LayoutWidget(chip.New(chip.Label("x")), 500, 100)
+	if size.Height != 32 {
+		t.Errorf("height = %v, want 32", size.Height)
+	}
+}
+
+func TestLayout_PaddingAddsSize(t *testing.T) {
+	base := uitest.LayoutWidget(chip.New(chip.Label("x")), 500, 100)
+	padded := uitest.LayoutWidget(chip.New(chip.Label("x")).Padding(5), 500, 100)
+	if padded.Height != base.Height+10 {
+		t.Errorf("padded height = %v, want base %v + 10", padded.Height, base.Height)
+	}
+}
+
+func TestLayout_RespectsConstraints(t *testing.T) {
+	size := uitest.LayoutWidget(chip.New(chip.Label("very long label here")), 20, 20)
+	if size.Width > 20 || size.Height > 20 {
+		t.Errorf("size = %v, want constrained to 20x20", size)
+	}
+}
+
+// --- Draw ---
+
+func drawAt(c *chip.Widget) *uitest.MockCanvas {
+	c.SetBounds(geometry.NewRect(0, 0, 80, 32))
+	return uitest.DrawWidget(c)
+}
+
+func TestDraw_UnselectedHasBorder(t *testing.T) {
+	c := chip.New(chip.Label("Tag"))
+	canvas := drawAt(c)
+	if len(canvas.StrokeRoundRects) == 0 {
+		t.Error("unselected chip should stroke a border")
+	}
+	uitest.AssertDrawnText(t, canvas, "Tag")
+}
+
+func TestDraw_SelectedFillsBackground(t *testing.T) {
+	c := chip.New(chip.Label("Tag"), chip.Selectable(true), chip.Selected(true))
+	canvas := drawAt(c)
+	if len(canvas.RoundRects) == 0 {
+		t.Error("selected chip should fill a background round rect")
+	}
+}
+
+func TestDraw_DisabledUsesDisabledBackground(t *testing.T) {
+	canvas := drawAt(chip.New(chip.Label("Tag"), chip.Disabled(true)))
+	if len(canvas.RoundRects) == 0 {
+		t.Error("disabled chip should fill a background round rect")
+	}
+}
+
+func TestDraw_FocusedDrawsRing(t *testing.T) {
+	c := chip.New(chip.Label("Tag"))
+	c.SetFocused(true)
+	canvas := drawAt(c)
+	// Unselected draws 1 border stroke; focus adds a 2nd stroke (the ring).
+	if len(canvas.StrokeRoundRects) < 2 {
+		t.Errorf("focused chip strokes = %d, want >= 2 (border + ring)", len(canvas.StrokeRoundRects))
+	}
+}
+
+func TestDraw_HoverAddsStateLayer(t *testing.T) {
+	c := chip.New(chip.Label("Tag"), chip.Selected(true), chip.Selectable(true))
+	base := drawAt(c)
+	baseFills := len(base.RoundRects)
+
+	// Hover the chip; the state layer adds an extra filled round rect.
+	c.SetBounds(geometry.NewRect(0, 0, 80, 32))
+	c.Event(uitest.NewMockContext(), uitest.MouseEnter(10, 10))
+	hovered := uitest.DrawWidget(c)
+	if len(hovered.RoundRects) <= baseFills {
+		t.Errorf("hover fills = %d, want > base %d (state layer)", len(hovered.RoundRects), baseFills)
+	}
+}
+
+func TestDraw_ColorSchemeOverride(t *testing.T) {
+	scheme := chip.ChipColorScheme{
+		SelectedBackground: widget.Hex(0x00FF00),
+		SelectedLabel:      widget.Hex(0x000000),
+	}
+	c := chip.New(chip.Label("x"), chip.Selectable(true), chip.Selected(true), chip.ColorSchemeOpt(scheme))
+	canvas := drawAt(c)
+	if len(canvas.RoundRects) == 0 {
+		t.Fatal("expected a filled round rect")
+	}
+	uitest.AssertColorEqual(t, canvas.RoundRects[0].Color, widget.Hex(0x00FF00))
+}
+
+func TestDraw_PaddingInsetsContent(t *testing.T) {
+	c := chip.New(chip.Label("x"), chip.Selected(true), chip.Selectable(true)).Padding(4)
+	c.SetBounds(geometry.NewRect(0, 0, 100, 40))
+	canvas := uitest.DrawWidget(c)
+	if len(canvas.RoundRects) == 0 {
+		t.Fatal("expected a filled round rect")
+	}
+	got := canvas.RoundRects[0].Bounds
+	want := geometry.NewRect(4, 4, 92, 32)
+	if got != want {
+		t.Errorf("content bounds = %v, want %v", got, want)
+	}
+}
+
+// --- Selection state mutation ---
+
+func TestSetSelected_Uncontrolled(t *testing.T) {
+	c := chip.New(chip.Selectable(true))
+	c.SetSelected(true)
+	if !c.Selected() {
+		t.Error("SetSelected(true) should select in uncontrolled mode")
+	}
+}
+
+func TestSetSelected_ControlledNoOp(t *testing.T) {
+	sig := state.NewSignal(false)
+	c := chip.New(chip.Selectable(true), chip.SelectedSignal(sig))
+	c.SetSelected(true)
+	if c.Selected() {
+		t.Error("SetSelected should be a no-op when selection is signal-controlled")
+	}
+}
+
+// --- Events ---
+
+func TestClick_ActionChipFiresOnClick(t *testing.T) {
+	clicked := false
+	c := chip.New(chip.Label("Go"), chip.OnClick(func() { clicked = true }))
+	c.SetBounds(geometry.NewRect(0, 0, 80, 32))
+	if !uitest.SimulateClick(c, 10, 10) {
+		t.Error("press should be consumed")
+	}
+	if !clicked {
+		t.Error("OnClick should fire on click")
+	}
+}
+
+func TestClick_FilterChipTogglesAndNotifies(t *testing.T) {
+	var got bool
+	var fired int
+	c := chip.New(chip.Label("Filter"), chip.Selectable(true),
+		chip.OnSelectedChanged(func(sel bool) { got = sel; fired++ }))
+	c.SetBounds(geometry.NewRect(0, 0, 80, 32))
+
+	uitest.SimulateClick(c, 10, 10)
+	if fired != 1 || !got {
+		t.Errorf("after first click: fired=%d got=%v, want 1/true", fired, got)
+	}
+	if !c.Selected() {
+		t.Error("filter chip should be selected after first click")
+	}
+
+	uitest.SimulateClick(c, 10, 10)
+	if fired != 2 || got {
+		t.Errorf("after second click: fired=%d got=%v, want 2/false", fired, got)
+	}
+	if c.Selected() {
+		t.Error("filter chip should be deselected after second click")
+	}
+}
+
+func TestClick_FilterControlledDoesNotMutateLocal(t *testing.T) {
+	sig := state.NewSignal(false)
+	var notified bool
+	c := chip.New(chip.Selectable(true), chip.SelectedSignal(sig),
+		chip.OnSelectedChanged(func(sel bool) { notified = sel }))
+	c.SetBounds(geometry.NewRect(0, 0, 80, 32))
+
+	uitest.SimulateClick(c, 10, 10)
+	if !notified {
+		t.Error("OnSelectedChanged should report new state true")
+	}
+	// Controlled: local state stays in sync with the (unchanged) signal.
+	if c.Selected() {
+		t.Error("controlled chip should not flip local state; owner updates the signal")
+	}
+}
+
+func TestClick_DisabledIgnored(t *testing.T) {
+	clicked := false
+	c := chip.New(chip.Disabled(true), chip.OnClick(func() { clicked = true }))
+	c.SetBounds(geometry.NewRect(0, 0, 80, 32))
+	if uitest.SimulateClick(c, 10, 10) {
+		t.Error("disabled chip should not consume events")
+	}
+	if clicked {
+		t.Error("disabled chip should not fire OnClick")
+	}
+}
+
+func TestMouseRelease_OutsideDoesNotActivate(t *testing.T) {
+	clicked := false
+	c := chip.New(chip.OnClick(func() { clicked = true }))
+	c.SetBounds(geometry.NewRect(0, 0, 80, 32))
+	ctx := uitest.NewMockContext()
+	c.Event(ctx, uitest.Click(10, 10))     // press inside
+	c.Event(ctx, uitest.Release(200, 200)) // release outside
+	if clicked {
+		t.Error("release outside bounds should not activate")
+	}
+}
+
+func TestMousePress_NonLeftIgnored(t *testing.T) {
+	c := chip.New()
+	c.SetBounds(geometry.NewRect(0, 0, 80, 32))
+	ctx := uitest.NewMockContext()
+	if c.Event(ctx, uitest.RightClick(10, 10)) {
+		t.Error("right click press should not be consumed")
+	}
+}
+
+func TestHover_SetsCursorAndConsumes(t *testing.T) {
+	c := chip.New()
+	c.SetBounds(geometry.NewRect(0, 0, 80, 32))
+	ctx := uitest.NewMockContext()
+	if !c.Event(ctx, uitest.MouseEnter(10, 10)) {
+		t.Error("MouseEnter should be consumed")
+	}
+	uitest.AssertCursor(t, ctx, widget.CursorPointer)
+	if !c.Event(ctx, uitest.MouseLeave(10, 10)) {
+		t.Error("MouseLeave should be consumed")
+	}
+	uitest.AssertCursor(t, ctx, widget.CursorDefault)
+}
+
+func TestKeyboard_ActivatesWhenFocused(t *testing.T) {
+	for _, key := range []event.Key{event.KeyEnter, event.KeySpace} {
+		clicked := false
+		c := chip.New(chip.OnClick(func() { clicked = true }))
+		c.SetFocused(true)
+		ctx := uitest.NewMockContext()
+		c.Event(ctx, uitest.KeyPress(key, event.ModNone))
+		c.Event(ctx, uitest.KeyRelease(key, event.ModNone))
+		if !clicked {
+			t.Errorf("key %v should activate a focused chip", key)
+		}
+	}
+}
+
+func TestKeyboard_IgnoredWhenNotFocused(t *testing.T) {
+	clicked := false
+	c := chip.New(chip.OnClick(func() { clicked = true }))
+	ctx := uitest.NewMockContext()
+	if c.Event(ctx, uitest.KeyPress(event.KeyEnter, event.ModNone)) {
+		t.Error("unfocused chip should not consume key events")
+	}
+	if clicked {
+		t.Error("unfocused chip should not activate")
+	}
+}
+
+func TestChildren_Nil(t *testing.T) {
+	if chip.New().Children() != nil {
+		t.Error("chip should have no children")
+	}
+}
+
+// --- Custom painter ---
+
+type recordPainter struct{ last chip.PaintState }
+
+func (p *recordPainter) PaintChip(_ widget.Canvas, ps chip.PaintState) { p.last = ps }
+
+func TestPainterOpt_ReceivesState(t *testing.T) {
+	p := &recordPainter{}
+	c := chip.New(chip.Label("Z"), chip.Selectable(true), chip.Selected(true), chip.PainterOpt(p))
+	drawAt(c)
+	if p.last.Label != "Z" || !p.last.Selected || !p.last.Selectable {
+		t.Errorf("painter state = %+v, want Label=Z Selected Selectable", p.last)
+	}
+}
+
+func TestDefaultPainter_EmptyBoundsNoOp(t *testing.T) {
+	canvas := &uitest.MockCanvas{}
+	chip.DefaultPainter{}.PaintChip(canvas, chip.PaintState{Label: "x"})
+	if canvas.TotalDrawCalls() != 0 {
+		t.Errorf("empty bounds draw calls = %d, want 0", canvas.TotalDrawCalls())
+	}
+}
+
+// --- Mount / signals ---
+
+type mockScheduler struct{ dirtyCount int }
+
+func (s *mockScheduler) MarkDirty(_ widget.Widget) { s.dirtyCount++ }
+
+func mountWith(t *testing.T, c *chip.Widget) *mockScheduler {
+	t.Helper()
+	sched := &mockScheduler{}
+	ctx := widget.NewContext()
+	ctx.SetScheduler(sched)
+	c.Mount(ctx)
+	return sched
+}
+
+func TestMount_LabelSignalNotifies(t *testing.T) {
+	sig := state.NewSignal("a")
+	c := chip.New(chip.LabelSignal(sig))
+	sched := mountWith(t, c)
+	sig.Set("b")
+	if sched.dirtyCount == 0 {
+		t.Error("label change should notify scheduler")
+	}
+}
+
+func TestMount_ReadonlyLabelSignalNotifies(t *testing.T) {
+	sig := state.NewSignal("a")
+	c := chip.New(chip.LabelReadonlySignal(sig))
+	sched := mountWith(t, c)
+	sig.Set("b")
+	if sched.dirtyCount == 0 {
+		t.Error("readonly label change should notify scheduler")
+	}
+}
+
+func TestMount_SelectedSignalNotifies(t *testing.T) {
+	sig := state.NewSignal(false)
+	c := chip.New(chip.Selectable(true), chip.SelectedSignal(sig))
+	sched := mountWith(t, c)
+	sig.Set(true)
+	if sched.dirtyCount == 0 {
+		t.Error("selected change should notify scheduler")
+	}
+}
+
+func TestMount_ReadonlySelectedSignalNotifies(t *testing.T) {
+	sig := state.NewSignal(false)
+	c := chip.New(chip.Selectable(true), chip.SelectedReadonlySignal(sig))
+	sched := mountWith(t, c)
+	sig.Set(true)
+	if sched.dirtyCount == 0 {
+		t.Error("readonly selected change should notify scheduler")
+	}
+}
+
+func TestMount_DisabledSignalNotifies(t *testing.T) {
+	sig := state.NewSignal(false)
+	c := chip.New(chip.DisabledSignal(sig))
+	sched := mountWith(t, c)
+	sig.Set(true)
+	if sched.dirtyCount == 0 {
+		t.Error("disabled change should notify scheduler")
+	}
+}
+
+func TestMount_ReadonlyDisabledSignalNotifies(t *testing.T) {
+	sig := state.NewSignal(false)
+	c := chip.New(chip.DisabledReadonlySignal(sig))
+	sched := mountWith(t, c)
+	sig.Set(true)
+	if sched.dirtyCount == 0 {
+		t.Error("readonly disabled change should notify scheduler")
+	}
+}
+
+func TestMount_NilSchedulerNoPanic(t *testing.T) {
+	c := chip.New(chip.LabelSignal(state.NewSignal("a")))
+	c.Mount(widget.NewContext()) // scheduler nil; must not panic
+}
+
+func TestUnmount_CleanupStopsNotifications(t *testing.T) {
+	sig := state.NewSignal("a")
+	c := chip.New(chip.LabelSignal(sig))
+	sched := mountWith(t, c)
+	c.CleanupBindings()
+	c.Unmount()
+	sched.dirtyCount = 0
+	sig.Set("z")
+	if sched.dirtyCount > 0 {
+		t.Error("scheduler should not be notified after cleanup")
+	}
+}
+
+// --- Fluent & interface compliance ---
+
+func TestPadding_Chaining(t *testing.T) {
+	c := chip.New()
+	if c.Padding(2) != c {
+		t.Error("Padding should return the same widget")
+	}
+}
+
+func TestWidget_ImplementsInterfaces(t *testing.T) {
+	var _ widget.Widget = chip.New()
+	var _ widget.Focusable = chip.New()
+	var _ widget.Lifecycle = chip.New()
+}
+
+// --- Additional painter / event branch coverage ---
+
+func TestDraw_UnselectedColorSchemeOverride(t *testing.T) {
+	scheme := chip.ChipColorScheme{
+		Background: widget.Hex(0x112233), // opaque -> triggers fill path
+		Border:     widget.Hex(0x445566),
+		Label:      widget.Hex(0x778899),
+	}
+	canvas := drawAt(chip.New(chip.Label("x"), chip.ColorSchemeOpt(scheme)))
+	if len(canvas.RoundRects) == 0 {
+		t.Fatal("opaque scheme background should produce a fill")
+	}
+	uitest.AssertColorEqual(t, canvas.RoundRects[0].Color, widget.Hex(0x112233))
+	if len(canvas.StrokeRoundRects) == 0 {
+		t.Fatal("unselected chip should stroke a border")
+	}
+	uitest.AssertColorEqual(t, canvas.StrokeRoundRects[0].Color, widget.Hex(0x445566))
+}
+
+func TestDraw_DisabledColorSchemeOverride(t *testing.T) {
+	scheme := chip.ChipColorScheme{
+		DisabledBackground: widget.Hex(0xABCDEF),
+		DisabledLabel:      widget.Hex(0x123456),
+	}
+	canvas := drawAt(chip.New(chip.Label("x"), chip.Disabled(true), chip.ColorSchemeOpt(scheme)))
+	if len(canvas.RoundRects) == 0 {
+		t.Fatal("disabled chip should fill a background")
+	}
+	uitest.AssertColorEqual(t, canvas.RoundRects[0].Color, widget.Hex(0xABCDEF))
+}
+
+func TestDraw_PressedAddsStateLayer(t *testing.T) {
+	c := chip.New(chip.Label("Tag"), chip.Selectable(true), chip.Selected(true))
+	base := drawAt(c)
+	baseFills := len(base.RoundRects)
+
+	c.SetBounds(geometry.NewRect(0, 0, 80, 32))
+	c.Event(uitest.NewMockContext(), uitest.Click(10, 10)) // press -> statePressed
+	pressed := uitest.DrawWidget(c)
+	if len(pressed.RoundRects) <= baseFills {
+		t.Errorf("pressed fills = %d, want > base %d (state layer)", len(pressed.RoundRects), baseFills)
+	}
+}
+
+func TestEvent_NonMouseNonKeyIgnored(t *testing.T) {
+	c := chip.New()
+	c.SetBounds(geometry.NewRect(0, 0, 80, 32))
+	if c.Event(uitest.NewMockContext(), uitest.WheelScroll(10, 10, 1)) {
+		t.Error("wheel events should not be consumed by a chip")
+	}
+}
+
+func TestKeyboard_OtherKeyIgnored(t *testing.T) {
+	c := chip.New()
+	c.SetFocused(true)
+	if c.Event(uitest.NewMockContext(), uitest.KeyPress(event.KeyTab, event.ModNone)) {
+		t.Error("non-activation key should not be consumed")
+	}
+}
+
+func TestKeyboard_RepeatEventIgnored(t *testing.T) {
+	c := chip.New()
+	c.SetFocused(true)
+	// A key-repeat for Enter is neither an initial press nor a release;
+	// handleActivationKey should ignore it.
+	repeat := event.NewKeyEvent(event.KeyRepeat, event.KeyEnter, 0, event.ModNone)
+	if c.Event(uitest.NewMockContext(), repeat) {
+		t.Error("key repeat event should not be consumed")
+	}
+}

--- a/core/chip/config.go
+++ b/core/chip/config.go
@@ -1,0 +1,91 @@
+package chip
+
+import (
+	"github.com/gogpu/ui/state"
+	"github.com/gogpu/ui/widget"
+)
+
+// config holds the chip's configuration, set at construction time via options.
+type config struct {
+	label                  string
+	labelFn                func() string
+	labelSignal            state.Signal[string]
+	readonlyLabelSignal    state.ReadonlySignal[string]
+	selectable             bool
+	selected               bool
+	selectedFn             func() bool
+	selectedSignal         state.Signal[bool]
+	readonlySelectedSignal state.ReadonlySignal[bool]
+	onClick                func()
+	onSelectedChanged      func(bool)
+	disabled               bool
+	disabledFn             func() bool
+	disabledSignal         state.Signal[bool]
+	readonlyDisabledSignal state.ReadonlySignal[bool]
+	colorScheme            ChipColorScheme
+	painter                Painter
+}
+
+// ResolvedLabel returns the current display label.
+// Priority: ReadonlySignal > Signal > Fn > Static.
+func (c *config) ResolvedLabel() string {
+	if c.readonlyLabelSignal != nil {
+		return c.readonlyLabelSignal.Get()
+	}
+	if c.labelSignal != nil {
+		return c.labelSignal.Get()
+	}
+	if c.labelFn != nil {
+		return c.labelFn()
+	}
+	return c.label
+}
+
+// ResolvedSelected returns the current selected state.
+// Priority: ReadonlySignal > Signal > Fn > Static.
+func (c *config) ResolvedSelected() bool {
+	if c.readonlySelectedSignal != nil {
+		return c.readonlySelectedSignal.Get()
+	}
+	if c.selectedSignal != nil {
+		return c.selectedSignal.Get()
+	}
+	if c.selectedFn != nil {
+		return c.selectedFn()
+	}
+	return c.selected
+}
+
+// selectedIsDynamic reports whether the selected state is driven by an
+// external source (function or signal). When false, the chip owns its
+// selected state and may toggle it directly (uncontrolled mode).
+func (c *config) selectedIsDynamic() bool {
+	return c.readonlySelectedSignal != nil || c.selectedSignal != nil || c.selectedFn != nil
+}
+
+// ResolvedDisabled returns the current disabled state.
+// Priority: ReadonlySignal > Signal > Fn > Static.
+func (c *config) ResolvedDisabled() bool {
+	if c.readonlyDisabledSignal != nil {
+		return c.readonlyDisabledSignal.Get()
+	}
+	if c.disabledSignal != nil {
+		return c.disabledSignal.Get()
+	}
+	if c.disabledFn != nil {
+		return c.disabledFn()
+	}
+	return c.disabled
+}
+
+// ChipColorScheme provides theme-derived colors for chip painting.
+// Zero value means the painter should use its built-in defaults.
+type ChipColorScheme struct {
+	Background         widget.Color // unselected fill color
+	Border             widget.Color // unselected outline color
+	Label              widget.Color // unselected label color
+	SelectedBackground widget.Color // selected fill color
+	SelectedLabel      widget.Color // selected label color
+	DisabledBackground widget.Color // fill color when disabled
+	DisabledLabel      widget.Color // label color when disabled
+}

--- a/core/chip/config.go
+++ b/core/chip/config.go
@@ -56,13 +56,6 @@ func (c *config) ResolvedSelected() bool {
 	return c.selected
 }
 
-// selectedIsDynamic reports whether the selected state is driven by an
-// external source (function or signal). When false, the chip owns its
-// selected state and may toggle it directly (uncontrolled mode).
-func (c *config) selectedIsDynamic() bool {
-	return c.readonlySelectedSignal != nil || c.selectedSignal != nil || c.selectedFn != nil
-}
-
 // ResolvedDisabled returns the current disabled state.
 // Priority: ReadonlySignal > Signal > Fn > Static.
 func (c *config) ResolvedDisabled() bool {

--- a/core/chip/doc.go
+++ b/core/chip/doc.go
@@ -21,12 +21,17 @@
 //     and invokes [OnSelectedChanged]. The chip renders a filled background
 //     when selected and an outlined background when not.
 //
-// # Controlled vs uncontrolled selection
+// # Selection write-back
 //
-// When [Selected] is bound to a function or signal, the chip is "controlled":
-// the owner is responsible for updating that source in response to
-// [OnSelectedChanged]. With only a static initial value, the chip is
-// "uncontrolled" and toggles its own internal state on activation.
+// On activation a selectable chip toggles its selected state and writes the
+// new value back to the appropriate source, matching the checkbox widget:
+//
+//   - With a writable [SelectedSignal], the new value is written to the signal
+//     (two-way binding).
+//   - With only a static value, the chip updates its own internal state.
+//   - With a read-only source ([SelectedFn] or [SelectedReadonlySignal]), the
+//     chip leaves the source untouched; the owner is responsible for updating
+//     it in response to [OnSelectedChanged].
 //
 // # Visual Style
 //

--- a/core/chip/doc.go
+++ b/core/chip/doc.go
@@ -1,0 +1,49 @@
+// Package chip provides a compact chip widget for tags, filters, and inline
+// actions, following the Material 3 chip guidelines.
+//
+// A chip is a small, interactive, pill-shaped element. It can act as a simple
+// action (assist/suggestion chip) or as a toggleable filter (filter chip).
+//
+// Construction uses functional options for immutable configuration, while
+// fluent methods handle mutable styling:
+//
+//	c := chip.New(
+//	    chip.Label("In stock"),
+//	    chip.Selectable(true),
+//	    chip.OnSelectedChanged(func(sel bool) { applyFilter(sel) }),
+//	).Padding(2)
+//
+// # Modes
+//
+//   - Action chip (default): clicking invokes the [OnClick] handler. Use for
+//     assist or suggestion chips.
+//   - Filter chip ([Selectable] is true): clicking toggles the selected state
+//     and invokes [OnSelectedChanged]. The chip renders a filled background
+//     when selected and an outlined background when not.
+//
+// # Controlled vs uncontrolled selection
+//
+// When [Selected] is bound to a function or signal, the chip is "controlled":
+// the owner is responsible for updating that source in response to
+// [OnSelectedChanged]. With only a static initial value, the chip is
+// "uncontrolled" and toggles its own internal state on activation.
+//
+// # Visual Style
+//
+// The visual rendering is provided by a [Painter] implementation. Each design
+// system (Material 3, Fluent, Cupertino) may supply its own painter. If no
+// painter is set, [DefaultPainter] is used.
+//
+// # Signal Binding
+//
+// Chip properties can be bound to reactive signals from the [state] package:
+//
+//   - [LabelSignal] / [LabelReadonlySignal] / [LabelFn] -- the label text
+//   - [SelectedSignal] / [SelectedReadonlySignal] / [SelectedFn] -- selected state
+//   - [DisabledSignal] / [DisabledReadonlySignal] / [DisabledFn] -- disabled state
+//
+// # Accessibility
+//
+// A chip is focusable when visible, enabled, and not disabled. It activates on
+// the Enter and Space keys, matching the button widget.
+package chip

--- a/core/chip/event.go
+++ b/core/chip/event.go
@@ -108,10 +108,9 @@ func handleActivationKey(w *Widget, e *event.KeyEvent) bool {
 func activate(w *Widget) {
 	if w.cfg.selectable {
 		newSel := !w.cfg.ResolvedSelected()
-		// Uncontrolled mode: own the selected state when no dynamic source.
-		if !w.cfg.selectedIsDynamic() {
-			w.cfg.selected = newSel
-		}
+		// Two-way: write back to the bound signal (or static field) so the
+		// chip's rendered state stays in sync after the click.
+		w.applySelected(newSel)
 		if w.cfg.onSelectedChanged != nil {
 			w.cfg.onSelectedChanged(newSel)
 		}

--- a/core/chip/event.go
+++ b/core/chip/event.go
@@ -1,0 +1,123 @@
+package chip
+
+import (
+	"github.com/gogpu/ui/event"
+	"github.com/gogpu/ui/widget"
+)
+
+// handleEvent processes input events for the chip widget.
+// It manages hover, press, and keyboard activation states.
+func handleEvent(w *Widget, ctx widget.Context, e event.Event) bool {
+	if w.cfg.ResolvedDisabled() {
+		return false
+	}
+
+	switch ev := e.(type) {
+	case *event.MouseEvent:
+		return handleMouseEvent(w, ctx, ev)
+	case *event.KeyEvent:
+		return handleKeyEvent(w, ev)
+	default:
+		return false
+	}
+}
+
+// handleMouseEvent processes mouse events for hover, press, and click.
+func handleMouseEvent(w *Widget, ctx widget.Context, e *event.MouseEvent) bool {
+	switch e.MouseType {
+	case event.MouseEnter:
+		w.state = stateHover
+		ctx.SetCursor(widget.CursorPointer)
+		w.SetNeedsRedraw(true)
+		ctx.InvalidateRect(w.Bounds())
+		return true
+
+	case event.MouseLeave:
+		w.state = stateNormal
+		ctx.SetCursor(widget.CursorDefault)
+		w.SetNeedsRedraw(true)
+		ctx.InvalidateRect(w.Bounds())
+		return true
+
+	case event.MousePress:
+		if e.Button != event.ButtonLeft {
+			return false
+		}
+		w.state = statePressed
+		ctx.RequestFocus(w)
+		w.SetNeedsRedraw(true)
+		ctx.InvalidateRect(w.Bounds())
+		return true
+
+	case event.MouseRelease:
+		if e.Button != event.ButtonLeft {
+			return false
+		}
+		wasPressed := w.state == statePressed
+		inside := w.Bounds().Contains(e.Position)
+		if inside {
+			w.state = stateHover
+		} else {
+			w.state = stateNormal
+		}
+		w.SetNeedsRedraw(true)
+		ctx.InvalidateRect(w.Bounds())
+		if wasPressed && inside {
+			activate(w)
+		}
+		return true
+
+	default:
+		return false
+	}
+}
+
+// handleKeyEvent processes keyboard events for Enter/Space activation.
+func handleKeyEvent(w *Widget, e *event.KeyEvent) bool {
+	if !w.IsFocused() {
+		return false
+	}
+	switch e.Key {
+	case event.KeyEnter, event.KeySpace:
+		return handleActivationKey(w, e)
+	default:
+		return false
+	}
+}
+
+// handleActivationKey processes Enter/Space press and release.
+func handleActivationKey(w *Widget, e *event.KeyEvent) bool {
+	switch e.KeyType {
+	case event.KeyPress:
+		w.state = statePressed
+		return true
+	case event.KeyRelease:
+		wasPressed := w.state == statePressed
+		w.state = stateNormal
+		if wasPressed {
+			activate(w)
+		}
+		return true
+	default:
+		return false
+	}
+}
+
+// activate runs the chip's activation logic: toggling selection for filter
+// chips and invoking the configured handlers.
+func activate(w *Widget) {
+	if w.cfg.selectable {
+		newSel := !w.cfg.ResolvedSelected()
+		// Uncontrolled mode: own the selected state when no dynamic source.
+		if !w.cfg.selectedIsDynamic() {
+			w.cfg.selected = newSel
+		}
+		if w.cfg.onSelectedChanged != nil {
+			w.cfg.onSelectedChanged(newSel)
+		}
+	}
+	if w.cfg.onClick != nil {
+		w.cfg.onClick()
+	}
+	w.SetNeedsRedraw(true)
+}

--- a/core/chip/options.go
+++ b/core/chip/options.go
@@ -1,0 +1,144 @@
+package chip
+
+import (
+	"github.com/gogpu/ui/state"
+)
+
+// Option configures a chip during construction.
+type Option func(*config)
+
+// Label sets the chip's static label text.
+func Label(s string) Option {
+	return func(c *config) {
+		c.label = s
+	}
+}
+
+// LabelFn sets a dynamic label function evaluated on each draw.
+// When set, this takes precedence over the static label but not over
+// a signal set via [LabelSignal] or [LabelReadonlySignal].
+func LabelFn(fn func() string) Option {
+	return func(c *config) {
+		c.labelFn = fn
+	}
+}
+
+// LabelSignal binds the chip's label to a reactive signal.
+// When set, the signal value takes precedence over both [LabelFn] and [Label]
+// but not over [LabelReadonlySignal].
+func LabelSignal(sig state.Signal[string]) Option {
+	return func(c *config) {
+		c.labelSignal = sig
+	}
+}
+
+// LabelReadonlySignal binds the chip's label to a read-only signal.
+// When set, this takes highest precedence over all other label sources.
+func LabelReadonlySignal(sig state.ReadonlySignal[string]) Option {
+	return func(c *config) {
+		c.readonlyLabelSignal = sig
+	}
+}
+
+// Selectable makes the chip toggle a selected state on activation
+// (a filter chip). When false (the default), the chip is an action chip
+// that only invokes its [OnClick] handler.
+func Selectable(enabled bool) Option {
+	return func(c *config) {
+		c.selectable = enabled
+	}
+}
+
+// Selected sets the chip's initial selected state. Only meaningful when
+// [Selectable] is enabled.
+func Selected(sel bool) Option {
+	return func(c *config) {
+		c.selected = sel
+	}
+}
+
+// SelectedFn sets a dynamic selected-state function evaluated on each draw.
+// Using a function (or signal) places the chip in controlled mode: the owner
+// must update the source in response to [OnSelectedChanged].
+func SelectedFn(fn func() bool) Option {
+	return func(c *config) {
+		c.selectedFn = fn
+	}
+}
+
+// SelectedSignal binds the selected state to a reactive signal (controlled mode).
+func SelectedSignal(sig state.Signal[bool]) Option {
+	return func(c *config) {
+		c.selectedSignal = sig
+	}
+}
+
+// SelectedReadonlySignal binds the selected state to a read-only signal
+// (controlled mode). Takes highest precedence over all other selected sources.
+func SelectedReadonlySignal(sig state.ReadonlySignal[bool]) Option {
+	return func(c *config) {
+		c.readonlySelectedSignal = sig
+	}
+}
+
+// OnClick sets the handler invoked when the chip is activated by click or
+// keyboard. It fires for both action and filter chips.
+func OnClick(fn func()) Option {
+	return func(c *config) {
+		c.onClick = fn
+	}
+}
+
+// OnSelectedChanged sets the handler invoked when a selectable chip toggles.
+// The argument is the new selected state. Only fires when [Selectable] is set.
+func OnSelectedChanged(fn func(bool)) Option {
+	return func(c *config) {
+		c.onSelectedChanged = fn
+	}
+}
+
+// ColorSchemeOpt sets the color scheme for painting, overriding defaults.
+func ColorSchemeOpt(cs ChipColorScheme) Option {
+	return func(c *config) {
+		c.colorScheme = cs
+	}
+}
+
+// Disabled sets the chip's disabled state.
+func Disabled(d bool) Option {
+	return func(c *config) {
+		c.disabled = d
+	}
+}
+
+// DisabledFn sets a dynamic function for the disabled state.
+// When set, this takes precedence over the static value but not over
+// a signal set via [DisabledSignal].
+func DisabledFn(fn func() bool) Option {
+	return func(c *config) {
+		c.disabledFn = fn
+	}
+}
+
+// DisabledSignal binds the disabled state to a reactive signal.
+func DisabledSignal(sig state.Signal[bool]) Option {
+	return func(c *config) {
+		c.disabledSignal = sig
+	}
+}
+
+// DisabledReadonlySignal binds the disabled state to a read-only signal.
+// Takes highest precedence over all other disabled sources.
+func DisabledReadonlySignal(sig state.ReadonlySignal[bool]) Option {
+	return func(c *config) {
+		c.readonlyDisabledSignal = sig
+	}
+}
+
+// PainterOpt sets the painter used to render the chip. If not set,
+// [DefaultPainter] is used.
+func PainterOpt(p Painter) Option {
+	return func(c *config) {
+		c.painter = p
+	}
+}

--- a/core/chip/painter.go
+++ b/core/chip/painter.go
@@ -1,0 +1,160 @@
+package chip
+
+import (
+	"github.com/gogpu/ui/geometry"
+	"github.com/gogpu/ui/widget"
+)
+
+// Painter draws the visual representation of a chip.
+// Each design system (Material 3, Fluent, Cupertino) provides its own
+// Painter implementation. If no Painter is set, the chip uses [DefaultPainter].
+type Painter interface {
+	PaintChip(canvas widget.Canvas, state PaintState)
+}
+
+// PaintState provides the current chip state to the painter.
+type PaintState struct {
+	Label       string          // chip label text
+	Bounds      geometry.Rect   // total widget bounds (excludes outer padding)
+	Radius      float32         // corner radius
+	Selectable  bool            // chip toggles a selected state
+	Selected    bool            // chip is currently selected
+	Hovered     bool            // pointer is over the chip
+	Pressed     bool            // chip is being pressed
+	Focused     bool            // chip has keyboard focus
+	Disabled    bool            // chip is disabled
+	ColorScheme ChipColorScheme // theme-derived colors (zero = use defaults)
+}
+
+// DefaultPainter provides a minimal fallback painter with Material-3-flavored
+// styling: an outlined pill when unselected and a filled pill when selected,
+// with a translucent state layer for hover and press.
+type DefaultPainter struct{}
+
+// PaintChip renders the chip. If state.ColorScheme is non-zero, its colors are
+// used instead of the built-in defaults.
+func (p DefaultPainter) PaintChip(canvas widget.Canvas, ps PaintState) {
+	if ps.Bounds.IsEmpty() {
+		return
+	}
+
+	hasScheme := ps.ColorScheme != (ChipColorScheme{})
+	bounds := ps.Bounds
+	radius := ps.Radius
+
+	labelColor := resolveLabelColor(ps, hasScheme)
+
+	switch {
+	case ps.Disabled:
+		canvas.DrawRoundRect(bounds, resolveDisabledBackground(ps, hasScheme), radius)
+	case ps.Selected:
+		canvas.DrawRoundRect(bounds, resolveSelectedBackground(ps, hasScheme), radius)
+	default:
+		// Outlined: optional fill plus a border.
+		if bg := resolveBackground(ps, hasScheme); bg.A > 0 {
+			canvas.DrawRoundRect(bounds, bg, radius)
+		}
+		canvas.StrokeRoundRect(bounds, resolveBorder(ps, hasScheme), radius, borderWidth)
+	}
+
+	// State layer for hover/press (skipped when disabled).
+	if !ps.Disabled {
+		if alpha := stateLayerAlpha(ps); alpha > 0 {
+			canvas.DrawRoundRect(bounds, labelColor.WithAlpha(alpha), radius)
+		}
+	}
+
+	if ps.Label != "" {
+		canvas.DrawText(ps.Label, bounds, defaultFontSize, labelColor, false, widget.TextAlignCenter)
+	}
+
+	if ps.Focused && !ps.Disabled {
+		ringBounds := bounds.Expand(focusRingOffset)
+		canvas.StrokeRoundRect(ringBounds, focusRingColor, radius+focusRingOffset, focusRingStrokeWidth)
+	}
+}
+
+// stateLayerAlpha returns the translucent overlay alpha for the current
+// interaction state, following Material 3 state-layer opacities.
+func stateLayerAlpha(ps PaintState) float32 {
+	switch {
+	case ps.Pressed:
+		return pressStateAlpha
+	case ps.Hovered:
+		return hoverStateAlpha
+	default:
+		return 0
+	}
+}
+
+// Color resolution helpers.
+
+func resolveBackground(ps PaintState, hasScheme bool) widget.Color {
+	if hasScheme {
+		return ps.ColorScheme.Background
+	}
+	return defaultBackground
+}
+
+func resolveBorder(ps PaintState, hasScheme bool) widget.Color {
+	if hasScheme {
+		return ps.ColorScheme.Border
+	}
+	return defaultBorder
+}
+
+func resolveLabelColor(ps PaintState, hasScheme bool) widget.Color {
+	if ps.Disabled {
+		if hasScheme {
+			return ps.ColorScheme.DisabledLabel
+		}
+		return defaultDisabledLabel
+	}
+	if ps.Selected {
+		if hasScheme {
+			return ps.ColorScheme.SelectedLabel
+		}
+		return defaultSelectedLabel
+	}
+	if hasScheme {
+		return ps.ColorScheme.Label
+	}
+	return defaultLabel
+}
+
+func resolveSelectedBackground(ps PaintState, hasScheme bool) widget.Color {
+	if hasScheme {
+		return ps.ColorScheme.SelectedBackground
+	}
+	return defaultSelectedBackground
+}
+
+func resolveDisabledBackground(ps PaintState, hasScheme bool) widget.Color {
+	if hasScheme {
+		return ps.ColorScheme.DisabledBackground
+	}
+	return defaultDisabledBackground
+}
+
+// Painting constants.
+const (
+	borderWidth          float32 = 1
+	focusRingOffset      float32 = 2
+	focusRingStrokeWidth float32 = 2
+	hoverStateAlpha      float32 = 0.08
+	pressStateAlpha      float32 = 0.12
+)
+
+// focusRingColor is the default color for focus indicators.
+var focusRingColor = widget.Hex(0x6750A4).WithAlpha(0.7)
+
+// Default colors for DefaultPainter (Material 3 flavored).
+var (
+	defaultBackground         = widget.RGBA(0, 0, 0, 0) // transparent (outlined)
+	defaultBorder             = widget.Hex(0x79747E)    // M3 outline
+	defaultLabel              = widget.Hex(0x1D1B20)    // M3 on-surface
+	defaultSelectedBackground = widget.Hex(0xE8DEF8)    // M3 secondary container
+	defaultSelectedLabel      = widget.Hex(0x1D192B)    // M3 on-secondary container
+	defaultDisabledBackground = widget.RGBA(0.88, 0.88, 0.88, 1.0)
+	defaultDisabledLabel      = widget.RGBA(0.60, 0.60, 0.60, 1.0)
+)

--- a/core/chip/painter.go
+++ b/core/chip/painter.go
@@ -17,6 +17,7 @@ type PaintState struct {
 	Label       string          // chip label text
 	Bounds      geometry.Rect   // total widget bounds (excludes outer padding)
 	Radius      float32         // corner radius
+	FontSize    float32         // label font size in logical pixels (0 = painter default)
 	Selectable  bool            // chip toggles a selected state
 	Selected    bool            // chip is currently selected
 	Hovered     bool            // pointer is over the chip
@@ -65,7 +66,11 @@ func (p DefaultPainter) PaintChip(canvas widget.Canvas, ps PaintState) {
 	}
 
 	if ps.Label != "" {
-		canvas.DrawText(ps.Label, bounds, defaultFontSize, labelColor, false, widget.TextAlignCenter)
+		fontSize := ps.FontSize
+		if fontSize <= 0 {
+			fontSize = defaultFontSize
+		}
+		canvas.DrawText(ps.Label, bounds, fontSize, labelColor, false, widget.TextAlignCenter)
 	}
 
 	if ps.Focused && !ps.Disabled {


### PR DESCRIPTION
## Summary

Implements the **Chip** widget listed in `ROADMAP.md` → Phase 5 (Low complexity):

> **Chip** — Filter/action chips (M3 spec)

A compact, interactive, pill-shaped element for tags, filters, and inline actions. Event handling mirrors `core/button`; structure mirrors the existing core widgets (functional options + pluggable `Painter` + `DefaultPainter`).

## Behavior

- **Action chip** (default): activation invokes `OnClick` (assist/suggestion chips).
- **Filter chip** (`chip.Selectable(true)`): activation toggles the selected state and invokes `OnSelectedChanged(bool)`. Renders **filled** when selected, **outlined** otherwise.
- **Controlled vs uncontrolled**: with a `SelectedFn`/`SelectedSignal` the chip is controlled (owner updates the source on `OnSelectedChanged`); with only a static initial value it toggles its own state.
- Material 3 **state layers** for hover/press, **keyboard activation** (Enter/Space), **focus ring**, pointer cursor.
- Reactive bindings for `label`, `selected`, and `disabled`.
- Focusable leaf widget; disabled chips ignore all input.

## API sketch

```go
// Action chip
chip.New(chip.Label("Refresh"), chip.OnClick(refresh))

// Filter chip (uncontrolled)
chip.New(chip.Label("In stock"), chip.Selectable(true),
    chip.OnSelectedChanged(func(sel bool) { applyFilter(sel) }))

// Filter chip (controlled by a signal)
sel := state.NewSignal(false)
chip.New(chip.Label("On sale"), chip.Selectable(true),
    chip.SelectedSignal(sel),
    chip.OnSelectedChanged(func(v bool) { sel.Set(v) }))
```

## Files

`core/chip/`: `doc.go`, `config.go`, `options.go`, `painter.go`, `event.go`, `chip.go`, `chip_test.go`.

## Verification

- `go build ./...` — OK
- `go test ./core/chip/ -cover` — **99.0%** statement coverage
- `golangci-lint run ./core/chip/` — **0 issues**
- `gofmt` clean

## Notes

- Same scoping choice as the Badge PR: theme-system painters (M3 / DevTools / Fluent / Cupertino) are intentionally left out to keep the PR focused; the chip is fully functional via `DefaultPainter` and accepts a `ChipColorScheme` for theming. Happy to follow up with per-theme painters.
- Leading/trailing icons and a delete (`x`) affordance are deliberately out of scope for this first cut; they can be layered on once the icon integration approach is agreed.
- Per `CONTRIBUTING.md`, glad to move design discussion to an issue if preferred — opening as a PR since the widget is on the roadmap.