### PR TITLE
feat(widget): wire MarkNeedsLayout into layout-affecting paths (ADR-032 Phase 2a)

### DIFF
--- a/app/window.go
+++ b/app/window.go
@@ -559,14 +559,17 @@ func (w *Window) Frame() {
 	if w.needsLayout {
 		ui.Logger().Info("[LAYOUT-TRIGGER]")
 		layoutStart := time.Now()
+		// Clear before layout so both ctx.Invalidate() and MarkNeedsLayout()
+		// can re-set it during layout (animation ticks). The respective
+		// callbacks (onInvalidate, onLayoutDirty) set w.needsLayout = true.
+		w.needsLayout = false
 		w.layout()
 		layoutDur = time.Since(layoutStart)
-		// Clear needsLayout only if no widget re-invalidated during layout.
-		// Animations call ctx.Invalidate() from tickAnimation() during layout,
-		// which sets needsLayout back to true — we must not clobber that.
-		if !w.ctx.IsInvalidated() {
-			w.needsLayout = false
-		}
+		// ADR-032: mark all widgets layout-clean so MarkNeedsLayout()'s
+		// idempotency guard works before LayoutChild activates per-widget
+		// caching. Redundant once LayoutChild is adopted (layoutCacheStore
+		// handles the lifecycle).
+		widget.MarkLayoutCleanRecursive(w.root)
 		// Layout completed — widgets with changed positions need redraw.
 		// ADR-028: do NOT MarkRedrawInTree(root) — that marks ALL widgets
 		// dirty → full screen repaint. Only widgets that actually changed

--- a/core/badge/badge.go
+++ b/core/badge/badge.go
@@ -216,7 +216,7 @@ func (w *Widget) Mount(ctx widget.Context) {
 // MarkDirty is only called when the clamped count differs from the last drawn
 // count, preventing redundant redraws.
 func (w *Widget) bindCountSignal(sig state.ReadonlySignal[int], sched widget.SchedulerRef) *state.Binding {
-	return state.BindToSchedulerFunc(sig, func(newVal int) bool {
+	return state.BindToSchedulerLayoutFunc(sig, func(newVal int) bool {
 		if newVal < 0 {
 			newVal = 0
 		}

--- a/core/button/widget.go
+++ b/core/button/widget.go
@@ -153,10 +153,10 @@ func (w *Widget) Mount(ctx widget.Context) {
 		return
 	}
 	if w.cfg.readonlyTextSignal != nil {
-		b := state.BindToScheduler(w.cfg.readonlyTextSignal, w, sched)
+		b := state.BindToSchedulerLayout(w.cfg.readonlyTextSignal, w, sched)
 		w.AddBinding(b)
 	} else if w.cfg.textSignal != nil {
-		b := state.BindToScheduler(w.cfg.textSignal, w, sched)
+		b := state.BindToSchedulerLayout(w.cfg.textSignal, w, sched)
 		w.AddBinding(b)
 	}
 	if w.cfg.readonlyDisabledSignal != nil {

--- a/core/checkbox/widget.go
+++ b/core/checkbox/widget.go
@@ -144,10 +144,10 @@ func (w *Widget) Mount(ctx widget.Context) {
 		w.AddBinding(b)
 	}
 	if w.cfg.readonlyLabelSig != nil {
-		b := state.BindToScheduler(w.cfg.readonlyLabelSig, w, sched)
+		b := state.BindToSchedulerLayout(w.cfg.readonlyLabelSig, w, sched)
 		w.AddBinding(b)
 	} else if w.cfg.labelSignal != nil {
-		b := state.BindToScheduler(w.cfg.labelSignal, w, sched)
+		b := state.BindToSchedulerLayout(w.cfg.labelSignal, w, sched)
 		w.AddBinding(b)
 	}
 	if w.cfg.readonlyDisabledSig != nil {

--- a/core/chip/chip.go
+++ b/core/chip/chip.go
@@ -186,9 +186,9 @@ func (w *Widget) Mount(ctx widget.Context) {
 		return
 	}
 	if w.cfg.readonlyLabelSignal != nil {
-		w.AddBinding(state.BindToScheduler(w.cfg.readonlyLabelSignal, w, sched))
+		w.AddBinding(state.BindToSchedulerLayout(w.cfg.readonlyLabelSignal, w, sched))
 	} else if w.cfg.labelSignal != nil {
-		w.AddBinding(state.BindToScheduler(w.cfg.labelSignal, w, sched))
+		w.AddBinding(state.BindToSchedulerLayout(w.cfg.labelSignal, w, sched))
 	}
 	if w.cfg.readonlySelectedSignal != nil {
 		w.AddBinding(state.BindToScheduler(w.cfg.readonlySelectedSignal, w, sched))

--- a/core/collapsible/collapsible.go
+++ b/core/collapsible/collapsible.go
@@ -299,10 +299,10 @@ func (w *Widget) Mount(ctx widget.Context) {
 		w.AddBinding(b)
 	}
 	if w.cfg.readonlyExpandedSignal != nil {
-		b := state.BindToScheduler(w.cfg.readonlyExpandedSignal, w, sched)
+		b := state.BindToSchedulerLayout(w.cfg.readonlyExpandedSignal, w, sched)
 		w.AddBinding(b)
 	} else if w.cfg.expandedSignal != nil {
-		b := state.BindToScheduler(w.cfg.expandedSignal, w, sched)
+		b := state.BindToSchedulerLayout(w.cfg.expandedSignal, w, sched)
 		w.AddBinding(b)
 	}
 }

--- a/core/collapsible/event.go
+++ b/core/collapsible/event.go
@@ -92,8 +92,8 @@ func handleMouseEvent(w *Widget, ctx widget.Context, e *event.MouseEvent) bool {
 		}
 		if wasPressed && hdr.Contains(e.Position) {
 			w.Toggle()
-			// ADR-028: layout change — Toggle changes height, needs full layout recalc.
-			ctx.Invalidate()
+			// ADR-032: layout change — Toggle changes height.
+			w.MarkNeedsLayout()
 			return true
 		}
 		// ADR-028: visual only — state changed from pressed to hover/normal.
@@ -132,8 +132,8 @@ func handleActivationKey(w *Widget, ctx widget.Context, e *event.KeyEvent) bool 
 		w.istate = stateNormal
 		if wasPressed {
 			w.Toggle()
-			// ADR-028: layout change — Toggle changes height.
-			ctx.Invalidate()
+			// ADR-032: layout change — Toggle changes height.
+			w.MarkNeedsLayout()
 		} else {
 			// ADR-028: visual only — state changed to normal.
 			w.SetNeedsRedraw(true)

--- a/core/collapsible/internal_test.go
+++ b/core/collapsible/internal_test.go
@@ -771,10 +771,13 @@ func TestGranularInvalidation_Press_NoFullInvalidate(t *testing.T) {
 	}
 }
 
-func TestGranularInvalidation_Release_KeepsFullInvalidation(t *testing.T) {
+func TestGranularInvalidation_Release_KeepsLayoutInvalidation(t *testing.T) {
 	w := New(Title("Test"), Animated(false))
 	w.SetBounds(geometry.NewRect(0, 0, 200, 36))
 	ctx := widget.NewContext()
+
+	// Populate the layout cache so MarkNeedsLayout's guard passes.
+	widget.LayoutChild(w, ctx, geometry.Loose(geometry.Sz(200, 300)))
 
 	// Press first.
 	press := event.NewMouseEvent(event.MousePress, event.ButtonLeft, event.ButtonStateLeft,
@@ -790,8 +793,8 @@ func TestGranularInvalidation_Release_KeepsFullInvalidation(t *testing.T) {
 		geometry.Pt(100, 18), geometry.Pt(100, 18), event.ModNone)
 	handleEvent(w, ctx, release)
 
-	if !ctx.IsInvalidated() {
-		t.Error("MouseRelease with Toggle MUST trigger full invalidation (structural change)")
+	if w.IsLayoutCacheValid() {
+		t.Error("MouseRelease with Toggle MUST invalidate layout cache (structural change)")
 	}
 }
 
@@ -814,10 +817,13 @@ func TestGranularInvalidation_KeyPress_NoFullInvalidate(t *testing.T) {
 	}
 }
 
-func TestGranularInvalidation_KeyRelease_KeepsFullInvalidation(t *testing.T) {
+func TestGranularInvalidation_KeyRelease_KeepsLayoutInvalidation(t *testing.T) {
 	w := New(Title("Test"), Animated(false))
 	w.SetFocused(true)
 	ctx := widget.NewContext()
+
+	// Populate the layout cache so MarkNeedsLayout's guard passes.
+	widget.LayoutChild(w, ctx, geometry.Loose(geometry.Sz(200, 300)))
 
 	// Press first.
 	press := event.NewKeyEvent(event.KeyPress, event.KeySpace, 0, event.ModNone)
@@ -831,8 +837,8 @@ func TestGranularInvalidation_KeyRelease_KeepsFullInvalidation(t *testing.T) {
 	release := event.NewKeyEvent(event.KeyRelease, event.KeySpace, 0, event.ModNone)
 	handleEvent(w, ctx, release)
 
-	if !ctx.IsInvalidated() {
-		t.Error("Key release MUST trigger full invalidation (Toggle is structural)")
+	if w.IsLayoutCacheValid() {
+		t.Error("Key release MUST invalidate layout cache (Toggle is structural)")
 	}
 }
 

--- a/core/datatable/datatable.go
+++ b/core/datatable/datatable.go
@@ -493,10 +493,10 @@ func (w *Widget) Mount(ctx widget.Context) {
 	}
 
 	if w.cfg.readonlyRowCountSignal != nil {
-		b := state.BindToScheduler(w.cfg.readonlyRowCountSignal, w, sched)
+		b := state.BindToSchedulerLayout(w.cfg.readonlyRowCountSignal, w, sched)
 		w.AddBinding(b)
 	} else if w.cfg.rowCountSignal != nil {
-		b := state.BindToScheduler(w.cfg.rowCountSignal, w, sched)
+		b := state.BindToSchedulerLayout(w.cfg.rowCountSignal, w, sched)
 		w.AddBinding(b)
 	}
 
@@ -989,8 +989,8 @@ func (w *Widget) handleHeaderMousePress(ctx widget.Context, e *event.MouseEvent,
 	}
 
 	ctx.RequestFocus(w)
-	// ADR-028: layout change — sort reorders rows, may change content.
-	ctx.Invalidate()
+	// ADR-032: layout change — sort reorders rows, may change content.
+	w.MarkNeedsLayout()
 	return true
 }
 

--- a/core/docking/host.go
+++ b/core/docking/host.go
@@ -471,8 +471,8 @@ func (h *Host) handleTabPress(ctx widget.Context, me *event.MouseEvent) bool {
 			ts := &h.tabStates[z][i]
 			if ts.Bounds.Contains(me.Position) {
 				h.zones[z].activeIdx = i
-				// ADR-028: layout change — active panel switch changes zone content.
-				ctx.Invalidate()
+				// ADR-032: layout change — active panel switch changes zone content.
+				h.MarkNeedsLayout()
 				return true
 			}
 		}
@@ -543,8 +543,8 @@ func (h *Host) closePanel(ctx widget.Context, z Zone, idx int) {
 		h.cfg.onPanelClose(panel, z)
 	}
 
-	// ADR-028: layout change — panel removed, zone layout changes.
-	ctx.Invalidate()
+	// ADR-032: layout change — panel removed, zone layout changes.
+	h.MarkNeedsLayout()
 }
 
 // updateTabStates refreshes tab states for a zone from the current panels.

--- a/core/docking/host.go
+++ b/core/docking/host.go
@@ -428,7 +428,7 @@ func (h *Host) handleZoneTabEvents(ctx widget.Context, e event.Event) bool {
 
 	switch me.MouseType {
 	case event.MousePress:
-		return h.handleTabPress(ctx, me)
+		return h.handleTabPress(me)
 	case event.MouseMove:
 		return h.handleTabMove(ctx, me)
 	case event.MouseLeave:
@@ -439,7 +439,7 @@ func (h *Host) handleZoneTabEvents(ctx widget.Context, e event.Event) bool {
 }
 
 // handleTabPress handles mouse clicks on zone tab headers.
-func (h *Host) handleTabPress(ctx widget.Context, me *event.MouseEvent) bool {
+func (h *Host) handleTabPress(me *event.MouseEvent) bool {
 	if me.Button != event.ButtonLeft {
 		return false
 	}
@@ -461,7 +461,7 @@ func (h *Host) handleTabPress(ctx widget.Context, me *event.MouseEvent) bool {
 				continue
 			}
 			if ts.CloseButtonBounds.Contains(me.Position) {
-				h.closePanel(ctx, z, i)
+				h.closePanel(z, i)
 				return true
 			}
 		}
@@ -530,7 +530,7 @@ func (h *Host) handleTabLeave(ctx widget.Context) bool {
 }
 
 // closePanel removes the panel at index idx from zone z.
-func (h *Host) closePanel(ctx widget.Context, z Zone, idx int) {
+func (h *Host) closePanel(z Zone, idx int) {
 	g := &h.zones[z]
 	if idx < 0 || idx >= len(g.panels) {
 		return

--- a/core/gridview/gridview.go
+++ b/core/gridview/gridview.go
@@ -548,10 +548,10 @@ func (w *Widget) Mount(ctx widget.Context) {
 
 	// Bind item count signals.
 	if w.cfg.readonlyItemCountSignal != nil {
-		b := state.BindToScheduler(w.cfg.readonlyItemCountSignal, w, sched)
+		b := state.BindToSchedulerLayout(w.cfg.readonlyItemCountSignal, w, sched)
 		w.AddBinding(b)
 	} else if w.cfg.itemCountSignal != nil {
-		b := state.BindToScheduler(w.cfg.itemCountSignal, w, sched)
+		b := state.BindToSchedulerLayout(w.cfg.itemCountSignal, w, sched)
 		w.AddBinding(b)
 	}
 
@@ -575,10 +575,10 @@ func (w *Widget) Mount(ctx widget.Context) {
 
 	// Bind columns signals.
 	if w.cfg.readonlyColumnsSignal != nil {
-		b := state.BindToScheduler(w.cfg.readonlyColumnsSignal, w, sched)
+		b := state.BindToSchedulerLayout(w.cfg.readonlyColumnsSignal, w, sched)
 		w.AddBinding(b)
 	} else if w.cfg.columnsSignal != nil {
-		b := state.BindToScheduler(w.cfg.columnsSignal, w, sched)
+		b := state.BindToSchedulerLayout(w.cfg.columnsSignal, w, sched)
 		w.AddBinding(b)
 	}
 

--- a/core/listview/widget.go
+++ b/core/listview/widget.go
@@ -227,10 +227,10 @@ func (w *Widget) Mount(ctx widget.Context) {
 
 	// Bind item count signals.
 	if w.cfg.readonlyItemCountSignal != nil {
-		b := state.BindToScheduler(w.cfg.readonlyItemCountSignal, w, sched)
+		b := state.BindToSchedulerLayout(w.cfg.readonlyItemCountSignal, w, sched)
 		w.AddBinding(b)
 	} else if w.cfg.itemCountSignal != nil {
-		b := state.BindToScheduler(w.cfg.itemCountSignal, w, sched)
+		b := state.BindToSchedulerLayout(w.cfg.itemCountSignal, w, sched)
 		w.AddBinding(b)
 	}
 

--- a/core/splitview/splitview.go
+++ b/core/splitview/splitview.go
@@ -464,7 +464,7 @@ func (w *Widget) handleMouseMove(ctx widget.Context, me *event.MouseEvent) bool 
 			return false
 		}
 
-		w.updateRatioFromDrag(ctx, me.Position)
+		w.updateRatioFromDrag(me.Position)
 		w.updateCursor(ctx) // Maintain drag cursor on every move
 		return true
 	}
@@ -497,7 +497,7 @@ func (w *Widget) handleMousePress(ctx widget.Context, me *event.MouseEvent) bool
 	if w.cfg.collapsible {
 		now := ctx.Now()
 		if now.Sub(w.lastClickAt) < doubleClickThreshold && w.isNearLastClick(me.Position) {
-			w.toggleCollapse(ctx)
+			w.toggleCollapse()
 			w.lastClickAt = time.Time{} // Reset to prevent triple-click.
 			return true
 		}
@@ -549,21 +549,21 @@ func (w *Widget) isNearLastClick(p geometry.Point) bool {
 }
 
 // toggleCollapse toggles the collapsed state of the first panel.
-func (w *Widget) toggleCollapse(ctx widget.Context) {
+func (w *Widget) toggleCollapse() {
 	if w.collapsed {
 		// Restore previous ratio.
 		w.collapsed = false
-		w.setRatio(ctx, w.preCollapse)
+		w.setRatio(w.preCollapse)
 	} else {
 		// Collapse first panel.
 		w.preCollapse = w.effectiveRatio()
 		w.collapsed = true
-		w.setRatio(ctx, 0)
+		w.setRatio(0)
 	}
 }
 
 // updateRatioFromDrag calculates the new ratio based on drag position.
-func (w *Widget) updateRatioFromDrag(ctx widget.Context, pos geometry.Point) {
+func (w *Widget) updateRatioFromDrag(pos geometry.Point) {
 	bounds := w.Bounds()
 	divW := w.cfg.resolvedDividerWidth()
 
@@ -590,7 +590,7 @@ func (w *Widget) updateRatioFromDrag(ctx widget.Context, pos geometry.Point) {
 		w.collapsed = false
 	}
 
-	w.setRatio(ctx, newRatio)
+	w.setRatio(newRatio)
 }
 
 // clampRatioToConstraints applies min panel constraints to the ratio.
@@ -622,7 +622,7 @@ func (w *Widget) clampRatioToConstraints(ratio, totalSpace float32) float32 {
 
 // setRatio updates the split ratio, writes to signal if bound, and fires callback.
 // If fixedFirst is active, the pixel size is updated from the new ratio.
-func (w *Widget) setRatio(ctx widget.Context, ratio float32) {
+func (w *Widget) setRatio(ratio float32) {
 	ratio = clampRatio(ratio)
 	current := w.cfg.ResolvedRatio()
 

--- a/core/splitview/splitview.go
+++ b/core/splitview/splitview.go
@@ -654,9 +654,8 @@ func (w *Widget) setRatio(ctx widget.Context, ratio float32) {
 		w.cfg.onRatioChange(ratio)
 	}
 
-	w.SetNeedsRedraw(true)
-	// ADR-028: layout change — ratio change resizes child panels.
-	ctx.Invalidate()
+	// ADR-032: layout change — ratio change resizes child panels.
+	w.MarkNeedsLayout()
 }
 
 // effectiveRatio returns the current ratio, accounting for collapsed state.
@@ -734,10 +733,10 @@ func (w *Widget) Mount(ctx widget.Context) {
 		return
 	}
 	if w.cfg.readonlyRatioSignal != nil {
-		b := state.BindToScheduler(w.cfg.readonlyRatioSignal, w, sched)
+		b := state.BindToSchedulerLayout(w.cfg.readonlyRatioSignal, w, sched)
 		w.AddBinding(b)
 	} else if w.cfg.ratioSignal != nil {
-		b := state.BindToScheduler(w.cfg.ratioSignal, w, sched)
+		b := state.BindToSchedulerLayout(w.cfg.ratioSignal, w, sched)
 		w.AddBinding(b)
 	}
 }

--- a/core/tabview/event.go
+++ b/core/tabview/event.go
@@ -11,7 +11,7 @@ func handleEvent(w *Widget, ctx widget.Context, e event.Event) bool {
 	case *event.MouseEvent:
 		return handleMouseEvent(w, ctx, ev)
 	case *event.KeyEvent:
-		return handleKeyEvent(w, ctx, ev)
+		return handleKeyEvent(w, ev)
 	default:
 		return false
 	}
@@ -67,7 +67,7 @@ func handleMousePress(w *Widget, ctx widget.Context, e *event.MouseEvent) bool {
 			continue
 		}
 		if ts.Bounds.Contains(e.Position) {
-			w.selectTab(ctx, i)
+			w.selectTab(i)
 			return true
 		}
 	}
@@ -113,7 +113,7 @@ func handleMouseLeave(w *Widget, ctx widget.Context) bool {
 }
 
 // handleKeyEvent processes keyboard events for tab navigation.
-func handleKeyEvent(w *Widget, ctx widget.Context, e *event.KeyEvent) bool {
+func handleKeyEvent(w *Widget, e *event.KeyEvent) bool {
 	if !w.IsFocused() {
 		return false
 	}
@@ -123,26 +123,26 @@ func handleKeyEvent(w *Widget, ctx widget.Context, e *event.KeyEvent) bool {
 
 	switch e.Key {
 	case event.KeyLeft:
-		return navigatePrev(w, ctx)
+		return navigatePrev(w)
 	case event.KeyRight:
-		return navigateNext(w, ctx)
+		return navigateNext(w)
 	case event.KeyHome:
-		return navigateFirst(w, ctx)
+		return navigateFirst(w)
 	case event.KeyEnd:
-		return navigateLast(w, ctx)
+		return navigateLast(w)
 	default:
 		return false
 	}
 }
 
 // navigatePrev selects the previous enabled tab.
-func navigatePrev(w *Widget, ctx widget.Context) bool {
+func navigatePrev(w *Widget) bool {
 	current := w.cfg.ResolvedSelected()
 	tabCount := len(w.cfg.tabs)
 	for i := 1; i < tabCount; i++ {
 		idx := (current - i + tabCount) % tabCount
 		if !w.cfg.tabs[idx].Disabled {
-			w.selectTab(ctx, idx)
+			w.selectTab(idx)
 			return true
 		}
 	}
@@ -150,13 +150,13 @@ func navigatePrev(w *Widget, ctx widget.Context) bool {
 }
 
 // navigateNext selects the next enabled tab.
-func navigateNext(w *Widget, ctx widget.Context) bool {
+func navigateNext(w *Widget) bool {
 	current := w.cfg.ResolvedSelected()
 	tabCount := len(w.cfg.tabs)
 	for i := 1; i < tabCount; i++ {
 		idx := (current + i) % tabCount
 		if !w.cfg.tabs[idx].Disabled {
-			w.selectTab(ctx, idx)
+			w.selectTab(idx)
 			return true
 		}
 	}
@@ -164,10 +164,10 @@ func navigateNext(w *Widget, ctx widget.Context) bool {
 }
 
 // navigateFirst selects the first enabled tab.
-func navigateFirst(w *Widget, ctx widget.Context) bool {
+func navigateFirst(w *Widget) bool {
 	for i := range w.cfg.tabs {
 		if !w.cfg.tabs[i].Disabled {
-			w.selectTab(ctx, i)
+			w.selectTab(i)
 			return true
 		}
 	}
@@ -175,10 +175,10 @@ func navigateFirst(w *Widget, ctx widget.Context) bool {
 }
 
 // navigateLast selects the last enabled tab.
-func navigateLast(w *Widget, ctx widget.Context) bool {
+func navigateLast(w *Widget) bool {
 	for i := len(w.cfg.tabs) - 1; i >= 0; i-- {
 		if !w.cfg.tabs[i].Disabled {
-			w.selectTab(ctx, i)
+			w.selectTab(i)
 			return true
 		}
 	}
@@ -186,7 +186,7 @@ func navigateLast(w *Widget, ctx widget.Context) bool {
 }
 
 // selectTab sets the selected tab index and fires callbacks.
-func (w *Widget) selectTab(ctx widget.Context, idx int) {
+func (w *Widget) selectTab(idx int) {
 	if idx == w.cfg.ResolvedSelected() {
 		return
 	}

--- a/core/tabview/event.go
+++ b/core/tabview/event.go
@@ -54,8 +54,8 @@ func handleMousePress(w *Widget, ctx widget.Context, e *event.MouseEvent) bool {
 			if w.cfg.onClose != nil {
 				w.cfg.onClose(i)
 			}
-			// ADR-028: layout change — tab removal changes tab strip layout.
-			ctx.Invalidate()
+			// ADR-032: layout change — tab removal changes tab strip layout.
+			w.MarkNeedsLayout()
 			return true
 		}
 	}
@@ -194,6 +194,6 @@ func (w *Widget) selectTab(ctx widget.Context, idx int) {
 	if w.cfg.onSelect != nil {
 		w.cfg.onSelect(idx)
 	}
-	// ADR-028: layout change — tab switch changes content panel.
-	ctx.Invalidate()
+	// ADR-032: layout change — tab switch changes content panel.
+	w.MarkNeedsLayout()
 }

--- a/core/tabview/internal_test.go
+++ b/core/tabview/internal_test.go
@@ -259,7 +259,7 @@ func TestGranularInvalidation_MouseLeave_NoFullInvalidate(t *testing.T) {
 	}
 }
 
-func TestGranularInvalidation_SelectTab_KeepsFullInvalidation(t *testing.T) {
+func TestGranularInvalidation_SelectTab_KeepsLayoutInvalidation(t *testing.T) {
 	tabs := []Tab{
 		{Label: "Tab1"},
 		{Label: "Tab2"},
@@ -268,11 +268,14 @@ func TestGranularInvalidation_SelectTab_KeepsFullInvalidation(t *testing.T) {
 	w.SetBounds(geometry.NewRect(0, 0, 200, 300))
 	ctx := widget.NewContext()
 
-	// selectTab is a structural change (content swap) -- MUST use full invalidation.
+	// Populate the layout cache so MarkNeedsLayout's guard passes.
+	widget.LayoutChild(w, ctx, geometry.Loose(geometry.Sz(200, 300)))
+
+	// selectTab is a structural change (content swap) -- MUST invalidate layout.
 	w.selectTab(ctx, 1)
 
-	if !ctx.IsInvalidated() {
-		t.Error("selectTab MUST trigger full invalidation (structural change: content swap)")
+	if w.IsLayoutCacheValid() {
+		t.Error("selectTab MUST invalidate layout cache (structural change: content swap)")
 	}
 }
 

--- a/core/tabview/internal_test.go
+++ b/core/tabview/internal_test.go
@@ -272,7 +272,7 @@ func TestGranularInvalidation_SelectTab_KeepsLayoutInvalidation(t *testing.T) {
 	widget.LayoutChild(w, ctx, geometry.Loose(geometry.Sz(200, 300)))
 
 	// selectTab is a structural change (content swap) -- MUST invalidate layout.
-	w.selectTab(ctx, 1)
+	w.selectTab(1)
 
 	if w.IsLayoutCacheValid() {
 		t.Error("selectTab MUST invalidate layout cache (structural change: content swap)")

--- a/core/treeview/event.go
+++ b/core/treeview/event.go
@@ -79,7 +79,7 @@ func handleMousePress(w *Widget, ctx widget.Context, e *event.MouseEvent) bool {
 	if !row.node.IsLeaf() {
 		iconBounds := w.expandIconBounds(row.depth, rowBounds)
 		if iconBounds.Contains(e.Position) {
-			w.toggleNode(ctx, row.node)
+			w.toggleNode(row.node)
 			return true
 		}
 	}
@@ -149,7 +149,7 @@ func (w *Widget) handleKeyRight(ctx widget.Context, idx int) bool {
 
 	if !row.node.Expanded {
 		// Expand the node.
-		w.toggleNode(ctx, row.node)
+		w.toggleNode(row.node)
 		return true
 	}
 
@@ -169,7 +169,7 @@ func (w *Widget) handleKeyLeft(ctx widget.Context, idx int) bool {
 
 	// If expanded branch, collapse it.
 	if !row.node.IsLeaf() && row.node.Expanded {
-		w.toggleNode(ctx, row.node)
+		w.toggleNode(row.node)
 		return true
 	}
 

--- a/core/treeview/treeview.go
+++ b/core/treeview/treeview.go
@@ -444,7 +444,7 @@ func (w *Widget) setSelectedNodeID(ctx widget.Context, id string) {
 }
 
 // toggleNode toggles the expanded state of the given node.
-func (w *Widget) toggleNode(ctx widget.Context, node *TreeNode) {
+func (w *Widget) toggleNode(node *TreeNode) {
 	if node.IsLeaf() {
 		return
 	}

--- a/core/treeview/treeview.go
+++ b/core/treeview/treeview.go
@@ -203,10 +203,10 @@ func (w *Widget) Mount(ctx widget.Context) {
 
 	// Bind root signals.
 	if w.cfg.readonlyRootSignal != nil {
-		b := state.BindToScheduler(w.cfg.readonlyRootSignal, w, sched)
+		b := state.BindToSchedulerLayout(w.cfg.readonlyRootSignal, w, sched)
 		w.AddBinding(b)
 	} else if w.cfg.rootSignal != nil {
-		b := state.BindToScheduler(w.cfg.rootSignal, w, sched)
+		b := state.BindToSchedulerLayout(w.cfg.rootSignal, w, sched)
 		w.AddBinding(b)
 	}
 
@@ -457,8 +457,8 @@ func (w *Widget) toggleNode(ctx widget.Context, node *TreeNode) {
 		w.cfg.onToggle(node, node.Expanded)
 	}
 
-	// ADR-028: layout change — expand/collapse changes row count and tree height.
-	ctx.Invalidate()
+	// ADR-032: layout change — expand/collapse changes row count and tree height.
+	w.MarkNeedsLayout()
 }
 
 // buildConnectorState builds the connector state for the row at index i.

--- a/core/treeview/treeview_test.go
+++ b/core/treeview/treeview_test.go
@@ -1436,11 +1436,10 @@ func TestSetSelectedNodeID_SameValue_Noop(t *testing.T) {
 func TestToggleNode_LeafIgnored(t *testing.T) {
 	root := makeTestTree()
 	w := New(Root(root))
-	ctx := makeCtx()
 
 	gc1 := findNodeByID(root, "gc1")
 	rowsBefore := w.RowCount()
-	w.toggleNode(ctx, gc1)
+	w.toggleNode(gc1)
 
 	if w.RowCount() != rowsBefore {
 		t.Error("toggling leaf should not change row count")

--- a/state/binding.go
+++ b/state/binding.go
@@ -115,3 +115,51 @@ func BindToSchedulerFunc[T any](sig ReadonlySignal[T], shouldDirty func(T) bool,
 	b.cleanup = unsub
 	return b
 }
+
+// layoutInvalidator is satisfied by widgets that embed [widget.WidgetBase] and
+// support layout cache invalidation (ADR-032). Used by [BindToSchedulerLayout]
+// via type assertion so [widget.SchedulerRef] stays unchanged (no mock breakage).
+type layoutInvalidator interface {
+	MarkNeedsLayout()
+}
+
+// BindToSchedulerLayout creates a [Binding] that marks w as dirty in sched
+// AND invalidates its layout cache whenever sig changes.
+//
+// Use this for signals whose value affects the widget's measured size (text
+// content, item count, column count, ratio). Paint-only signals (color,
+// checked state, scroll offset) should use [BindToScheduler] instead.
+//
+// The layout invalidation uses a type assertion (not an interface extension)
+// so that [widget.SchedulerRef] and uitest mocks remain unchanged.
+func BindToSchedulerLayout[T any](sig ReadonlySignal[T], w widget.Widget, sched widget.SchedulerRef) *Binding {
+	b := &Binding{active: true}
+	unsub := sig.SubscribeForever(func(_ T) {
+		if lm, ok := w.(layoutInvalidator); ok {
+			lm.MarkNeedsLayout()
+		}
+		sched.MarkDirty(w)
+	})
+	b.cleanup = unsub
+	return b
+}
+
+// BindToSchedulerLayoutFunc creates a [Binding] that marks w as dirty in sched
+// AND invalidates its layout cache when sig changes AND the predicate returns true.
+//
+// This is the layout-aware variant of [BindToSchedulerFunc]. The predicate
+// suppresses redundant invalidations when the signal fires with a value that
+// doesn't actually change the widget's measured size.
+func BindToSchedulerLayoutFunc[T any](sig ReadonlySignal[T], shouldDirty func(T) bool, w widget.Widget, sched widget.SchedulerRef) *Binding {
+	b := &Binding{active: true}
+	unsub := sig.SubscribeForever(func(v T) {
+		if shouldDirty(v) {
+			if lm, ok := w.(layoutInvalidator); ok {
+				lm.MarkNeedsLayout()
+			}
+			sched.MarkDirty(w)
+		}
+	})
+	b.cleanup = unsub
+	return b
+}

--- a/state/binding_test.go
+++ b/state/binding_test.go
@@ -199,6 +199,87 @@ func TestBindToSchedulerFunc(t *testing.T) {
 	}
 }
 
+func TestBindToSchedulerLayout(t *testing.T) {
+	sig := state.NewSignal(0)
+	w := &mockWidget{name: "layout-test"}
+	var flushed []widget.Widget
+	sched := state.NewScheduler(func(dirty []widget.Widget) {
+		flushed = append(flushed, dirty...)
+	})
+
+	ctx := widget.NewContext()
+	widget.LayoutChild(w, ctx, geometry.Loose(geometry.Sz(100, 100)))
+	if !w.IsLayoutCacheValid() {
+		t.Fatal("cache should be valid after LayoutChild")
+	}
+
+	binding := state.BindToSchedulerLayout(sig.AsReadonly(), w, sched)
+	defer binding.Unbind()
+
+	sig.Set(1)
+
+	if w.IsLayoutCacheValid() {
+		t.Error("BindToSchedulerLayout must invalidate layout cache on signal change")
+	}
+	if got := sched.PendingCount(); got != 1 {
+		t.Errorf("pending count = %d, want 1", got)
+	}
+}
+
+func TestBindToSchedulerLayout_Unbind(t *testing.T) {
+	sig := state.NewSignal(0)
+	w := &mockWidget{name: "layout-unbind"}
+	sched := state.NewScheduler(func(_ []widget.Widget) {})
+
+	ctx := widget.NewContext()
+	widget.LayoutChild(w, ctx, geometry.Loose(geometry.Sz(100, 100)))
+
+	binding := state.BindToSchedulerLayout(sig.AsReadonly(), w, sched)
+	sig.Set(1)
+	binding.Unbind()
+	sched.Flush()
+
+	widget.LayoutChild(w, ctx, geometry.Loose(geometry.Sz(100, 100)))
+
+	sig.Set(2)
+	if !w.IsLayoutCacheValid() {
+		t.Error("after unbind, layout cache should remain valid")
+	}
+	if sched.PendingCount() != 0 {
+		t.Errorf("after unbind, pending = %d, want 0", sched.PendingCount())
+	}
+}
+
+func TestBindToSchedulerLayoutFunc(t *testing.T) {
+	sig := state.NewSignal(0.5)
+	w := &mockWidget{name: "layout-func"}
+	sched := state.NewScheduler(func(_ []widget.Widget) {})
+
+	ctx := widget.NewContext()
+	widget.LayoutChild(w, ctx, geometry.Loose(geometry.Sz(100, 100)))
+
+	binding := state.BindToSchedulerLayoutFunc(sig.AsReadonly(), func(v float64) bool {
+		return v > 0.5
+	}, w, sched)
+	defer binding.Unbind()
+
+	sig.Set(0.3)
+	if !w.IsLayoutCacheValid() {
+		t.Error("predicate false: layout cache should remain valid")
+	}
+	if sched.PendingCount() != 0 {
+		t.Errorf("predicate false: pending = %d, want 0", sched.PendingCount())
+	}
+
+	sig.Set(0.8)
+	if w.IsLayoutCacheValid() {
+		t.Error("predicate true: layout cache must be invalidated")
+	}
+	if sched.PendingCount() != 1 {
+		t.Errorf("predicate true: pending = %d, want 1", sched.PendingCount())
+	}
+}
+
 func TestBindToSchedulerFunc_Unbind(t *testing.T) {
 	sig := state.NewSignal(1.0)
 	w := &mockWidget{name: "bar"}

--- a/widget/layout_cache_test.go
+++ b/widget/layout_cache_test.go
@@ -331,6 +331,61 @@ func TestDebugVerifier_PanicsOnConstraintsViolation(t *testing.T) {
 	widget.LayoutChild(w, ctx, tight) // miss → assertConstraintsSatisfied → panic
 }
 
+// clwContainer is a clwWidget that holds children, for testing tree walks.
+type clwContainer struct {
+	clwWidget
+	children []widget.Widget
+}
+
+func (c *clwContainer) Children() []widget.Widget { return c.children }
+
+// --- MarkLayoutCleanRecursive ---
+
+func TestMarkLayoutCleanRecursive_SetsCleanOnTree(t *testing.T) {
+	child := newWB()
+	parent := &clwContainer{
+		clwWidget: *newWB(),
+		children:  []widget.Widget{child},
+	}
+
+	if parent.IsLayoutCacheValid() || child.IsLayoutCacheValid() {
+		t.Fatal("fresh widgets should start with invalid cache")
+	}
+
+	widget.MarkLayoutCleanRecursive(parent)
+
+	if !parent.IsLayoutCacheValid() {
+		t.Error("parent should be layout-clean after MarkLayoutCleanRecursive")
+	}
+	if !child.IsLayoutCacheValid() {
+		t.Error("child should be layout-clean after MarkLayoutCleanRecursive")
+	}
+}
+
+func TestMarkLayoutCleanRecursive_EnablesMarkNeedsLayout(t *testing.T) {
+	w := newWB()
+	widget.MarkLayoutCleanRecursive(w)
+
+	if !w.IsLayoutCacheValid() {
+		t.Fatal("should be clean after MarkLayoutCleanRecursive")
+	}
+
+	w.MarkNeedsLayout()
+
+	if w.IsLayoutCacheValid() {
+		t.Error("MarkNeedsLayout should invalidate after MarkLayoutCleanRecursive")
+	}
+}
+
+func TestMarkLayoutCleanRecursive_NilSafe(t *testing.T) {
+	widget.MarkLayoutCleanRecursive(nil) // must not panic
+}
+
+func TestMarkLayoutCleanRecursive_SkipsNonWidgetBase(t *testing.T) {
+	nb := &noBaseWidget{}
+	widget.MarkLayoutCleanRecursive(nb) // must not panic
+}
+
 func TestSetLayoutDebug_RestoresPrevious(t *testing.T) {
 	prev := widget.SetLayoutDebug(true)
 	if widget.SetLayoutDebug(prev) != true {

--- a/widget/layout_clean.go
+++ b/widget/layout_clean.go
@@ -1,0 +1,29 @@
+package widget
+
+// MarkLayoutCleanRecursive walks the widget tree rooted at w and marks every
+// WidgetBase-embedding widget as layout-clean (layoutCacheValid = true).
+//
+// This is called by the Window after a full-tree layout pass so that
+// MarkNeedsLayout()'s idempotency guard works before LayoutChild activates
+// per-widget caching. Without this shim, layoutCacheValid is never set to
+// true (its zero value is false), so MarkNeedsLayout() is a permanent no-op.
+//
+// When LayoutChild is adopted (PR 2b), layoutCacheStore handles the cache
+// lifecycle and this function becomes redundant (harmless but unnecessary).
+func MarkLayoutCleanRecursive(w Widget) {
+	if w == nil {
+		return
+	}
+	if lc, ok := w.(interface{ markLayoutClean() }); ok {
+		lc.markLayoutClean()
+	}
+	for _, child := range w.Children() {
+		MarkLayoutCleanRecursive(child)
+	}
+}
+
+func (w *WidgetBase) markLayoutClean() {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.layoutCacheValid = true
+}


### PR DESCRIPTION
## Summary

Wire `MarkNeedsLayout()` into all layout-affecting signal bindings and event handlers, establishing the invalidation path for ADR-032 layout caching — without activating per-widget caching yet (that's PR 2b via `LayoutChild`).

- **Signal bindings (11 sites):** `BindToScheduler` → `BindToSchedulerLayout` for button/text, checkbox/label, chip/label, badge/count, collapsible/expanded, treeview/root, listview/itemCount, gridview/itemCount+columns, datatable/rowCount, splitview/ratio
- **Event handlers (9 sites):** `ctx.Invalidate()` → `w.MarkNeedsLayout()` in collapsible/toggle, datatable/sort, docking/tab+close, splitview/drag, tabview/close+select, treeview/expand
- **Infrastructure:** `BindToSchedulerLayout`/`BindToSchedulerLayoutFunc` in state/binding.go, `MarkLayoutCleanRecursive` in widget/layout_clean.go, window layout pass fix in app/window.go (clear before layout, mark clean after)

Animation ticks (collapsible, transition) retain `ctx.Invalidate()` pending a BeginFrame mechanism (GAP-3).

Depends on #143.
Ref: #142

## Changed files (19)

| Area | Files | What |
|------|-------|------|
| Infrastructure | `state/binding.go`, `widget/layout_clean.go`, `app/window.go` | New binding variants, post-layout clean walk, layout pass fix |
| Signal bindings | 10 widget files | `BindToScheduler` → `BindToSchedulerLayout` |
| Event handlers | `collapsible/event.go`, `datatable/datatable.go`, `docking/host.go`, `splitview/splitview.go`, `tabview/event.go`, `treeview/treeview.go` | `ctx.Invalidate()` → `MarkNeedsLayout()` |
| Tests | `state/binding_test.go`, `collapsible/internal_test.go`, `tabview/internal_test.go` | New binding tests + updated guard tests |

## Design decisions

1. **`BindToSchedulerLayout` uses type assertion, not interface extension** — avoids breaking `SchedulerRef` / mocks. The `layoutInvalidator` interface is private to `state/binding.go`.
2. **`MarkLayoutCleanRecursive` after window layout** — needed because `layoutCacheValid` defaults to `false` (Go zero value), so `MarkNeedsLayout()`'s idempotency guard would be a permanent no-op without it.
3. **Window clears `needsLayout` before layout** — supports both `ctx.Invalidate()` and `MarkNeedsLayout()` re-invalidation during layout (animation ticks).
4. **Animation ticks keep `ctx.Invalidate()`** — continuous per-frame animations need window-level re-invalidation; `MarkNeedsLayout()` guard prevents re-entry during the same layout pass. Proper fix (tick in BeginFrame) is GAP-3.

## Test plan

- [x] `go test ./...` — all packages pass
- [x] 3 new `BindToSchedulerLayout` tests (basic, unbind, predicate)
- [x] 3 updated guard tests assert `IsLayoutCacheValid()` instead of `ctx.IsInvalidated()`
- [x] All 18 existing layout cache tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)