### PR TITLE
fix(radio): invalidate previously-selected item on selection change (#145)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Layout cache infrastructure** ([#143](https://github.com/gogpu/ui/pull/143), @TimLai666) — ADR-032 Phase 1: per-node constraint cache on WidgetBase, `widget.LayoutChild()` helper (symmetric with DrawChild), `MarkNeedsLayout()` with idempotency guard and upward propagation, `GOGPU_DEBUG_LAYOUT=1` debug verifier. Purely additive — mechanism is inert until containers adopt LayoutChild in Phase 2.
+
+### Fixed
+
+- **Radio group stale selection pixels** ([#145](https://github.com/gogpu/ui/issues/145)) — selecting a new radio button now invalidates both the newly-selected and previously-selected items. Previously only the clicked item was invalidated, causing the old "selected dot" to persist on damage-aware compositors (Wayland, Vulkan `VK_KHR_incremental_present`, DX12 `FLIP_SEQUENTIAL`). Also expanded invalidation rect to cover focus ring area (drawn 2px beyond item bounds).
+
 ## [0.1.35] — 2026-06-21
 
 ### Added

--- a/core/radio/event.go
+++ b/core/radio/event.go
@@ -2,8 +2,27 @@ package radio
 
 import (
 	"github.com/gogpu/ui/event"
+	"github.com/gogpu/ui/geometry"
 	"github.com/gogpu/ui/widget"
 )
+
+// focusRingMargin is the extra space beyond item bounds occupied by the
+// focus ring (offset + half stroke width). InvalidateRect must include
+// this margin so the compositor clears focus ring pixels.
+const focusRingMargin = focusRingOffset + focusRingStrokeWidth/2 + 1
+
+// invalidateItem marks an item for redraw with bounds expanded to cover
+// the focus ring area. Without this expansion, the focus ring (drawn
+// outside item bounds) leaves stale pixels on damage-aware compositors.
+func invalidateItem(it *Item, ctx widget.Context) {
+	it.SetNeedsRedraw(true)
+	b := it.Bounds()
+	expanded := geometry.NewRect(
+		b.Min.X-focusRingMargin, b.Min.Y-focusRingMargin,
+		b.Width()+focusRingMargin*2, b.Height()+focusRingMargin*2,
+	)
+	ctx.InvalidateRect(expanded)
+}
 
 // handleItemEvent processes input events for a single radio item.
 // It manages hover, press, and keyboard activation states.
@@ -29,15 +48,13 @@ func handleItemMouseEvent(it *Item, ctx widget.Context, e *event.MouseEvent) boo
 	case event.MouseEnter:
 		it.state = stateHover
 		ctx.SetCursor(widget.CursorPointer)
-		it.SetNeedsRedraw(true)
-		ctx.InvalidateRect(it.Bounds())
+		invalidateItem(it, ctx)
 		return true
 
 	case event.MouseLeave:
 		it.state = stateNormal
 		ctx.SetCursor(widget.CursorDefault)
-		it.SetNeedsRedraw(true)
-		ctx.InvalidateRect(it.Bounds())
+		invalidateItem(it, ctx)
 		return true
 
 	case event.MousePress:
@@ -46,8 +63,7 @@ func handleItemMouseEvent(it *Item, ctx widget.Context, e *event.MouseEvent) boo
 		}
 		it.state = statePressed
 		ctx.RequestFocus(it)
-		it.SetNeedsRedraw(true)
-		ctx.InvalidateRect(it.Bounds())
+		invalidateItem(it, ctx)
 		return true
 
 	case event.MouseRelease:
@@ -61,10 +77,11 @@ func handleItemMouseEvent(it *Item, ctx widget.Context, e *event.MouseEvent) boo
 		} else {
 			it.state = stateNormal
 		}
-		it.SetNeedsRedraw(true)
-		ctx.InvalidateRect(it.Bounds())
+		invalidateItem(it, ctx)
 		if wasPressed && it.Bounds().Contains(e.Position) {
-			it.group.selectValue(it.value)
+			if prev := it.group.selectValue(it.value); prev != nil {
+				invalidateItem(prev, ctx)
+			}
 		}
 		return true
 
@@ -94,16 +111,16 @@ func handleActivationKey(it *Item, ctx widget.Context, e *event.KeyEvent) bool {
 	switch e.KeyType {
 	case event.KeyPress:
 		it.state = statePressed
-		it.SetNeedsRedraw(true)
-		ctx.InvalidateRect(it.Bounds())
+		invalidateItem(it, ctx)
 		return true
 	case event.KeyRelease:
 		wasPressed := it.state == statePressed
 		it.state = stateNormal
-		it.SetNeedsRedraw(true)
-		ctx.InvalidateRect(it.Bounds())
+		invalidateItem(it, ctx)
 		if wasPressed {
-			it.group.selectValue(it.value)
+			if prev := it.group.selectValue(it.value); prev != nil {
+				invalidateItem(prev, ctx)
+			}
 		}
 		return true
 	default:

--- a/core/radio/group.go
+++ b/core/radio/group.go
@@ -113,17 +113,24 @@ func (g *Group) setSelectedLocked(value string) {
 }
 
 // selectValue is called by items when they are activated.
-func (g *Group) selectValue(value string) {
+// Returns the previously-selected item (nil if none) so the caller
+// can invalidate its region — the selection change alone does not
+// trigger redraw of the deselected item.
+func (g *Group) selectValue(value string) *Item {
 	g.mu.Lock()
 	prev := g.selected
 	g.setSelectedLocked(value)
 	changed := g.selected != prev
 	onChange := g.cfg.onChange
 	selectedSignal := g.cfg.selectedSignal
+	var prevItem *Item
+	if changed && prev >= 0 && prev < len(g.items) {
+		prevItem = g.items[prev]
+	}
 	g.mu.Unlock()
 
 	if !changed {
-		return
+		return nil
 	}
 
 	// TWO-WAY: if a SelectedSignal is bound, write back the new value.
@@ -134,6 +141,8 @@ func (g *Group) selectValue(value string) {
 	if onChange != nil {
 		onChange(value)
 	}
+
+	return prevItem
 }
 
 // isSelected reports whether the item with the given value is currently selected.

--- a/core/radio/internal_test.go
+++ b/core/radio/internal_test.go
@@ -1926,3 +1926,127 @@ func TestRadioGroupDoesNotForwardMouseEnterToItems(t *testing.T) {
 		t.Error("Group.Event should not consume MouseLeave")
 	}
 }
+
+// --- Issue #145: selection change must invalidate BOTH items ---
+
+func TestSelectionChange_InvalidatesPreviousItem(t *testing.T) {
+	g := NewGroup(
+		Items(
+			ItemDef{Value: "a", Label: "Alpha"},
+			ItemDef{Value: "b", Label: "Beta"},
+		),
+		Selected("a"),
+	)
+	a, b := g.items[0], g.items[1]
+	a.SetBounds(geometry.NewRect(0, 0, 100, 24))
+	b.SetBounds(geometry.NewRect(0, 28, 100, 24))
+
+	// Verify A is initially selected.
+	if !g.isSelected("a") {
+		t.Fatal("item A should be initially selected")
+	}
+
+	// Click B (press + release inside B's bounds).
+	// Group.Event translates to group-local coords, so position must
+	// be within B's bounds: (0,28)-(100,52).
+	clickPt := geometry.Pt(50, 40)
+	ctx := widget.NewContext()
+	press := event.NewMouseEvent(event.MousePress, event.ButtonLeft, event.ButtonStateLeft,
+		clickPt, clickPt, event.ModNone)
+	handleItemEvent(b, ctx, press)
+
+	ctx = widget.NewContext()
+	release := event.NewMouseEvent(event.MouseRelease, event.ButtonLeft, 0,
+		clickPt, clickPt, event.ModNone)
+	handleItemEvent(b, ctx, release)
+
+	// B should be selected now.
+	if !g.isSelected("b") {
+		t.Error("item B should be selected after click")
+	}
+
+	// A (previously selected) must be marked for redraw.
+	if !a.NeedsRedraw() {
+		t.Error("issue #145: previously-selected item A must be marked needsRedraw " +
+			"so damage-aware compositors clear its 'selected dot' pixels")
+	}
+}
+
+func TestSelectionChange_KeyActivation_InvalidatesPrevious(t *testing.T) {
+	g := NewGroup(
+		Items(
+			ItemDef{Value: "a", Label: "Alpha"},
+			ItemDef{Value: "b", Label: "Beta"},
+		),
+		Selected("a"),
+	)
+	a, b := g.items[0], g.items[1]
+	a.SetBounds(geometry.NewRect(0, 0, 100, 24))
+	b.SetBounds(geometry.NewRect(0, 28, 100, 24))
+	b.SetFocused(true)
+
+	// Key activate B.
+	ctx := widget.NewContext()
+	handleItemEvent(b, ctx, &event.KeyEvent{KeyType: event.KeyPress, Key: event.KeySpace})
+	ctx = widget.NewContext()
+	handleItemEvent(b, ctx, &event.KeyEvent{KeyType: event.KeyRelease, Key: event.KeySpace})
+
+	if !g.isSelected("b") {
+		t.Error("item B should be selected after key activation")
+	}
+	if !a.NeedsRedraw() {
+		t.Error("issue #145: previously-selected item A must be marked needsRedraw on key activation")
+	}
+}
+
+func TestSelectionChange_SameItem_NoPreviousInvalidation(t *testing.T) {
+	g := NewGroup(
+		Items(ItemDef{Value: "a", Label: "Alpha"}),
+		Selected("a"),
+	)
+	a := g.items[0]
+	a.SetBounds(geometry.NewRect(0, 0, 100, 24))
+
+	// Click already-selected item — no change, no previous invalidation needed.
+	ctx := widget.NewContext()
+	press := event.NewMouseEvent(event.MousePress, event.ButtonLeft, event.ButtonStateLeft,
+		geometry.Pt(50, 12), geometry.Pt(50, 12), event.ModNone)
+	handleItemEvent(a, ctx, press)
+	a.SetNeedsRedraw(false) // clear from press
+
+	ctx = widget.NewContext()
+	release := event.NewMouseEvent(event.MouseRelease, event.ButtonLeft, 0,
+		geometry.Pt(50, 12), geometry.Pt(50, 12), event.ModNone)
+	handleItemEvent(a, ctx, release)
+
+	// selectValue returns nil (no change), so only the clicked item is invalidated.
+	if !g.isSelected("a") {
+		t.Error("item A should still be selected")
+	}
+}
+
+func TestInvalidateItem_ExpandsBoundsForFocusRing(t *testing.T) {
+	g := NewGroup(Items(ItemDef{Value: "a", Label: "Alpha"}))
+	it := g.items[0]
+	it.SetBounds(geometry.NewRect(10, 20, 100, 24))
+
+	ctx := widget.NewContext()
+	invalidateItem(it, ctx)
+
+	if !it.NeedsRedraw() {
+		t.Error("invalidateItem should mark needsRedraw")
+	}
+
+	// The invalidated rect should be larger than item bounds
+	// to cover the focus ring area.
+	ir := ctx.InvalidatedRect()
+	bounds := it.Bounds()
+	if ir.Min.X >= bounds.Min.X || ir.Min.Y >= bounds.Min.Y {
+		t.Errorf("invalidated rect %v should expand beyond item bounds %v to cover focus ring",
+			ir, bounds)
+	}
+	if ir.Max.X <= bounds.Max.X || ir.Max.Y <= bounds.Max.Y {
+		t.Errorf("invalidated rect %v should expand beyond item bounds %v to cover focus ring",
+			ir, bounds)
+	}
+}


### PR DESCRIPTION
## Summary

- Fix radio group stale selection pixels on damage-aware compositors (#145)
- `selectValue()` now returns the previously-selected item for caller invalidation
- Expanded invalidation rect to cover focus ring area (2px beyond item bounds)
- Affects all damage-aware backends: Wayland, Vulkan (VK_KHR_incremental_present), DX12 (FLIP_SEQUENTIAL), Software

## Test plan

- [x] `go build ./...`
- [x] `go test ./... -count=1` (58 packages, 0 failures)
- [x] `golangci-lint run --timeout=5m` (0 issues)
- [x] 4 new tests: mouse selection invalidates previous, key activation invalidates previous, same-item no-op, focus ring bounds expansion
- [ ] Visual verification on Wayland (needs @striter-no confirmation)
- [ ] `GOGPU_DEBUG_DIRTY=1` — cyan should cover BOTH old and new radio on click