### PR TITLE
feat(widget): layout cache infrastructure (ADR-032 Phase 1)

### DIFF
--- a/app/window.go
+++ b/app/window.go
@@ -316,6 +316,22 @@ func (w *Window) SetRoot(root widget.Widget) {
 		be.SetRepaintBoundary(true)
 	}
 
+	// ADR-032 Phase 1: wire the layout-dirty callback on the root, symmetric
+	// with onBoundaryDirty. When a descendant's MarkNeedsLayout invalidation
+	// propagates up to the root, the Window schedules a layout pass. This is
+	// inert until containers/widgets adopt LayoutChild/MarkNeedsLayout.
+	type layoutDirtyWirer interface {
+		SetOnLayoutDirty(func())
+	}
+	if lw, ok := root.(layoutDirtyWirer); ok {
+		lw.SetOnLayoutDirty(func() {
+			w.needsLayout = true
+			if w.wp != nil {
+				w.wp.RequestRedraw()
+			}
+		})
+	}
+
 	w.needsLayout = true
 	w.needsRedraw = true
 	w.needsFullRepaint = true

--- a/widget/base.go
+++ b/widget/base.go
@@ -89,6 +89,17 @@ type WidgetBase struct {
 	// (e.g., ListView items scrolled outside ScrollView bounds).
 	compositorClip    geometry.Rect
 	hasCompositorClip bool
+
+	// --- Layout cache (ADR-032 Phase 1) ---
+	// Caches the most recent Layout() result keyed by the input constraints so
+	// an unchanged subtree is not re-measured on every relayout pass. This is
+	// the layout-side analog of the RepaintBoundary scene cache above (the
+	// distributed-cache pattern used by Flutter/Android/Qt). The cache is read
+	// and written by [LayoutChild] and invalidated by [WidgetBase.MarkNeedsLayout].
+	layoutCacheValid bool
+	lastConstraints  geometry.Constraints
+	lastSize         geometry.Size
+	onLayoutDirty    func() // Fires when layout invalidation reaches this node (root → Window)
 }
 
 // NewWidgetBase creates a new WidgetBase with default settings.

--- a/widget/layout_cache.go
+++ b/widget/layout_cache.go
@@ -4,11 +4,11 @@ import "github.com/gogpu/ui/geometry"
 
 // Layout caching (ADR-032 Phase 1).
 //
-// These methods implement the layout-side analog of the RepaintBoundary
-// scene cache (see boundary.go). A widget's measured size is cached keyed by
-// the input constraints; [LayoutChild] reuses it when a parent re-measures a
-// child with the same constraints, and [WidgetBase.MarkNeedsLayout] invalidates
-// it when a layout-affecting property changes.
+// These methods implement the layout-side analog of the RepaintBoundary scene
+// cache (see boundary.go). A widget's measured size is cached keyed by the
+// input constraints; [LayoutChild] reuses it when a parent re-measures a child
+// with the same constraints, and [WidgetBase.MarkNeedsLayout] invalidates it
+// when a layout-affecting property changes.
 //
 // Nothing in this package calls [LayoutChild] or [MarkNeedsLayout] yet — the
 // mechanism is wired into containers and widgets in a follow-up. On its own it
@@ -16,75 +16,118 @@ import "github.com/gogpu/ui/geometry"
 
 // MarkNeedsLayout marks this widget's cached layout result as stale and
 // propagates the invalidation up the parent chain, because an ancestor's size
-// generally depends on this subtree's size. Propagation currently reaches the
-// root (a RelayoutBoundary will bound it in Phase 2); the root notifies the
-// Window via the callback registered with [WidgetBase.SetOnLayoutDirty].
+// generally depends on this subtree's size. When the invalidation reaches the
+// root, the Window is notified via the callback registered with
+// [WidgetBase.SetOnLayoutDirty] so it schedules a layout pass.
 //
-// Per ADR-032 GAP-1, this marks paint-dirty on THIS widget only and does NOT
-// propagate paint dirtiness upward. Paint propagation to the nearest
-// RepaintBoundary happens in [LayoutChild] on the cache-miss path, after the
-// widget's Layout has actually run — mirroring Flutter, where markNeedsLayout
-// does not call markNeedsPaint.
+// Idempotency (Flutter object.dart `if (_needsLayout) return`, Android, Yoga):
+// the widget's own valid cache acts as the "clean" marker. If this widget has
+// no valid cache it is already pending relayout, so the call is a no-op; the
+// upward walk likewise stops at the first ancestor that is already invalid (its
+// own ancestors were invalidated by an earlier call). A batch of sibling
+// invalidations therefore costs one full walk plus O(1) per subsequent sibling,
+// and the root callback fires exactly once.
+//
+// Per ADR-032 GAP-1, this marks paint-dirty on THIS widget only. The upward
+// walk clears ancestors' layout caches but does NOT mark them paint-dirty —
+// paint propagation to the nearest RepaintBoundary happens in [LayoutChild] on
+// the cache-miss path, after a widget's Layout actually runs (Flutter:
+// markNeedsLayout does not call markNeedsPaint).
 //
 // Widgets call this when a layout-affecting property changes (text/content,
 // font size, padding, child set, explicit size), as distinct from
 // [WidgetBase.SetNeedsRedraw] which is paint-only.
+//
+// Note: because a valid cache is the "clean" marker, MarkNeedsLayout on a
+// never-laid-out widget is a no-op. That is safe: the first layout is always
+// forced by the Window (SetRoot/resize set needsLayout directly), after which
+// every widget has a cache.
 func (w *WidgetBase) MarkNeedsLayout() {
 	w.mu.Lock()
-	w.needsRedraw = true // self-only paint dirty (GAP-1)
+	if !w.layoutCacheValid {
+		w.mu.Unlock()
+		return // already pending relayout — idempotent
+	}
+	w.layoutCacheValid = false
+	w.lastConstraints = geometry.Constraints{}
+	w.lastSize = geometry.Size{}
+	w.needsRedraw = true // GAP-1: self-only paint dirty
 	parent := w.parent
+	selfCb := w.onLayoutDirty
 	w.mu.Unlock()
 
-	w.InvalidateLayoutCache()
-	invalidateLayoutCacheUpward(parent)
+	rootCb := invalidateLayoutUpward(parent)
+	switch {
+	case selfCb != nil: // this widget is itself the root
+		selfCb()
+	case rootCb != nil:
+		rootCb()
+	}
 }
 
-// InvalidateLayoutCache clears this node's cached layout result and, if this
-// node is the root (has an onLayoutDirty callback), notifies the Window that a
-// layout pass is needed. It does NOT propagate to ancestors — use
-// [WidgetBase.MarkNeedsLayout] for that.
+// invalidateLayoutUpward clears the layout cache on each ancestor (cache only —
+// never paint, preserving GAP-1), stopping at the first ancestor whose cache is
+// already invalid (a prior invalidation already walked its parents). It returns
+// the onLayoutDirty callback of the root if the walk reaches it, so the caller
+// can fire it exactly once after propagation completes.
+func invalidateLayoutUpward(w Widget) func() {
+	type layoutNode interface {
+		IsLayoutCacheValid() bool
+		InvalidateLayoutCache()
+		layoutDirtyCallback() func()
+	}
+	var rootCb func()
+	for w != nil {
+		if n, ok := w.(layoutNode); ok {
+			if !n.IsLayoutCacheValid() {
+				return rootCb // already invalidated up to the root
+			}
+			n.InvalidateLayoutCache()
+			if cb := n.layoutDirtyCallback(); cb != nil {
+				rootCb = cb
+			}
+		}
+		pg, ok := w.(interface{ Parent() Widget })
+		if !ok {
+			return rootCb
+		}
+		w = pg.Parent()
+	}
+	return rootCb
+}
+
+// InvalidateLayoutCache clears this node's cached layout result. It is a pure
+// cache-clearing operation with no side effects beyond zeroing the fields — it
+// does not propagate to ancestors, mark paint-dirty, or fire onLayoutDirty (use
+// [WidgetBase.MarkNeedsLayout] for the full invalidation flow).
 //
 // The whole cache is zeroed, not just the validity flag (Android
 // requestLayout/mMeasureCache.clear pattern), so a missed constraint
 // comparison can never produce a stale hit.
 func (w *WidgetBase) InvalidateLayoutCache() {
 	w.mu.Lock()
+	defer w.mu.Unlock()
 	w.layoutCacheValid = false
 	w.lastConstraints = geometry.Constraints{}
 	w.lastSize = geometry.Size{}
-	cb := w.onLayoutDirty
-	w.mu.Unlock()
-
-	if cb != nil {
-		cb()
-	}
 }
 
-// invalidateLayoutCacheUpward walks the parent chain from the given widget,
-// clearing each ancestor's layout cache. It stops when the chain ends (root).
-// Phase 2 will stop earlier at the nearest RelayoutBoundary.
-func invalidateLayoutCacheUpward(w Widget) {
-	type layoutCacheInvalidator interface{ InvalidateLayoutCache() }
-	for w != nil {
-		if inv, ok := w.(layoutCacheInvalidator); ok {
-			inv.InvalidateLayoutCache()
-		}
-		pg, ok := w.(interface{ Parent() Widget })
-		if !ok {
-			return
-		}
-		w = pg.Parent()
-	}
-}
-
-// SetOnLayoutDirty sets the callback invoked when layout invalidation reaches
-// this node. The Window wires this on the root widget in SetRoot so that a
-// descendant's MarkNeedsLayout schedules a layout pass — the layout-side
-// analog of [WidgetBase.SetOnBoundaryDirty].
+// SetOnLayoutDirty sets the callback invoked once when a layout invalidation
+// reaches this node. The Window wires this on the root widget in SetRoot so a
+// descendant's MarkNeedsLayout schedules a layout pass — the layout-side analog
+// of [WidgetBase.SetOnBoundaryDirty].
 func (w *WidgetBase) SetOnLayoutDirty(fn func()) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 	w.onLayoutDirty = fn
+}
+
+// layoutDirtyCallback returns the registered onLayoutDirty callback (nil on
+// non-root nodes). Used by the upward walk to fire the root notification once.
+func (w *WidgetBase) layoutDirtyCallback() func() {
+	w.mu.RLock()
+	defer w.mu.RUnlock()
+	return w.onLayoutDirty
 }
 
 // IsLayoutCacheValid reports whether this widget currently has a valid cached

--- a/widget/layout_cache.go
+++ b/widget/layout_cache.go
@@ -1,0 +1,117 @@
+package widget
+
+import "github.com/gogpu/ui/geometry"
+
+// Layout caching (ADR-032 Phase 1).
+//
+// These methods implement the layout-side analog of the RepaintBoundary
+// scene cache (see boundary.go). A widget's measured size is cached keyed by
+// the input constraints; [LayoutChild] reuses it when a parent re-measures a
+// child with the same constraints, and [WidgetBase.MarkNeedsLayout] invalidates
+// it when a layout-affecting property changes.
+//
+// Nothing in this package calls [LayoutChild] or [MarkNeedsLayout] yet — the
+// mechanism is wired into containers and widgets in a follow-up. On its own it
+// is inert and cannot change behavior.
+
+// MarkNeedsLayout marks this widget's cached layout result as stale and
+// propagates the invalidation up the parent chain, because an ancestor's size
+// generally depends on this subtree's size. Propagation currently reaches the
+// root (a RelayoutBoundary will bound it in Phase 2); the root notifies the
+// Window via the callback registered with [WidgetBase.SetOnLayoutDirty].
+//
+// Per ADR-032 GAP-1, this marks paint-dirty on THIS widget only and does NOT
+// propagate paint dirtiness upward. Paint propagation to the nearest
+// RepaintBoundary happens in [LayoutChild] on the cache-miss path, after the
+// widget's Layout has actually run — mirroring Flutter, where markNeedsLayout
+// does not call markNeedsPaint.
+//
+// Widgets call this when a layout-affecting property changes (text/content,
+// font size, padding, child set, explicit size), as distinct from
+// [WidgetBase.SetNeedsRedraw] which is paint-only.
+func (w *WidgetBase) MarkNeedsLayout() {
+	w.mu.Lock()
+	w.needsRedraw = true // self-only paint dirty (GAP-1)
+	parent := w.parent
+	w.mu.Unlock()
+
+	w.InvalidateLayoutCache()
+	invalidateLayoutCacheUpward(parent)
+}
+
+// InvalidateLayoutCache clears this node's cached layout result and, if this
+// node is the root (has an onLayoutDirty callback), notifies the Window that a
+// layout pass is needed. It does NOT propagate to ancestors — use
+// [WidgetBase.MarkNeedsLayout] for that.
+//
+// The whole cache is zeroed, not just the validity flag (Android
+// requestLayout/mMeasureCache.clear pattern), so a missed constraint
+// comparison can never produce a stale hit.
+func (w *WidgetBase) InvalidateLayoutCache() {
+	w.mu.Lock()
+	w.layoutCacheValid = false
+	w.lastConstraints = geometry.Constraints{}
+	w.lastSize = geometry.Size{}
+	cb := w.onLayoutDirty
+	w.mu.Unlock()
+
+	if cb != nil {
+		cb()
+	}
+}
+
+// invalidateLayoutCacheUpward walks the parent chain from the given widget,
+// clearing each ancestor's layout cache. It stops when the chain ends (root).
+// Phase 2 will stop earlier at the nearest RelayoutBoundary.
+func invalidateLayoutCacheUpward(w Widget) {
+	type layoutCacheInvalidator interface{ InvalidateLayoutCache() }
+	for w != nil {
+		if inv, ok := w.(layoutCacheInvalidator); ok {
+			inv.InvalidateLayoutCache()
+		}
+		pg, ok := w.(interface{ Parent() Widget })
+		if !ok {
+			return
+		}
+		w = pg.Parent()
+	}
+}
+
+// SetOnLayoutDirty sets the callback invoked when layout invalidation reaches
+// this node. The Window wires this on the root widget in SetRoot so that a
+// descendant's MarkNeedsLayout schedules a layout pass — the layout-side
+// analog of [WidgetBase.SetOnBoundaryDirty].
+func (w *WidgetBase) SetOnLayoutDirty(fn func()) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.onLayoutDirty = fn
+}
+
+// IsLayoutCacheValid reports whether this widget currently has a valid cached
+// layout result. Primarily for tests and the debug verifier.
+func (w *WidgetBase) IsLayoutCacheValid() bool {
+	w.mu.RLock()
+	defer w.mu.RUnlock()
+	return w.layoutCacheValid
+}
+
+// layoutCacheLookup returns the cached size if the cache is valid and was
+// computed for exactly these constraints. Constraints is a value of four
+// float32 fields, so equality is a direct, allocation-free comparison.
+func (w *WidgetBase) layoutCacheLookup(c geometry.Constraints) (geometry.Size, bool) {
+	w.mu.RLock()
+	defer w.mu.RUnlock()
+	if w.layoutCacheValid && w.lastConstraints == c {
+		return w.lastSize, true
+	}
+	return geometry.Size{}, false
+}
+
+// layoutCacheStore records the measured size for the given constraints.
+func (w *WidgetBase) layoutCacheStore(c geometry.Constraints, size geometry.Size) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.lastConstraints = c
+	w.lastSize = size
+	w.layoutCacheValid = true
+}

--- a/widget/layout_cache_test.go
+++ b/widget/layout_cache_test.go
@@ -1,0 +1,283 @@
+package widget_test
+
+import (
+	"testing"
+
+	"github.com/gogpu/ui/event"
+	"github.com/gogpu/ui/geometry"
+	"github.com/gogpu/ui/uitest"
+	"github.com/gogpu/ui/widget"
+)
+
+// clwWidget is a minimal WidgetBase-embedding widget that counts Layout calls
+// and returns a configurable size, for exercising the layout cache.
+type clwWidget struct {
+	widget.WidgetBase
+	size        geometry.Size
+	raw         bool // return size unconstrained (to test the debug constraints assert)
+	layoutCalls int
+}
+
+func (w *clwWidget) Layout(_ widget.Context, c geometry.Constraints) geometry.Size {
+	w.layoutCalls++
+	if w.raw {
+		return w.size
+	}
+	return c.Constrain(w.size)
+}
+func (w *clwWidget) Draw(_ widget.Context, _ widget.Canvas)     {}
+func (w *clwWidget) Event(_ widget.Context, _ event.Event) bool { return false }
+func (w *clwWidget) Children() []widget.Widget                  { return nil }
+
+// noBaseWidget implements Widget without embedding WidgetBase, so it cannot
+// participate in layout caching.
+type noBaseWidget struct{ layoutCalls int }
+
+func (w *noBaseWidget) Layout(_ widget.Context, c geometry.Constraints) geometry.Size {
+	w.layoutCalls++
+	return c.Constrain(geometry.Sz(10, 10))
+}
+func (w *noBaseWidget) Draw(_ widget.Context, _ widget.Canvas)     {}
+func (w *noBaseWidget) Event(_ widget.Context, _ event.Event) bool { return false }
+func (w *noBaseWidget) Children() []widget.Widget                  { return nil }
+
+func looseConstraints() geometry.Constraints {
+	return geometry.Constraints{MinWidth: 0, MaxWidth: 500, MinHeight: 0, MaxHeight: 500}
+}
+
+func newWB() *clwWidget {
+	w := &clwWidget{size: geometry.Sz(100, 50)}
+	w.SetVisible(true)
+	w.SetEnabled(true)
+	return w
+}
+
+// --- Cache hit / miss ---
+
+func TestLayoutChild_CachesOnSameConstraints(t *testing.T) {
+	w := newWB()
+	ctx := uitest.NewMockContext()
+	c := looseConstraints()
+
+	s1 := widget.LayoutChild(w, ctx, c)
+	s2 := widget.LayoutChild(w, ctx, c)
+
+	if w.layoutCalls != 1 {
+		t.Errorf("layoutCalls = %d, want 1 (second call should hit cache)", w.layoutCalls)
+	}
+	if s1 != (geometry.Sz(100, 50)) || s2 != s1 {
+		t.Errorf("sizes = %v, %v, want both (100,50)", s1, s2)
+	}
+	if !w.IsLayoutCacheValid() {
+		t.Error("cache should be valid after a layout")
+	}
+}
+
+func TestLayoutChild_RecomputesOnDifferentConstraints(t *testing.T) {
+	w := newWB()
+	ctx := uitest.NewMockContext()
+
+	widget.LayoutChild(w, ctx, looseConstraints())
+	widget.LayoutChild(w, ctx, geometry.Constraints{MaxWidth: 300, MaxHeight: 300})
+
+	if w.layoutCalls != 2 {
+		t.Errorf("layoutCalls = %d, want 2 (different constraints miss)", w.layoutCalls)
+	}
+}
+
+func TestLayoutChild_NilReturnsZero(t *testing.T) {
+	if got := widget.LayoutChild(nil, uitest.NewMockContext(), looseConstraints()); got != (geometry.Size{}) {
+		t.Errorf("LayoutChild(nil) = %v, want zero", got)
+	}
+}
+
+func TestLayoutChild_NonCacheableAlwaysLayouts(t *testing.T) {
+	w := &noBaseWidget{}
+	ctx := uitest.NewMockContext()
+	c := looseConstraints()
+
+	widget.LayoutChild(w, ctx, c)
+	widget.LayoutChild(w, ctx, c)
+
+	if w.layoutCalls != 2 {
+		t.Errorf("layoutCalls = %d, want 2 (no caching without WidgetBase)", w.layoutCalls)
+	}
+}
+
+// --- Invalidation ---
+
+func TestMarkNeedsLayout_InvalidatesCache(t *testing.T) {
+	w := newWB()
+	ctx := uitest.NewMockContext()
+	c := looseConstraints()
+
+	widget.LayoutChild(w, ctx, c)
+	w.MarkNeedsLayout()
+
+	if w.IsLayoutCacheValid() {
+		t.Error("cache should be invalid after MarkNeedsLayout")
+	}
+	widget.LayoutChild(w, ctx, c)
+	if w.layoutCalls != 2 {
+		t.Errorf("layoutCalls = %d, want 2 (recompute after invalidation)", w.layoutCalls)
+	}
+}
+
+func TestInvalidateLayoutCache_DoesNotPropagateUpward(t *testing.T) {
+	parent, child := newWB(), newWB()
+	child.SetParent(parent)
+	ctx := uitest.NewMockContext()
+	c := looseConstraints()
+
+	widget.LayoutChild(parent, ctx, c)
+	widget.LayoutChild(child, ctx, c)
+
+	child.InvalidateLayoutCache() // self-only
+
+	if child.IsLayoutCacheValid() {
+		t.Error("child cache should be invalid")
+	}
+	if !parent.IsLayoutCacheValid() {
+		t.Error("InvalidateLayoutCache must not touch ancestors")
+	}
+}
+
+func TestMarkNeedsLayout_PropagatesCacheInvalidationUpward(t *testing.T) {
+	parent, child := newWB(), newWB()
+	child.SetParent(parent)
+	ctx := uitest.NewMockContext()
+	c := looseConstraints()
+
+	widget.LayoutChild(parent, ctx, c)
+	widget.LayoutChild(child, ctx, c)
+
+	child.MarkNeedsLayout()
+
+	if parent.IsLayoutCacheValid() {
+		t.Error("ancestor cache must be invalidated (its size depends on the child)")
+	}
+}
+
+func TestMarkNeedsLayout_StopsAtNonWidgetBaseAncestor(t *testing.T) {
+	// A parent that implements Widget but not WidgetBase: it neither caches
+	// nor exposes Parent(), so upward propagation must skip it and stop.
+	child := newWB()
+	child.SetParent(&noBaseWidget{})
+	// Must not panic and must still invalidate the child itself.
+	widget.LayoutChild(child, uitest.NewMockContext(), looseConstraints())
+	child.MarkNeedsLayout()
+	if child.IsLayoutCacheValid() {
+		t.Error("child cache should be invalid after MarkNeedsLayout")
+	}
+}
+
+// --- GAP-1: paint dirty timing ---
+
+func TestMarkNeedsLayout_MarksPaintSelfOnly(t *testing.T) {
+	parent, child := newWB(), newWB()
+	child.SetParent(parent)
+	parent.SetNeedsRedraw(false)
+	child.SetNeedsRedraw(false)
+
+	child.MarkNeedsLayout()
+
+	if !child.NeedsRedraw() {
+		t.Error("MarkNeedsLayout should mark the widget itself paint-dirty")
+	}
+	if parent.NeedsRedraw() {
+		t.Error("GAP-1: MarkNeedsLayout must NOT propagate paint dirtiness to the parent")
+	}
+}
+
+func TestLayoutChild_CacheMissMarksPaint(t *testing.T) {
+	w := newWB()
+	w.SetNeedsRedraw(false)
+	widget.LayoutChild(w, uitest.NewMockContext(), looseConstraints())
+	if !w.NeedsRedraw() {
+		t.Error("cache miss should mark the child paint-dirty (changed subtree repaints)")
+	}
+}
+
+func TestLayoutChild_CacheHitDoesNotMarkPaint(t *testing.T) {
+	w := newWB()
+	ctx := uitest.NewMockContext()
+	c := looseConstraints()
+	widget.LayoutChild(w, ctx, c) // miss → marks paint
+	w.SetNeedsRedraw(false)
+	widget.LayoutChild(w, ctx, c) // hit
+	if w.NeedsRedraw() {
+		t.Error("cache hit must not mark paint-dirty (unchanged subtree)")
+	}
+}
+
+// --- Root callback wiring ---
+
+func TestOnLayoutDirty_FiresWhenInvalidationReachesRoot(t *testing.T) {
+	root, child := newWB(), newWB()
+	child.SetParent(root)
+	fired := 0
+	root.SetOnLayoutDirty(func() { fired++ })
+
+	child.MarkNeedsLayout()
+	if fired != 1 {
+		t.Errorf("onLayoutDirty fired %d times, want 1 (reached root via propagation)", fired)
+	}
+
+	root.MarkNeedsLayout()
+	if fired != 2 {
+		t.Errorf("onLayoutDirty fired %d times, want 2 (root invalidating itself)", fired)
+	}
+}
+
+// --- Debug verifier (ADR-032 Phase 1c) ---
+
+func TestDebugVerifier_PanicsOnStaleCache(t *testing.T) {
+	defer widget.SetLayoutDebug(widget.SetLayoutDebug(true))
+	w := newWB()
+	ctx := uitest.NewMockContext()
+	c := looseConstraints()
+
+	widget.LayoutChild(w, ctx, c) // cache (100,50)
+	w.size = geometry.Sz(200, 50) // layout-affecting change WITHOUT MarkNeedsLayout
+
+	defer func() {
+		if recover() == nil {
+			t.Error("expected panic: stale cache hit should be caught by the verifier")
+		}
+	}()
+	widget.LayoutChild(w, ctx, c) // hit → verifier recomputes → mismatch → panic
+}
+
+func TestDebugVerifier_NoPanicWhenStable(t *testing.T) {
+	defer widget.SetLayoutDebug(widget.SetLayoutDebug(true))
+	w := newWB()
+	ctx := uitest.NewMockContext()
+	c := looseConstraints()
+
+	widget.LayoutChild(w, ctx, c)
+	widget.LayoutChild(w, ctx, c) // hit, verified, matches — must not panic
+}
+
+func TestDebugVerifier_PanicsOnConstraintsViolation(t *testing.T) {
+	defer widget.SetLayoutDebug(widget.SetLayoutDebug(true))
+	w := &clwWidget{size: geometry.Sz(1000, 1000), raw: true} // ignores constraints
+	w.SetVisible(true)
+	ctx := uitest.NewMockContext()
+	tight := geometry.Constraints{MinWidth: 0, MaxWidth: 10, MinHeight: 0, MaxHeight: 10}
+
+	defer func() {
+		if recover() == nil {
+			t.Error("expected panic: returned size violates constraints")
+		}
+	}()
+	widget.LayoutChild(w, ctx, tight) // miss → assertConstraintsSatisfied → panic
+}
+
+func TestSetLayoutDebug_RestoresPrevious(t *testing.T) {
+	prev := widget.SetLayoutDebug(true)
+	if widget.SetLayoutDebug(prev) != true {
+		t.Error("SetLayoutDebug should return the value it just set")
+	}
+	// Leave the flag as it started.
+	widget.SetLayoutDebug(prev)
+}

--- a/widget/layout_cache_test.go
+++ b/widget/layout_cache_test.go
@@ -176,6 +176,11 @@ func TestMarkNeedsLayout_StopsAtNonWidgetBaseAncestor(t *testing.T) {
 func TestMarkNeedsLayout_MarksPaintSelfOnly(t *testing.T) {
 	parent, child := newWB(), newWB()
 	child.SetParent(parent)
+	ctx := uitest.NewMockContext()
+	c := looseConstraints()
+	// A valid cache is the "clean" marker the guard checks, so lay both out first.
+	widget.LayoutChild(parent, ctx, c)
+	widget.LayoutChild(child, ctx, c)
 	parent.SetNeedsRedraw(false)
 	child.SetNeedsRedraw(false)
 
@@ -185,7 +190,10 @@ func TestMarkNeedsLayout_MarksPaintSelfOnly(t *testing.T) {
 		t.Error("MarkNeedsLayout should mark the widget itself paint-dirty")
 	}
 	if parent.NeedsRedraw() {
-		t.Error("GAP-1: MarkNeedsLayout must NOT propagate paint dirtiness to the parent")
+		t.Error("GAP-1: the upward walk must clear the parent's cache but NOT mark it paint-dirty")
+	}
+	if parent.IsLayoutCacheValid() {
+		t.Error("the parent's layout cache should be invalidated (its size depends on the child)")
 	}
 }
 
@@ -215,17 +223,67 @@ func TestLayoutChild_CacheHitDoesNotMarkPaint(t *testing.T) {
 func TestOnLayoutDirty_FiresWhenInvalidationReachesRoot(t *testing.T) {
 	root, child := newWB(), newWB()
 	child.SetParent(root)
+	ctx := uitest.NewMockContext()
+	c := looseConstraints()
 	fired := 0
 	root.SetOnLayoutDirty(func() { fired++ })
 
-	child.MarkNeedsLayout()
+	widget.LayoutChild(root, ctx, c)
+	widget.LayoutChild(child, ctx, c)
+
+	child.MarkNeedsLayout() // propagates to root → fires once
 	if fired != 1 {
 		t.Errorf("onLayoutDirty fired %d times, want 1 (reached root via propagation)", fired)
 	}
 
-	root.MarkNeedsLayout()
+	widget.LayoutChild(root, ctx, c) // re-validate root (it was invalidated above)
+	root.MarkNeedsLayout()           // root invalidating itself → fires once
 	if fired != 2 {
 		t.Errorf("onLayoutDirty fired %d times, want 2 (root invalidating itself)", fired)
+	}
+}
+
+func TestMarkNeedsLayout_SelfGuardIsIdempotent(t *testing.T) {
+	root := newWB()
+	ctx := uitest.NewMockContext()
+	c := looseConstraints()
+	fired := 0
+	root.SetOnLayoutDirty(func() { fired++ })
+
+	widget.LayoutChild(root, ctx, c)
+	root.MarkNeedsLayout() // valid → fires, invalidates
+	root.MarkNeedsLayout() // already invalid → no-op
+	if fired != 1 {
+		t.Errorf("onLayoutDirty fired %d times, want 1 (second call is a no-op)", fired)
+	}
+}
+
+func TestMarkNeedsLayout_SiblingBatchFiresRootOnce(t *testing.T) {
+	// root → box → {c1, c2}. Invalidating both children in a batch must fire the
+	// root callback exactly once; the second child short-circuits at box.
+	root, box, c1, c2 := newWB(), newWB(), newWB(), newWB()
+	box.SetParent(root)
+	c1.SetParent(box)
+	c2.SetParent(box)
+	ctx := uitest.NewMockContext()
+	cc := looseConstraints()
+	fired := 0
+	root.SetOnLayoutDirty(func() { fired++ })
+
+	for _, w := range []*clwWidget{root, box, c1, c2} {
+		widget.LayoutChild(w, ctx, cc)
+	}
+
+	c1.MarkNeedsLayout() // full walk c1→box→root, fires once
+	c2.MarkNeedsLayout() // box already invalid → stops, no extra fire
+
+	if fired != 1 {
+		t.Errorf("onLayoutDirty fired %d times, want 1 (sibling batch coalesces)", fired)
+	}
+	for _, w := range []*clwWidget{box, c1, c2} {
+		if w.IsLayoutCacheValid() {
+			t.Error("all invalidated nodes should have cleared caches")
+		}
 	}
 }
 

--- a/widget/layout_child.go
+++ b/widget/layout_child.go
@@ -1,0 +1,98 @@
+package widget
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/gogpu/ui/geometry"
+)
+
+// layoutDebugEnabled turns on the layout-cache verifier (ADR-032 Phase 1c).
+// Enable with GOGPU_DEBUG_LAYOUT=1. Tests flip it via [SetLayoutDebug].
+var layoutDebugEnabled = os.Getenv("GOGPU_DEBUG_LAYOUT") == "1"
+
+// SetLayoutDebug toggles the layout-cache verifier at runtime and returns the
+// previous value. Intended for tests (so CI can exercise the verifier without
+// an env var); production code uses GOGPU_DEBUG_LAYOUT.
+func SetLayoutDebug(on bool) bool {
+	prev := layoutDebugEnabled
+	layoutDebugEnabled = on
+	return prev
+}
+
+// layoutCacheable is implemented by any widget embedding [WidgetBase] (the
+// cache lives on WidgetBase). Widgets that don't embed it simply never cache.
+type layoutCacheable interface {
+	layoutCacheLookup(geometry.Constraints) (geometry.Size, bool)
+	layoutCacheStore(geometry.Constraints, geometry.Size)
+}
+
+// LayoutChild measures a child widget through the layout cache (ADR-032).
+//
+// Container widgets should call this instead of child.Layout(ctx, constraints)
+// directly, mirroring how [DrawChild] wraps child.Draw. On a cache hit the
+// child's Layout is skipped entirely; on a miss the result is cached and the
+// child's nearest RepaintBoundary is marked dirty (GAP-1: paint propagation
+// happens here, on the miss path, after Layout has run — not in
+// MarkNeedsLayout).
+//
+// It returns the child's size only; positioning (SetBounds) remains the
+// parent's responsibility, exactly as today.
+//
+// A child that does not embed [WidgetBase] (and so cannot cache) is laid out
+// directly every time — same behavior as a plain child.Layout call.
+func LayoutChild(child Widget, ctx Context, constraints geometry.Constraints) geometry.Size {
+	if child == nil {
+		return geometry.Size{}
+	}
+
+	cacher, ok := child.(layoutCacheable)
+	if !ok {
+		return child.Layout(ctx, constraints)
+	}
+
+	if size, hit := cacher.layoutCacheLookup(constraints); hit {
+		if layoutDebugEnabled {
+			verifyLayoutCacheHit(child, ctx, constraints, size)
+		}
+		return size
+	}
+
+	// Cache miss: run layout, cache it, and mark the subtree's boundary dirty
+	// so it repaints (only changed subtrees miss, so only they repaint).
+	size := child.Layout(ctx, constraints)
+	cacher.layoutCacheStore(constraints, size)
+	if r, ok := child.(interface{ SetNeedsRedraw(bool) }); ok {
+		r.SetNeedsRedraw(true)
+	}
+
+	if layoutDebugEnabled {
+		assertConstraintsSatisfied(child, constraints, size)
+	}
+	return size
+}
+
+// verifyLayoutCacheHit re-runs the child's Layout and asserts the result
+// matches the cached value. A mismatch means a layout-affecting change was made
+// without a corresponding MarkNeedsLayout() call — the exact bug class the
+// cache risks. Flutter performs the equivalent assertion in debug builds.
+func verifyLayoutCacheHit(child Widget, ctx Context, c geometry.Constraints, cached geometry.Size) {
+	fresh := child.Layout(ctx, c)
+	if fresh != cached {
+		panic(fmt.Sprintf(
+			"layout cache stale for %T: cached %v but recomputed %v for constraints %v — "+
+				"a layout-affecting mutation is missing a MarkNeedsLayout() call",
+			child, cached, fresh, c))
+	}
+	assertConstraintsSatisfied(child, c, fresh)
+}
+
+// assertConstraintsSatisfied panics if the measured size violates the input
+// constraints (Flutter debugAssertDoesMeetConstraints). Debug-only.
+func assertConstraintsSatisfied(child Widget, c geometry.Constraints, size geometry.Size) {
+	if !c.IsSatisfiedBy(size) {
+		panic(fmt.Sprintf(
+			"%T returned size %v that does not satisfy constraints %v",
+			child, size, c))
+	}
+}


### PR DESCRIPTION
Implements **PR 1 (infrastructure)** of the ADR-032 layout-caching plan agreed in #142. Purely additive — nothing calls `LayoutChild`/`MarkNeedsLayout` in production yet (container/widget conversion is PR 2), so this **cannot change behavior**; it only lands the mechanism + tests.

## What's here

- **WidgetBase fields** (`layoutCacheValid`, `lastConstraints`, `lastSize`, `onLayoutDirty`) + methods `MarkNeedsLayout()`, `InvalidateLayoutCache()`, `SetOnLayoutDirty()`, `IsLayoutCacheValid()`, and unexported `layoutCacheLookup/Store`. Mirrors the existing `isRepaintBoundary` / `onBoundaryDirty` / `propagateDirtyUpward` machinery (base.go, boundary.go).
- **`widget.LayoutChild(child, ctx, constraints) geometry.Size`** — the choke point containers will call instead of `child.Layout`, symmetric with `DrawChild` (draw.go:102). Returns `Size` only (Option A). A child that doesn't embed `WidgetBase` is laid out directly every time (graceful fallback).
- **Debug verifier** (`GOGPU_DEBUG_LAYOUT=1`, or `widget.SetLayoutDebug` in tests): on a cache hit it re-runs `Layout` and asserts equality (catches a layout-affecting mutation missing its `MarkNeedsLayout`), plus a `constraints.IsSatisfiedBy(size)` assert on the miss path (Flutter `debugAssertDoesMeetConstraints`).
- **Window wiring**: `SetRoot` wires `onLayoutDirty` on the root, symmetric with `onBoundaryDirty` → sets `needsLayout` + `RequestRedraw`.

## Honoring the agreed gaps

- **GAP-1 (paint timing)**: `MarkNeedsLayout` marks paint-dirty **self-only** (`markDirtyLocal`, no upward paint propagation); paint propagation to the nearest RepaintBoundary happens in `LayoutChild` on the **cache-miss** path, after `Layout` returns. Matches Flutter (markNeedsLayout ≠ markNeedsPaint).
- **GAP-2 (layout-in-Draw)**: only adds the helper. The `listview`/`gridview` layout-in-Draw sites and the offscreen entry points stay on direct `child.Layout()` — left for the PR 2 conversion audit.
- **GAP-3 (animation path)**: no animation changes here (Collapsible/Transition restructure is PR 2).
- **Android full-clear**: `MarkNeedsLayout`/`InvalidateLayoutCache` zero `lastConstraints`/`lastSize`, not just the flag.
- **Upward invalidation**: ancestors' caches are cleared up the parent chain (their size depends on the child); stops at root for now (RelayoutBoundary bounds it in Phase 2).

## Verification

- `go build ./...`, `go test ./...` — all green (additive, no behavior change).
- New code: **100%** statement coverage (15 tests covering hit/miss, invalidation, upward propagation, GAP-1 self-only paint, miss-marks-paint/hit-doesn't, root callback, debug verifier stale-panic + constraints-violation + stable-no-panic, non-cacheable fallback, nil child).
- `golangci-lint run ./widget/ ./app/` — 0 issues; `gofmt` clean.

## Next (per #142)

- PR 2: convert the ~30 `child.Layout()` → `LayoutChild()` and 12 `ctx.Invalidate()` → `MarkNeedsLayout()` sites (with the GAP-2/GAP-3 exceptions), restructure Collapsible/Transition animation ticks.
- PR 3: `BindToSchedulerLayout` / `…Func`.
- PR 4: remove the now-unused `internal/layout/Engine`.

I validated correctness via the debug verifier + unit tests; happy to wire the software-rasterization (`createSoftwareDevice`) visual checks you mentioned into PR 2 where real container layout actually runs through the cache.