### PR TITLE
fix(compositor): snap boundary blit to integer pixels (#148)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **Radio group stale selection pixels** ([#145](https://github.com/gogpu/ui/issues/145)) — selecting a new radio button now invalidates both the newly-selected and previously-selected items. Previously only the clicked item was invalidated, causing the old "selected dot" to persist on damage-aware compositors (Wayland, Vulkan `VK_KHR_incremental_present`, DX12 `FLIP_SEQUENTIAL`). Also expanded invalidation rect to cover focus ring area (drawn 2px beyond item bounds).
+- **Inconsistent glyph weights in ListView** ([#148](https://github.com/gogpu/ui/issues/148)) — RepaintBoundary GPU textures were blitted at fractional pixel positions, causing the GPU's bilinear texture sampler to interpolate between texel rows differently per item. Snapped compositor blit coordinates to integer device pixels (Flutter `ComputeIntegralTransCTM` pattern). Also snapped clip rect coordinates for consistency.
+
+### Dependencies
+
+- gg v0.48.13 → v0.48.14
+- gogpu v0.42.1 → v0.42.5
 
 ## [0.1.35] — 2026-06-21
 

--- a/desktop/desktop.go
+++ b/desktop/desktop.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"image"
 	"log"
+	"math"
 	"os"
 	"sync"
 
@@ -787,7 +788,11 @@ func (rl *renderLoop) blitPictureLayer(pic *compositor.PictureLayerImpl, cc *gg.
 
 	bw, bh := pic.Size()
 	origin := pic.ScreenOrigin()
-	x, y := float64(origin.X), float64(origin.Y)
+	// Snap blit position to integer device pixels (Flutter ComputeIntegralTransCTM
+	// pattern). Without rounding, the GPU's bilinear texture sampler interpolates
+	// between texel rows at fractional positions, producing inconsistent glyph
+	// weights across ListView items at different Y offsets.
+	x, y := math.Round(float64(origin.X)), math.Round(float64(origin.Y))
 
 	rl.blitCount++
 	if isDebugDamageEnabled() {
@@ -804,8 +809,8 @@ func (rl *renderLoop) blitPictureLayer(pic *compositor.PictureLayerImpl, cc *gg.
 		if entry.hasClip {
 			clip := entry.clipRect
 			cc.Push()
-			cc.ClipRect(float64(clip.Min.X), float64(clip.Min.Y),
-				float64(clip.Width()), float64(clip.Height()))
+			cc.ClipRect(math.Round(float64(clip.Min.X)), math.Round(float64(clip.Min.Y)),
+				math.Round(float64(clip.Width())), math.Round(float64(clip.Height())))
 			cc.DrawGPUTextureWithOpacity(entry.texture, x, y, bw, bh, opacity)
 			cc.Pop()
 		} else {
@@ -815,8 +820,8 @@ func (rl *renderLoop) blitPictureLayer(pic *compositor.PictureLayerImpl, cc *gg.
 	case entry.hasClip:
 		clip := entry.clipRect
 		cc.Push()
-		cc.ClipRect(float64(clip.Min.X), float64(clip.Min.Y),
-			float64(clip.Width()), float64(clip.Height()))
+		cc.ClipRect(math.Round(float64(clip.Min.X)), math.Round(float64(clip.Min.Y)),
+			math.Round(float64(clip.Width())), math.Round(float64(clip.Height())))
 		cc.DrawGPUTexture(entry.texture, x, y, bw, bh)
 		cc.Pop()
 

--- a/desktop/gpu_work_test.go
+++ b/desktop/gpu_work_test.go
@@ -2,6 +2,7 @@ package desktop
 
 import (
 	"image"
+	"math"
 	"testing"
 	"unsafe"
 
@@ -521,5 +522,65 @@ func TestTrackBoundaryDamage_ChildAppendsBothRects(t *testing.T) {
 	wantPhysical := image.Rect(100, 200, 148, 248)
 	if rl.frameDamageRects[0] != wantPhysical {
 		t.Errorf("physical damage = %v, want %v", rl.frameDamageRects[0], wantPhysical)
+	}
+}
+
+// --- Test: pixel snap for boundary blit positions ---
+
+// TestPixelSnap_BlitPosition verifies that boundary blit coordinates are
+// rounded to integer device pixels (Flutter ComputeIntegralTransCTM pattern).
+// Without snapping, the GPU's bilinear texture sampler interpolates between
+// texel rows at fractional positions, producing inconsistent glyph weights
+// across ListView items at different Y offsets (#148).
+func TestPixelSnap_BlitPosition(t *testing.T) {
+	tests := []struct {
+		name string
+		inX  float32
+		inY  float32
+		outX float64
+		outY float64
+	}{
+		{"integer", 100, 200, 100, 200},
+		{"fractional_low", 100.3, 200.2, 100, 200},
+		{"fractional_high", 100.7, 200.8, 101, 201},
+		{"half", 100.5, 200.5, 101, 201},          // math.Round rounds 0.5 to even? No, to nearest
+		{"negative", -10.3, -20.7, -10, -21},
+		{"zero", 0, 0, 0, 0},
+		{"scroll_offset", 0, 36.3, 0, 36},         // ListView item after fractional scroll
+		{"large_fractional", 0, 1080.4, 0, 1080},   // near bottom of 1080p display
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotX := math.Round(float64(tt.inX))
+			gotY := math.Round(float64(tt.inY))
+			if gotX != tt.outX || gotY != tt.outY {
+				t.Errorf("snap(%v, %v) = (%v, %v), want (%v, %v)",
+					tt.inX, tt.inY, gotX, gotY, tt.outX, tt.outY)
+			}
+		})
+	}
+}
+
+// TestPixelSnap_ClipRect verifies that compositor clip rect coordinates
+// are also snapped to integer device pixels for consistency with blit positions.
+func TestPixelSnap_ClipRect(t *testing.T) {
+	clip := geometry.NewRect(10.3, 20.7, 100.5, 200.2)
+
+	x := math.Round(float64(clip.Min.X))
+	y := math.Round(float64(clip.Min.Y))
+	w := math.Round(float64(clip.Width()))
+	h := math.Round(float64(clip.Height()))
+
+	if x != 10 {
+		t.Errorf("clip.Min.X snap = %v, want 10", x)
+	}
+	if y != 21 {
+		t.Errorf("clip.Min.Y snap = %v, want 21", y)
+	}
+	if w != 101 {
+		t.Errorf("clip.Width snap = %v, want 101", w)
+	}
+	if h != 200 {
+		t.Errorf("clip.Height snap = %v, want 200", h)
 	}
 }

--- a/desktop/gpu_work_test.go
+++ b/desktop/gpu_work_test.go
@@ -543,11 +543,11 @@ func TestPixelSnap_BlitPosition(t *testing.T) {
 		{"integer", 100, 200, 100, 200},
 		{"fractional_low", 100.3, 200.2, 100, 200},
 		{"fractional_high", 100.7, 200.8, 101, 201},
-		{"half", 100.5, 200.5, 101, 201},          // math.Round rounds 0.5 to even? No, to nearest
+		{"half", 100.5, 200.5, 101, 201}, // math.Round rounds 0.5 to even? No, to nearest
 		{"negative", -10.3, -20.7, -10, -21},
 		{"zero", 0, 0, 0, 0},
-		{"scroll_offset", 0, 36.3, 0, 36},         // ListView item after fractional scroll
-		{"large_fractional", 0, 1080.4, 0, 1080},   // near bottom of 1080p display
+		{"scroll_offset", 0, 36.3, 0, 36},        // ListView item after fractional scroll
+		{"large_fractional", 0, 1080.4, 0, 1080}, // near bottom of 1080p display
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,8 @@ go 1.25.0
 
 require (
 	github.com/coregx/signals v0.1.0
-	github.com/gogpu/gg v0.48.13
-	github.com/gogpu/gogpu v0.42.1
+	github.com/gogpu/gg v0.48.14
+	github.com/gogpu/gogpu v0.42.5
 	github.com/gogpu/gpucontext v0.21.0
 	github.com/gogpu/gputypes v0.5.0
 	github.com/gogpu/wgpu v0.30.2

--- a/go.sum
+++ b/go.sum
@@ -8,10 +8,10 @@ github.com/go-webgpu/goffi v0.5.5 h1:xLWMhnJq+GrejlhTC3iVt3q8ozRbmYSq8kzuw6MKlgE
 github.com/go-webgpu/goffi v0.5.5/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
 github.com/go-webgpu/webgpu v0.5.2 h1:E+yKCbRw/Dgn77pb/CX3kXatwwROGX7/B4ZFbRPaRbQ=
 github.com/go-webgpu/webgpu v0.5.2/go.mod h1:d2RR3tI2kUtcMfpC+qJt46IRkDslRhftjCfQvnprGkY=
-github.com/gogpu/gg v0.48.13 h1:lbDbcNXBvydlNeWEs/sY1tenOZ5p41/tXv0ljjLulqg=
-github.com/gogpu/gg v0.48.13/go.mod h1:WTL0lwwKNBeUf3xNeloJyRQJeRE1TFnIkKPfwROcIDQ=
-github.com/gogpu/gogpu v0.42.1 h1:E8vNSl2jPR7fOTVlW/4o3Lc5wBMGk8/l72EEQ8qAqSw=
-github.com/gogpu/gogpu v0.42.1/go.mod h1:TCcGAknKAJ+v2XlPwUZlIa+k/QoffTORJTCHzMxLkN0=
+github.com/gogpu/gg v0.48.14 h1:ZGHEY3HhCG1gL7GyuWy2suR6SlP+OTQbXV4u9JaDYgw=
+github.com/gogpu/gg v0.48.14/go.mod h1:A9gUxN3tZd4GHM0xVsLgIoCyMjjsqo0Rn+qcUnPb8XE=
+github.com/gogpu/gogpu v0.42.5 h1:piSgdsFjPTXLkyHzWp2ePqJweG+rdOX3tBwjEUqKdVo=
+github.com/gogpu/gogpu v0.42.5/go.mod h1:TCcGAknKAJ+v2XlPwUZlIa+k/QoffTORJTCHzMxLkN0=
 github.com/gogpu/gpucontext v0.21.0 h1:O1SnXBiednIyVP4Zx5SASh0svYiG6g/wF1igNZVo1Pc=
 github.com/gogpu/gpucontext v0.21.0/go.mod h1:6zwdmYXH5GQltoiHbb3WXVS/UJ5bFsCux0mXCVqGlzY=
 github.com/gogpu/gputypes v0.5.0 h1:i2ED/9w6m6yLxf8XJT69/NIMSNTLO2y5F1LqvugCKIE=


### PR DESCRIPTION
## Summary

- Snap RepaintBoundary blit positions to integer device pixels (#148)
- Fixes inconsistent glyph weights across ListView items at different Y offsets
- Flutter `ComputeIntegralTransCTM` pattern (verified against `raster_cache_util.cc:80-81`)
- Also snaps clip rect coordinates for consistency
- Updates deps: gg v0.48.14, gogpu v0.42.5 (subpixel detection fix)

## Test plan

- [x] `go build ./...`
- [x] `go test ./... -count=1` (58 packages, 0 failures)
- [x] `golangci-lint run --timeout=5m` (0 issues)
- [x] 10 new tests: 8 blit position scenarios + clip rect snap
- [ ] Visual verification on Wayland (needs @striter-no)
