### PR TITLE
feat: painter/widget behavior separation + LayoutMetrics + ThemeBundle (ADR-034)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,35 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.37] — 2026-06-27
+
+### Added
+
+- **Painter/Widget behavior separation** (ADR-034) — enterprise-level refactor moving ALL behavioral logic (cursor position, selection, text measurement, animation easing, data mapping) from theme painters to core widgets. Painters are now draw-only. Enables community theme authoring.
+- **LayoutMetrics optional interface** — 7 widgets (button, checkbox, radio, slider, chip, dialog, textfield) define LayoutMetrics allowing theme painters to control spatial metrics (height, padding, fontSize, radius). 35 compile-time checked implementations across 5 painters.
+- **ThemeBundle interface** (`theme.Bundle`) — packages all painters for complete theme installation. Community themes implement this to provide a full design system.
+- **Gallery: 8 themes** — Fluent and Cupertino added to theme switcher alongside M3 (4 colors) + DevTools (dark/light).
+- **internal/textmetrics** — shared MeasureText-based text measurement replacing per-painter charWidthRatio estimates.
+
+### Fixed
+
+- **DevTools cursor wrong position** ([#126](https://github.com/gogpu/ui/issues/126)) — cursor position was computed differently per theme (MeasureText vs charWidthRatio). Now all themes use widget-computed CursorRect via MeasureText.
+- **Cursor height** — added 2px caretHeightOffset (Flutter `_kCaretHeightOffset` pattern) for cleaner cursor appearance.
+
+### Changed (breaking, v0.x)
+
+- **TextField PaintState** — expanded with pre-computed fields (DisplayText, ContentRect, CursorRect, SelectionRect, ShowCursor, ShowSelection, FontSize, ColorScheme). Pointer receiver (`*PaintState`).
+- **titlebar Painter** — `DrawBackground`/`DrawControlButton` renamed to `PaintBackground`/`PaintControlButton`.
+- **linechart Painter** — `PaintChart(canvas, bounds, state)` → `PaintChart(canvas, state)` with Bounds in PaintState.
+- **progressbar PaintState** — `ProgressBarColorScheme` field renamed to `ColorScheme`.
+
+### Removed
+
+- 4 duplicate `maskText` functions (one per theme painter — now single in core)
+- 4 duplicate `contentRect` functions (now computed by widget)
+- `charWidthRatio` constants from all theme textfield painters
+- `easeInOut` duplicate from M3 progress painter
+
 ## [0.1.36] — 2026-06-25
 
 ### Added

--- a/core/button/painter.go
+++ b/core/button/painter.go
@@ -46,8 +46,30 @@ type ButtonColorScheme struct {
 	FocusRing      widget.Color
 }
 
+// LayoutMetrics allows theme painters to provide spatial metrics used by the
+// widget's Layout method to compute height, padding, and font size.
+//
+// Painters that implement this interface provide custom per-size metrics.
+// Painters that do not implement it get default values from [DefaultPainter].
+type LayoutMetrics interface {
+	// ButtonHeight returns the target height in logical pixels for the given size.
+	ButtonHeight(size Size) float32
+
+	// ButtonPadding returns the horizontal and vertical padding for the given size.
+	ButtonPadding(size Size) (paddingX, paddingY float32)
+
+	// ButtonFontSize returns the font size in logical pixels for the given size.
+	ButtonFontSize(size Size) float32
+
+	// ButtonRadius returns the default corner radius for the button.
+	ButtonRadius() float32
+}
+
 // DefaultPainter provides a minimal fallback painter with no design system styling.
 // It draws a simple gray button -- useful for testing and as a base reference.
+//
+// DefaultPainter also implements [LayoutMetrics], providing the default spatial
+// values used when a painter does not implement that interface.
 type DefaultPainter struct{}
 
 // PaintButton renders a minimal button with gray background and black text.
@@ -102,6 +124,32 @@ func (p DefaultPainter) PaintButton(canvas widget.Canvas, state PaintState) {
 		drawFocusIndicator(canvas, state.Bounds, radius)
 	}
 }
+
+// ButtonHeight returns the default height for the given button size.
+func (DefaultPainter) ButtonHeight(size Size) float32 { return sizeHeight(size) }
+
+// ButtonPadding returns the default horizontal and vertical padding.
+func (DefaultPainter) ButtonPadding(_ Size) (float32, float32) {
+	return defaultPaddingX, defaultPaddingY
+}
+
+// ButtonFontSize returns the default font size for the given button size.
+func (DefaultPainter) ButtonFontSize(size Size) float32 { return sizeFontSize(size) }
+
+// ButtonRadius returns the default corner radius.
+func (DefaultPainter) ButtonRadius() float32 { return defaultRadius }
+
+// resolveButtonLayoutMetrics returns the LayoutMetrics from the painter if it
+// implements that interface, otherwise returns DefaultPainter metrics.
+func resolveButtonLayoutMetrics(p Painter) LayoutMetrics {
+	if lm, ok := p.(LayoutMetrics); ok {
+		return lm
+	}
+	return DefaultPainter{}
+}
+
+// Compile-time checks.
+var _ LayoutMetrics = DefaultPainter{}
 
 // Default colors for DefaultPainter.
 var (

--- a/core/button/widget.go
+++ b/core/button/widget.go
@@ -84,14 +84,18 @@ func (w *Widget) IsFocusable() bool {
 
 // Layout calculates the button's preferred size within the given constraints.
 func (w *Widget) Layout(_ widget.Context, constraints geometry.Constraints) geometry.Size {
-	height := sizeHeight(w.cfg.size)
+	// Query LayoutMetrics from painter (type assert with default fallback).
+	lm := resolveButtonLayoutMetrics(w.painter)
+
+	height := lm.ButtonHeight(w.cfg.size)
+	fontSize := lm.ButtonFontSize(w.cfg.size)
+	padX, padY := lm.ButtonPadding(w.cfg.size)
 
 	// Estimate text width: approximate at ~7px per character for medium font.
 	text := w.cfg.ResolvedText()
-	fontSize := sizeFontSize(w.cfg.size)
 	textWidth := float32(len(text)) * fontSize * charWidthRatio
 
-	totalWidth := textWidth + w.paddingX*2
+	totalWidth := textWidth + padX*2
 	totalHeight := height
 
 	// Apply min/max width overrides.
@@ -103,8 +107,8 @@ func (w *Widget) Layout(_ widget.Context, constraints geometry.Constraints) geom
 	}
 
 	// Ensure height accounts for vertical padding.
-	if totalHeight < w.paddingY*2 {
-		totalHeight = w.paddingY * 2
+	if totalHeight < padY*2 {
+		totalHeight = padY * 2
 	}
 
 	preferred := geometry.Sz(totalWidth, totalHeight)

--- a/core/checkbox/painter.go
+++ b/core/checkbox/painter.go
@@ -42,8 +42,27 @@ type CheckboxColorScheme struct {
 	FocusRing       widget.Color
 }
 
+// LayoutMetrics allows theme painters to provide spatial metrics used by the
+// widget's Layout method to compute box size, label gap, and font size.
+//
+// Painters that implement this interface provide custom metrics.
+// Painters that do not implement it get default values from [DefaultPainter].
+type LayoutMetrics interface {
+	// CheckboxBoxSize returns the checkbox square size in logical pixels.
+	CheckboxBoxSize() float32
+
+	// CheckboxLabelGap returns the gap between the checkbox box and label text.
+	CheckboxLabelGap() float32
+
+	// CheckboxFontSize returns the font size for the label text.
+	CheckboxFontSize() float32
+}
+
 // DefaultPainter provides a minimal fallback painter with no design system styling.
 // It draws a simple checkbox -- useful for testing and as a base reference.
+//
+// DefaultPainter also implements [LayoutMetrics], providing the default spatial
+// values used when a painter does not implement that interface.
 type DefaultPainter struct{}
 
 // PaintCheckbox renders a minimal checkbox with gray colors.
@@ -89,3 +108,24 @@ func resolveLabelColor(state PaintState, hasScheme bool) widget.Color {
 	}
 	return defaultLabelColor
 }
+
+// CheckboxBoxSize returns the default checkbox square size.
+func (DefaultPainter) CheckboxBoxSize() float32 { return boxSize }
+
+// CheckboxLabelGap returns the default gap between box and label.
+func (DefaultPainter) CheckboxLabelGap() float32 { return labelGap }
+
+// CheckboxFontSize returns the default font size for the label.
+func (DefaultPainter) CheckboxFontSize() float32 { return defaultFontSize }
+
+// resolveCheckboxLayoutMetrics returns the LayoutMetrics from the painter if it
+// implements that interface, otherwise returns DefaultPainter metrics.
+func resolveCheckboxLayoutMetrics(p Painter) LayoutMetrics {
+	if lm, ok := p.(LayoutMetrics); ok {
+		return lm
+	}
+	return DefaultPainter{}
+}
+
+// Compile-time checks.
+var _ LayoutMetrics = DefaultPainter{}

--- a/core/checkbox/widget.go
+++ b/core/checkbox/widget.go
@@ -74,14 +74,21 @@ func (w *Widget) IsFocusable() bool {
 
 // Layout calculates the checkbox's preferred size within the given constraints.
 func (w *Widget) Layout(_ widget.Context, constraints geometry.Constraints) geometry.Size {
+	// Query LayoutMetrics from painter (type assert with default fallback).
+	lm := resolveCheckboxLayoutMetrics(w.painter)
+
+	bs := lm.CheckboxBoxSize()
+	gap := lm.CheckboxLabelGap()
+	fontSize := lm.CheckboxFontSize()
+
 	// Box size + optional label width.
-	totalWidth := boxSize + w.padding*2
-	totalHeight := boxSize + w.padding*2
+	totalWidth := bs + w.padding*2
+	totalHeight := bs + w.padding*2
 
 	label := w.cfg.ResolvedLabel()
 	if label != "" {
-		textWidth := float32(len(label)) * defaultFontSize * charWidthRatio
-		totalWidth += labelGap + textWidth
+		textWidth := float32(len(label)) * fontSize * charWidthRatio
+		totalWidth += gap + textWidth
 	}
 
 	// Ensure minimum height.

--- a/core/chip/chip.go
+++ b/core/chip/chip.go
@@ -112,12 +112,19 @@ func (w *Widget) applySelected(sel bool) {
 
 // Layout calculates the chip's preferred size within the given constraints.
 func (w *Widget) Layout(_ widget.Context, constraints geometry.Constraints) geometry.Size {
-	text := w.cfg.ResolvedLabel()
-	textWidth := float32(len(text)) * defaultFontSize * charWidthRatio
+	// Query LayoutMetrics from painter (type assert with default fallback).
+	lm := resolveChipLayoutMetrics(w.painter)
 
-	contentW := textWidth + labelPaddingX*2
-	if contentW < minChipWidth {
-		contentW = minChipWidth
+	fontSize := lm.ChipFontSize()
+	minW := lm.ChipMinWidth()
+	padX := lm.ChipPadding()
+
+	text := w.cfg.ResolvedLabel()
+	textWidth := float32(len(text)) * fontSize * charWidthRatio
+
+	contentW := textWidth + padX*2
+	if contentW < minW {
+		contentW = minW
 	}
 
 	preferred := geometry.Sz(
@@ -129,11 +136,14 @@ func (w *Widget) Layout(_ widget.Context, constraints geometry.Constraints) geom
 
 // Draw renders the chip to the canvas.
 func (w *Widget) Draw(_ widget.Context, canvas widget.Canvas) {
+	// Query LayoutMetrics from painter (type assert with default fallback).
+	lm := resolveChipLayoutMetrics(w.painter)
+
 	w.painter.PaintChip(canvas, PaintState{
 		Label:       w.cfg.ResolvedLabel(),
 		Bounds:      w.contentBounds(),
-		Radius:      defaultChipRadius,
-		FontSize:    defaultFontSize,
+		Radius:      lm.ChipRadius(),
+		FontSize:    lm.ChipFontSize(),
 		Selectable:  w.cfg.selectable,
 		Selected:    w.cfg.ResolvedSelected(),
 		Hovered:     w.state == stateHover,

--- a/core/chip/painter.go
+++ b/core/chip/painter.go
@@ -12,6 +12,25 @@ type Painter interface {
 	PaintChip(canvas widget.Canvas, state PaintState)
 }
 
+// LayoutMetrics allows theme painters to provide spatial metrics used by the
+// widget's Layout method to compute chip dimensions.
+//
+// Painters that implement this interface provide custom metrics.
+// Painters that do not implement it get default values from [DefaultPainter].
+type LayoutMetrics interface {
+	// ChipFontSize returns the font size for the chip label.
+	ChipFontSize() float32
+
+	// ChipMinWidth returns the minimum chip width in logical pixels.
+	ChipMinWidth() float32
+
+	// ChipPadding returns the horizontal padding inside the chip.
+	ChipPadding() float32
+
+	// ChipRadius returns the corner radius for the chip.
+	ChipRadius() float32
+}
+
 // PaintState provides the current chip state to the painter.
 type PaintState struct {
 	Label       string          // chip label text
@@ -140,6 +159,30 @@ func resolveDisabledBackground(ps PaintState, hasScheme bool) widget.Color {
 	}
 	return defaultDisabledBackground
 }
+
+// ChipFontSize returns the default font size.
+func (DefaultPainter) ChipFontSize() float32 { return defaultFontSize }
+
+// ChipMinWidth returns the default minimum chip width.
+func (DefaultPainter) ChipMinWidth() float32 { return minChipWidth }
+
+// ChipPadding returns the default horizontal padding.
+func (DefaultPainter) ChipPadding() float32 { return labelPaddingX }
+
+// ChipRadius returns the default corner radius.
+func (DefaultPainter) ChipRadius() float32 { return defaultChipRadius }
+
+// resolveChipLayoutMetrics returns the LayoutMetrics from the painter if it
+// implements that interface, otherwise returns DefaultPainter metrics.
+func resolveChipLayoutMetrics(p Painter) LayoutMetrics {
+	if lm, ok := p.(LayoutMetrics); ok {
+		return lm
+	}
+	return DefaultPainter{}
+}
+
+// Compile-time checks.
+var _ LayoutMetrics = DefaultPainter{}
 
 // Painting constants.
 const (

--- a/core/dialog/painter.go
+++ b/core/dialog/painter.go
@@ -22,6 +22,12 @@ type PaintState struct {
 	Focused     bool
 	Bounds      geometry.Rect // dialog surface bounds (not backdrop)
 	ColorScheme DialogColorScheme
+
+	// ActionRects holds pre-computed button positions (one per action).
+	// The widget computes these using canvas.MeasureText for accurate layout.
+	// Painters should draw action buttons at these positions rather than
+	// computing button widths from character count estimates.
+	ActionRects []geometry.Rect
 }
 
 // DialogColorScheme provides theme-derived colors for dialog painting.
@@ -118,7 +124,15 @@ func (p DefaultPainter) paintActions(canvas widget.Canvas, ps PaintState, hasSch
 		actionFg = ps.ColorScheme.ActionFg
 	}
 
-	// Layout actions from right to left.
+	// Use pre-computed ActionRects when available (ADR-034 Phase 4).
+	if len(ps.ActionRects) == len(ps.Actions) {
+		for i, action := range ps.Actions {
+			canvas.DrawText(action.Label, ps.ActionRects[i], actionFontSize, actionFg, false, textAlignCenter)
+		}
+		return
+	}
+
+	// Legacy fallback: compute button layout from character count estimate.
 	x := ps.Bounds.Max.X - dialogPadding
 	y := ps.Bounds.Max.Y - dialogPadding - actionHeight
 

--- a/core/dialog/painter.go
+++ b/core/dialog/painter.go
@@ -37,8 +37,27 @@ type DialogColorScheme struct {
 	ActionBg widget.Color // primary action button background
 }
 
+// LayoutMetrics allows theme painters to provide spatial metrics used by the
+// widget's layout calculations to compute dialog dimensions.
+//
+// Painters that implement this interface provide custom metrics.
+// Painters that do not implement it get default values from [DefaultPainter].
+type LayoutMetrics interface {
+	// DialogPadding returns the internal padding of the dialog surface.
+	DialogPadding() float32
+
+	// DialogTitleHeight returns the height reserved for the title text.
+	DialogTitleHeight() float32
+
+	// DialogMaxWidth returns the default maximum width for the dialog.
+	DialogMaxWidth() float32
+}
+
 // DefaultPainter provides a minimal fallback painter with no design system styling.
 // It draws a simple dialog -- useful for testing and as a base reference.
+//
+// DefaultPainter also implements [LayoutMetrics], providing the default spatial
+// values used when a painter does not implement that interface.
 type DefaultPainter struct{}
 
 // PaintDialog renders a minimal dialog with white surface and gray border.
@@ -114,6 +133,27 @@ func (p DefaultPainter) paintActions(canvas widget.Canvas, ps PaintState, hasSch
 		x -= actionSpacing
 	}
 }
+
+// DialogPadding returns the default dialog padding.
+func (DefaultPainter) DialogPadding() float32 { return dialogPadding }
+
+// DialogTitleHeight returns the default title height.
+func (DefaultPainter) DialogTitleHeight() float32 { return titleHeight }
+
+// DialogMaxWidth returns the default maximum width.
+func (DefaultPainter) DialogMaxWidth() float32 { return defaultMaxWidth }
+
+// resolveDialogLayoutMetrics returns the LayoutMetrics from the painter if it
+// implements that interface, otherwise returns DefaultPainter metrics.
+func resolveDialogLayoutMetrics(p Painter) LayoutMetrics {
+	if lm, ok := p.(LayoutMetrics); ok {
+		return lm
+	}
+	return DefaultPainter{}
+}
+
+// Compile-time checks.
+var _ LayoutMetrics = DefaultPainter{}
 
 // Default painting constants.
 const (

--- a/core/dialog/widget.go
+++ b/core/dialog/widget.go
@@ -176,9 +176,12 @@ func (w *Widget) Unmount() {
 // computeDialogBounds calculates the centered dialog surface bounds
 // within the given window size.
 func (w *Widget) computeDialogBounds(windowSize geometry.Size) geometry.Rect {
+	// Query LayoutMetrics from painter (type assert with default fallback).
+	lm := resolveDialogLayoutMetrics(w.painter)
+
 	maxW := w.cfg.maxWidth
 	if maxW <= 0 {
-		maxW = defaultMaxWidth
+		maxW = lm.DialogMaxWidth()
 	}
 
 	// Constrain to window bounds.

--- a/core/dialog/widget.go
+++ b/core/dialog/widget.go
@@ -219,6 +219,48 @@ func (w *Widget) computeDialogBounds(windowSize geometry.Size) geometry.Rect {
 	return geometry.NewRect(x, y, maxW, dialogH)
 }
 
+// computeActionRects pre-computes action button rects using MeasureText for
+// accurate text measurement. This is the preferred path when a canvas is
+// available (during Draw). Buttons are laid out right-to-left.
+func computeActionRects(canvas widget.Canvas, dialogBounds geometry.Rect, actions []Action) []geometry.Rect {
+	if len(actions) == 0 {
+		return nil
+	}
+
+	rects := make([]geometry.Rect, len(actions))
+	x := dialogBounds.Max.X - dialogPadding
+	y := dialogBounds.Max.Y - dialogPadding - actionHeight
+
+	for i := len(actions) - 1; i >= 0; i-- {
+		textW := canvas.MeasureText(actions[i].Label, actionFontSize, false)
+		btnWidth := textW + actionPaddingX*2
+		x -= btnWidth
+		rects[i] = geometry.NewRect(x, y, btnWidth, actionHeight)
+		x -= actionSpacing
+	}
+	return rects
+}
+
+// computeActionRectsLegacy computes action button rects using the character
+// count estimate. Used for hit-testing when no canvas is available.
+func computeActionRectsLegacy(dialogBounds geometry.Rect, actions []Action) []geometry.Rect {
+	if len(actions) == 0 {
+		return nil
+	}
+
+	rects := make([]geometry.Rect, len(actions))
+	x := dialogBounds.Max.X - dialogPadding
+	y := dialogBounds.Max.Y - dialogPadding - actionHeight
+
+	for i := len(actions) - 1; i >= 0; i-- {
+		btnWidth := float32(len(actions[i].Label))*actionCharWidth + actionPaddingX*2
+		x -= btnWidth
+		rects[i] = geometry.NewRect(x, y, btnWidth, actionHeight)
+		x -= actionSpacing
+	}
+	return rects
+}
+
 // Compile-time interface checks.
 var (
 	_ widget.Widget    = (*Widget)(nil)
@@ -282,13 +324,17 @@ func (s *surfaceWidget) Draw(ctx widget.Context, canvas widget.Canvas) {
 	windowSize := ctx.WindowSize()
 	dialogBounds := d.computeDialogBounds(windowSize)
 
+	// Pre-compute action button rects using MeasureText (ADR-034 Phase 4).
+	actionRects := computeActionRects(canvas, dialogBounds, d.cfg.actions)
+
 	// Delegate to painter for the dialog surface.
 	d.painter.PaintDialog(canvas, PaintState{
-		Title:      d.cfg.ResolvedTitle(),
-		HasContent: d.cfg.content != nil,
-		Actions:    d.cfg.actions,
-		Focused:    s.focusIndex >= 0,
-		Bounds:     dialogBounds,
+		Title:       d.cfg.ResolvedTitle(),
+		HasContent:  d.cfg.content != nil,
+		Actions:     d.cfg.actions,
+		Focused:     s.focusIndex >= 0,
+		Bounds:      dialogBounds,
+		ActionRects: actionRects,
 	})
 
 	// Draw content widget if present.
@@ -406,17 +452,12 @@ func (s *surfaceWidget) handleActionClick(ctx widget.Context, e *event.MouseEven
 		return
 	}
 
-	// Action buttons are right-aligned at the bottom.
-	x := dialogBounds.Max.X - dialogPadding
-	y := dialogBounds.Max.Y - dialogPadding - actionHeight
+	// Use the same pre-computed rects as painting (ADR-034 Phase 4).
+	// Fall back to legacy charWidth estimate if no canvas available.
+	actionRects := computeActionRectsLegacy(dialogBounds, d.cfg.actions)
 
-	for i := len(d.cfg.actions) - 1; i >= 0; i-- {
-		label := d.cfg.actions[i].Label
-		btnWidth := float32(len(label))*actionCharWidth + actionPaddingX*2
-		x -= btnWidth
-
-		btnBounds := geometry.NewRect(x, y, btnWidth, actionHeight)
-		if btnBounds.Contains(e.Position) {
+	for i, rect := range actionRects {
+		if rect.Contains(e.Position) {
 			action := d.cfg.actions[i]
 			if action.OnClick != nil {
 				action.OnClick()
@@ -424,8 +465,6 @@ func (s *surfaceWidget) handleActionClick(ctx widget.Context, e *event.MouseEven
 			d.doClose(ctx)
 			return
 		}
-
-		x -= actionSpacing
 	}
 }
 

--- a/core/linechart/linechart.go
+++ b/core/linechart/linechart.go
@@ -347,7 +347,8 @@ func (w *Widget) Draw(_ widget.Context, canvas widget.Canvas) {
 
 	// Build PaintState from current data.
 	chartState := w.buildPaintState()
-	w.painter.PaintChart(canvas, bounds, chartState)
+	chartState.Bounds = bounds
+	w.painter.PaintChart(canvas, chartState)
 }
 
 // buildPaintState creates a read-only snapshot for the painter.

--- a/core/linechart/linechart.go
+++ b/core/linechart/linechart.go
@@ -346,14 +346,15 @@ func (w *Widget) Draw(_ widget.Context, canvas widget.Canvas) {
 	}
 
 	// Build PaintState from current data.
-	chartState := w.buildPaintState()
-	chartState.Bounds = bounds
+	chartState := w.buildPaintState(bounds)
 	w.painter.PaintChart(canvas, chartState)
 }
 
 // buildPaintState creates a read-only snapshot for the painter.
-func (w *Widget) buildPaintState() PaintState {
+// Pre-computes plot geometry so painters only draw (ADR-034 Phase 4).
+func (w *Widget) buildPaintState(bounds geometry.Rect) PaintState {
 	cs := PaintState{
+		Bounds:     bounds,
 		MaxPoints:  w.cfg.maxPoints,
 		YMin:       w.cfg.yMin,
 		YMax:       w.cfg.yMax,
@@ -373,7 +374,67 @@ func (w *Widget) buildPaintState() PaintState {
 		w.mu.Unlock()
 	}
 
+	// Pre-compute plot geometry (ADR-034 Phase 4).
+	cs.PlotArea = computePlotArea(bounds, cs.ShowLabels)
+	cs.GridLines = w.computeGridLines(cs.PlotArea, cs.YMin, cs.YMax)
+	cs.SeriesLines = w.computeSeriesLines(cs.PlotArea, cs.Series, cs.YMin, cs.YMax)
+
 	return cs
+}
+
+// computeGridLines pre-computes Y grid line positions and labels.
+func (w *Widget) computeGridLines(plotArea geometry.Rect, yMin, yMax float64) []GridLine {
+	if plotArea.IsEmpty() {
+		return nil
+	}
+	lines := make([]GridLine, 0, gridDivisions+1)
+	yRange := yMax - yMin
+	for i := 0; i <= gridDivisions; i++ {
+		t := float64(i) / float64(gridDivisions)
+		value := yMin + t*yRange
+		y := plotArea.Max.Y - float32(t)*plotArea.Height()
+		lines = append(lines, GridLine{
+			Y:     y,
+			Label: formatLabel(value, yMin, yMax),
+		})
+	}
+	return lines
+}
+
+// computeSeriesLines pre-computes pixel coordinates for each data series.
+func (w *Widget) computeSeriesLines(plotArea geometry.Rect, series []Series, yMin, yMax float64) [][]geometry.Point {
+	if plotArea.IsEmpty() || len(series) == 0 {
+		return nil
+	}
+
+	yRange := yMax - yMin
+	if yRange <= zeroThreshold && yRange >= -zeroThreshold {
+		return nil
+	}
+
+	slots := w.cfg.maxPoints - 1
+	if slots < 1 {
+		slots = 1
+	}
+	xStep := plotArea.Width() / float32(slots)
+
+	result := make([][]geometry.Point, len(series))
+	for si, s := range series {
+		pointCount := len(s.Points)
+		if pointCount < 2 {
+			result[si] = nil
+			continue
+		}
+		startX := plotArea.Max.X - float32(pointCount-1)*xStep
+		pts := make([]geometry.Point, pointCount)
+		for i := 0; i < pointCount; i++ {
+			x := startX + float32(i)*xStep
+			y := yForValue(s.Points[i].Value, plotArea, yMin, yRange)
+			pts[i] = geometry.Pt(x, y)
+		}
+		result[si] = pts
+	}
+	return result
 }
 
 // Event handles an input event and returns true if consumed.

--- a/core/linechart/linechart_test.go
+++ b/core/linechart/linechart_test.go
@@ -553,7 +553,7 @@ func TestPadding_Chaining(t *testing.T) {
 func TestDefaultPainter_EmptyBounds(t *testing.T) {
 	p := DefaultPainter{}
 	canvas := &recordingCanvas{}
-	p.PaintChart(canvas, geometry.Rect{}, PaintState{})
+	p.PaintChart(canvas, PaintState{})
 
 	if canvas.drawCount > 0 {
 		t.Error("should not draw with empty bounds")
@@ -572,8 +572,8 @@ func TestDefaultPainter_ZeroYRange(t *testing.T) {
 		},
 		Background: defaultBackground,
 	}
-	bounds := geometry.NewRect(0, 0, 400, 200)
-	p.PaintChart(canvas, bounds, cs)
+	cs.Bounds = geometry.NewRect(0, 0, 400, 200)
+	p.PaintChart(canvas, cs)
 
 	// Should draw background but no lines (zero range).
 	if canvas.lineCount > 0 {
@@ -596,8 +596,8 @@ func TestDefaultPainter_ClampValues(t *testing.T) {
 			}},
 		},
 	}
-	bounds := geometry.NewRect(0, 0, 400, 200)
-	p.PaintChart(canvas, bounds, cs)
+	cs.Bounds = geometry.NewRect(0, 0, 400, 200)
+	p.PaintChart(canvas, cs)
 
 	// Should draw 1 line segment, clamped to bounds.
 	if canvas.lineCount != 1 {
@@ -760,7 +760,7 @@ type mockPainter struct {
 	called bool
 }
 
-func (p *mockPainter) PaintChart(_ widget.Canvas, _ geometry.Rect, _ PaintState) {
+func (p *mockPainter) PaintChart(_ widget.Canvas, _ PaintState) {
 	p.called = true
 }
 

--- a/core/linechart/painter.go
+++ b/core/linechart/painter.go
@@ -5,6 +5,12 @@ import (
 	"github.com/gogpu/ui/widget"
 )
 
+// GridLine holds a pre-computed Y grid position and its formatted label.
+type GridLine struct {
+	Y     float32 // Y pixel coordinate within the plot area
+	Label string  // formatted value string
+}
+
 // PaintState holds the read-only snapshot passed to the painter.
 type PaintState struct {
 	Bounds     geometry.Rect // total widget bounds
@@ -16,6 +22,13 @@ type PaintState struct {
 	ShowLabels bool
 	GridColor  widget.Color
 	Background widget.Color
+
+	// Pre-computed plot geometry (ADR-034 Phase 4).
+	// The widget computes these from Bounds and data. Painters should use
+	// these instead of recomputing data-to-pixel mapping.
+	PlotArea    geometry.Rect      // computed plot area (after label margins)
+	GridLines   []GridLine         // pre-computed Y grid positions + labels
+	SeriesLines [][]geometry.Point // pre-computed pixel coordinates per series
 }
 
 // Painter renders the chart visuals.
@@ -42,8 +55,12 @@ func (p DefaultPainter) PaintChart(canvas widget.Canvas, cs PaintState) {
 	// Background fill.
 	canvas.DrawRect(bounds, cs.Background)
 
-	// Compute the plot area (inset for labels if enabled).
-	plotArea := computePlotArea(bounds, cs.ShowLabels)
+	// Prefer pre-computed plot data (ADR-034 Phase 4).
+	plotArea := cs.PlotArea
+	if plotArea.IsEmpty() {
+		// Legacy fallback.
+		plotArea = computePlotArea(bounds, cs.ShowLabels)
+	}
 
 	if plotArea.Width() <= 0 || plotArea.Height() <= 0 {
 		return
@@ -55,17 +72,31 @@ func (p DefaultPainter) PaintChart(canvas widget.Canvas, cs PaintState) {
 
 	// Grid lines.
 	if cs.ShowGrid {
-		drawGrid(canvas, plotArea, cs)
+		if len(cs.GridLines) > 0 {
+			drawPrecomputedGrid(canvas, plotArea, cs.GridLines, cs.GridColor)
+		} else {
+			drawGrid(canvas, plotArea, cs)
+		}
 	}
 
 	// Y-axis labels.
 	if cs.ShowLabels {
-		drawLabels(canvas, bounds, plotArea, cs)
+		if len(cs.GridLines) > 0 {
+			drawPrecomputedLabels(canvas, bounds, cs.GridLines, defaultLabelColor)
+		} else {
+			drawLabels(canvas, bounds, plotArea, cs)
+		}
 	}
 
 	// Data lines.
-	for _, series := range cs.Series {
-		drawSeriesLine(canvas, plotArea, series, cs)
+	if len(cs.SeriesLines) == len(cs.Series) {
+		for i, series := range cs.Series {
+			drawPrecomputedSeries(canvas, cs.SeriesLines[i], series.Color)
+		}
+	} else {
+		for _, series := range cs.Series {
+			drawSeriesLine(canvas, plotArea, series, cs)
+		}
 	}
 }
 
@@ -165,4 +196,33 @@ func yForValue(value float64, plotArea geometry.Rect, yMin, yRange float64) floa
 		t = 1
 	}
 	return plotArea.Max.Y - float32(t)*plotArea.Height()
+}
+
+// drawPrecomputedGrid draws horizontal grid lines at pre-computed Y positions.
+func drawPrecomputedGrid(canvas widget.Canvas, plotArea geometry.Rect, gridLines []GridLine, gridColor widget.Color) {
+	for _, gl := range gridLines {
+		from := geometry.Pt(plotArea.Min.X, gl.Y)
+		to := geometry.Pt(plotArea.Max.X, gl.Y)
+		canvas.DrawLine(from, to, gridColor, gridLineWidth)
+	}
+}
+
+// drawPrecomputedLabels draws Y-axis labels at pre-computed positions.
+func drawPrecomputedLabels(canvas widget.Canvas, bounds geometry.Rect, gridLines []GridLine, color widget.Color) {
+	for _, gl := range gridLines {
+		labelBounds := geometry.NewRect(
+			bounds.Min.X,
+			gl.Y-labelFontSize/2,
+			labelAreaWidth-labelPadding,
+			labelFontSize,
+		)
+		canvas.DrawText(gl.Label, labelBounds, labelFontSize, color, false, labelAlign)
+	}
+}
+
+// drawPrecomputedSeries draws connected line segments from pre-computed pixel coordinates.
+func drawPrecomputedSeries(canvas widget.Canvas, points []geometry.Point, color widget.Color) {
+	for i := 1; i < len(points); i++ {
+		canvas.DrawLine(points[i-1], points[i], color, lineWidth)
+	}
 }

--- a/core/linechart/painter.go
+++ b/core/linechart/painter.go
@@ -7,6 +7,7 @@ import (
 
 // PaintState holds the read-only snapshot passed to the painter.
 type PaintState struct {
+	Bounds     geometry.Rect // total widget bounds
 	Series     []Series
 	MaxPoints  int
 	YMin       float64
@@ -23,7 +24,7 @@ type PaintState struct {
 //
 // If no Painter is set, [DefaultPainter] is used.
 type Painter interface {
-	PaintChart(canvas widget.Canvas, bounds geometry.Rect, state PaintState)
+	PaintChart(canvas widget.Canvas, state PaintState)
 }
 
 // DefaultPainter provides a minimal fallback painter with no design system styling.
@@ -32,7 +33,8 @@ type DefaultPainter struct{}
 
 // PaintChart renders the chart with background, optional grid, optional labels,
 // and line segments for each data series.
-func (p DefaultPainter) PaintChart(canvas widget.Canvas, bounds geometry.Rect, cs PaintState) {
+func (p DefaultPainter) PaintChart(canvas widget.Canvas, cs PaintState) {
+	bounds := cs.Bounds
 	if bounds.IsEmpty() {
 		return
 	}

--- a/core/progress/painter.go
+++ b/core/progress/painter.go
@@ -29,6 +29,18 @@ type PaintState struct {
 	AnimationPhase float64             // 0-1 sawtooth phase within one grow/shrink cycle
 	Disabled       bool                // widget is disabled
 	ColorScheme    ProgressColorScheme // theme-derived colors (zero = use defaults)
+
+	// Pre-computed geometry (ADR-034 Phase 4).
+	// The widget computes these from Bounds, Diameter, and StrokeWidth.
+	// Painters should prefer these over recomputing center/radius.
+	Center geometry.Point // pre-computed circle center
+	Radius float32        // pre-computed radius (after stroke width inset)
+
+	// Pre-computed arc angles for indeterminate mode (ADR-034 Phase 4).
+	// The widget applies easing to AnimationPhase and computes the arc geometry.
+	// Painters should use these instead of duplicating the easing function.
+	ArcStartAngle float64 // start angle including rotation and tail offset
+	ArcSweepAngle float64 // sweep angle after easing (clamped to minimum)
 }
 
 // DefaultPainter provides a minimal fallback painter with no design system styling.
@@ -43,22 +55,15 @@ func (p DefaultPainter) PaintProgress(canvas widget.Canvas, ps PaintState) {
 		return
 	}
 
-	bounds := ps.Bounds
-	centerX := bounds.Min.X + bounds.Width()/2
-	centerY := bounds.Min.Y + bounds.Height()/2
-	center := geometry.Pt(centerX, centerY)
-
-	// Use the smaller of width/height for the radius, minus stroke width.
-	availDiameter := ps.Diameter
-	if bounds.Width() < availDiameter {
-		availDiameter = bounds.Width()
-	}
-	if bounds.Height() < availDiameter {
-		availDiameter = bounds.Height()
-	}
-	radius := (availDiameter - ps.StrokeWidth) / 2
+	// Use pre-computed geometry when available (ADR-034 Phase 4).
+	center := ps.Center
+	radius := ps.Radius
 	if radius <= 0 {
-		return
+		// Legacy fallback: compute center and radius from bounds.
+		center, radius = ComputeCenterRadius(ps)
+		if radius <= 0 {
+			return
+		}
 	}
 
 	if ps.Indeterminate {
@@ -108,18 +113,13 @@ func (p DefaultPainter) paintIndeterminate(canvas widget.Canvas, ps PaintState, 
 	trackColor := resolveTrackColor(ps, hasScheme)
 	canvas.StrokeCircle(center, radius, trackColor, ps.StrokeWidth)
 
-	// Compute variable sweep from AnimationPhase.
-	phase := ps.AnimationPhase
-	headValue := easeInOut(math.Min(phase*2, 1.0))
-	tailValue := easeInOut(math.Max((phase-0.5)*2, 0.0))
-
-	const maxSweep = math.Pi * 1.5 // 270°
-	const minSweep = 0.05
-	arcSweep := (headValue - tailValue) * maxSweep
-	if arcSweep < minSweep {
-		arcSweep = minSweep
+	// Use pre-computed arc angles when available (ADR-034 Phase 4).
+	arcStart := ps.ArcStartAngle
+	arcSweep := ps.ArcSweepAngle
+	if arcSweep == 0 {
+		// Legacy fallback: compute from AnimationPhase with easing.
+		arcStart, arcSweep = ComputeArcAngles(ps.AnimationPhase, ps.Rotation)
 	}
-	arcStart := -math.Pi/2 + ps.Rotation + tailValue*maxSweep
 
 	indicatorColor := resolveIndicatorColor(ps, hasScheme)
 	drawArcStyled(canvas, center, radius, arcStart, arcSweep, indicatorColor, ps.StrokeWidth, widget.LineCapRound)
@@ -134,6 +134,49 @@ func drawArcStyled(canvas widget.Canvas, center geometry.Point, radius float32,
 	}
 	canvas.StrokeArc(center, radius, startAngle, sweepAngle, color, strokeWidth)
 }
+
+// ComputeCenterRadius derives center point and radius from PaintState bounds,
+// diameter, and stroke width. Used as legacy fallback when pre-computed
+// Center/Radius are not set. Theme painters may call this for backward
+// compatibility with directly constructed PaintState values.
+func ComputeCenterRadius(ps PaintState) (geometry.Point, float32) {
+	bounds := ps.Bounds
+	centerX := bounds.Min.X + bounds.Width()/2
+	centerY := bounds.Min.Y + bounds.Height()/2
+	center := geometry.Pt(centerX, centerY)
+
+	availDiameter := ps.Diameter
+	if bounds.Width() < availDiameter {
+		availDiameter = bounds.Width()
+	}
+	if bounds.Height() < availDiameter {
+		availDiameter = bounds.Height()
+	}
+	radius := (availDiameter - ps.StrokeWidth) / 2
+	return center, radius
+}
+
+// ComputeArcAngles computes the indeterminate arc start and sweep angles
+// from an animation phase and rotation using cubic ease-in-out. Theme
+// painters may call this for backward compatibility with directly
+// constructed PaintState values.
+func ComputeArcAngles(phase, rotation float64) (arcStart, arcSweep float64) {
+	headValue := easeInOut(math.Min(phase*2, 1.0))
+	tailValue := easeInOut(math.Max((phase-0.5)*2, 0.0))
+
+	arcSweep = (headValue - tailValue) * maxArcSweep
+	if arcSweep < minArcSweep {
+		arcSweep = minArcSweep
+	}
+	arcStart = -math.Pi/2 + rotation + tailValue*maxArcSweep
+	return arcStart, arcSweep
+}
+
+// Arc sweep constants shared between widget and painter.
+const (
+	maxArcSweep = math.Pi * 1.5 // 270° maximum arc sweep
+	minArcSweep = 0.05          // minimum arc to prevent visual disappearance
+)
 
 // easeInOut applies a cubic ease-in-out curve.
 func easeInOut(t float64) float64 {

--- a/core/progress/progress.go
+++ b/core/progress/progress.go
@@ -159,6 +159,9 @@ func (w *Widget) drawDeterminate(_ widget.Context, canvas widget.Canvas, bounds 
 		ps.Label = w.resolveLabel(value)
 	}
 
+	// Pre-compute geometry (ADR-034 Phase 4).
+	ps.Center, ps.Radius = ComputeCenterRadius(ps)
+
 	w.painter.PaintProgress(canvas, ps)
 }
 
@@ -174,6 +177,9 @@ func (w *Widget) drawIndeterminate(ctx widget.Context, canvas widget.Canvas, bou
 	}
 
 	elapsed := w.elapsedSeconds(ctx)
+	rotation := computeRotation(elapsed)
+	phase := computeAnimationPhase(elapsed)
+
 	ps := PaintState{
 		Bounds:         bounds,
 		Diameter:       diameter,
@@ -181,9 +187,13 @@ func (w *Widget) drawIndeterminate(ctx widget.Context, canvas widget.Canvas, bou
 		Disabled:       w.cfg.ResolvedDisabled(),
 		ColorScheme:    w.cfg.colorScheme,
 		Indeterminate:  true,
-		Rotation:       computeRotation(elapsed),
-		AnimationPhase: computeAnimationPhase(elapsed),
+		Rotation:       rotation,
+		AnimationPhase: phase,
 	}
+
+	// Pre-compute geometry and arc angles (ADR-034 Phase 4).
+	ps.Center, ps.Radius = ComputeCenterRadius(ps)
+	ps.ArcStartAngle, ps.ArcSweepAngle = ComputeArcAngles(phase, rotation)
 
 	w.painter.PaintProgress(canvas, ps)
 	w.SetNeedsRedraw(true)

--- a/core/progressbar/painter.go
+++ b/core/progressbar/painter.go
@@ -16,14 +16,14 @@ type Painter interface {
 
 // PaintState provides the current progress bar state to the painter.
 type PaintState struct {
-	Value                  float64                // current value clamped to [0, 1]
-	Bounds                 geometry.Rect          // total widget bounds
-	BarHeight              float32                // height of the bar in logical pixels
-	Radius                 float32                // corner radius for rounded ends
-	ShowLabel              bool                   // whether to show percentage label
-	Label                  string                 // pre-formatted label text (empty if ShowLabel is false)
-	Disabled               bool                   // widget is disabled
-	ProgressBarColorScheme ProgressBarColorScheme // theme-derived colors (zero = use defaults)
+	Value       float64                // current value clamped to [0, 1]
+	Bounds      geometry.Rect          // total widget bounds
+	BarHeight   float32                // height of the bar in logical pixels
+	Radius      float32                // corner radius for rounded ends
+	ShowLabel   bool                   // whether to show percentage label
+	Label       string                 // pre-formatted label text (empty if ShowLabel is false)
+	Disabled    bool                   // widget is disabled
+	ColorScheme ProgressBarColorScheme // theme-derived colors (zero = use defaults)
 }
 
 // DefaultPainter provides a minimal fallback painter with no design system styling.
@@ -32,13 +32,13 @@ type DefaultPainter struct{}
 
 // PaintProgressBar renders a minimal progress bar with a gray track,
 // blue fill, and optional centered label.
-// If state.ProgressBarColorScheme is non-zero, its colors are used instead of built-in defaults.
+// If state.ColorScheme is non-zero, its colors are used instead of built-in defaults.
 func (p DefaultPainter) PaintProgressBar(canvas widget.Canvas, ps PaintState) {
 	if ps.Bounds.IsEmpty() {
 		return
 	}
 
-	hasScheme := ps.ProgressBarColorScheme != (ProgressBarColorScheme{})
+	hasScheme := ps.ColorScheme != (ProgressBarColorScheme{})
 	bounds := ps.Bounds
 
 	// Calculate bar rect centered vertically in bounds.
@@ -82,12 +82,12 @@ func (p DefaultPainter) PaintProgressBar(canvas widget.Canvas, ps PaintState) {
 func resolveTrackColor(ps PaintState, hasScheme bool) widget.Color {
 	if ps.Disabled {
 		if hasScheme {
-			return ps.ProgressBarColorScheme.DisabledTrack
+			return ps.ColorScheme.DisabledTrack
 		}
 		return defaultDisabledTrack
 	}
 	if hasScheme {
-		return ps.ProgressBarColorScheme.Track
+		return ps.ColorScheme.Track
 	}
 	return defaultTrackColor
 }
@@ -95,19 +95,19 @@ func resolveTrackColor(ps PaintState, hasScheme bool) widget.Color {
 func resolveBarColor(ps PaintState, hasScheme bool) widget.Color {
 	if ps.Disabled {
 		if hasScheme {
-			return ps.ProgressBarColorScheme.DisabledBar
+			return ps.ColorScheme.DisabledBar
 		}
 		return defaultDisabledBar
 	}
 	if hasScheme {
-		return ps.ProgressBarColorScheme.Bar
+		return ps.ColorScheme.Bar
 	}
 	return defaultBarColor
 }
 
 func resolveLabelColor(ps PaintState, hasScheme bool) widget.Color {
 	if hasScheme {
-		return ps.ProgressBarColorScheme.Label
+		return ps.ColorScheme.Label
 	}
 	return defaultLabelColor
 }

--- a/core/progressbar/progressbar.go
+++ b/core/progressbar/progressbar.go
@@ -126,14 +126,14 @@ func (w *Widget) Draw(_ widget.Context, canvas widget.Canvas) {
 	label := w.resolveLabel(value)
 
 	w.painter.PaintProgressBar(canvas, PaintState{
-		Value:                  value,
-		Bounds:                 w.Bounds(),
-		BarHeight:              barH,
-		Radius:                 radius,
-		ShowLabel:              w.cfg.showLabel,
-		Label:                  label,
-		Disabled:               w.cfg.ResolvedDisabled(),
-		ProgressBarColorScheme: w.cfg.colorScheme,
+		Value:       value,
+		Bounds:      w.Bounds(),
+		BarHeight:   barH,
+		Radius:      radius,
+		ShowLabel:   w.cfg.showLabel,
+		Label:       label,
+		Disabled:    w.cfg.ResolvedDisabled(),
+		ColorScheme: w.cfg.colorScheme,
 	})
 }
 

--- a/core/radio/item.go
+++ b/core/radio/item.go
@@ -60,12 +60,20 @@ func (it *Item) IsFocusable() bool {
 
 // Layout calculates the item's preferred size within the given constraints.
 func (it *Item) Layout(_ widget.Context, constraints geometry.Constraints) geometry.Size {
-	totalWidth := outerRadius*2 + itemPadding*2
-	totalHeight := outerRadius*2 + itemPadding*2
+	// Query LayoutMetrics from painter (type assert with default fallback).
+	lm := resolveRadioLayoutMetrics(it.painter)
+
+	radius := lm.RadioCircleRadius()
+	pad := lm.RadioItemPadding()
+	gap := lm.RadioLabelGap()
+	fontSize := lm.RadioFontSize()
+
+	totalWidth := radius*2 + pad*2
+	totalHeight := radius*2 + pad*2
 
 	if it.label != "" {
-		textWidth := float32(len(it.label)) * defaultFontSize * charWidthRatio
-		totalWidth += labelGap + textWidth
+		textWidth := float32(len(it.label)) * fontSize * charWidthRatio
+		totalWidth += gap + textWidth
 	}
 
 	if totalHeight < itemMinHeight {

--- a/core/radio/painter.go
+++ b/core/radio/painter.go
@@ -40,8 +40,30 @@ type RadioColorScheme struct {
 	FocusRing        widget.Color
 }
 
+// LayoutMetrics allows theme painters to provide spatial metrics used by the
+// item's Layout method to compute circle size, label gap, and font size.
+//
+// Painters that implement this interface provide custom metrics.
+// Painters that do not implement it get default values from [DefaultPainter].
+type LayoutMetrics interface {
+	// RadioCircleRadius returns the outer circle radius in logical pixels.
+	RadioCircleRadius() float32
+
+	// RadioLabelGap returns the gap between the circle and label text.
+	RadioLabelGap() float32
+
+	// RadioFontSize returns the font size for the label text.
+	RadioFontSize() float32
+
+	// RadioItemPadding returns the padding around each radio item.
+	RadioItemPadding() float32
+}
+
 // DefaultPainter provides a minimal fallback painter with no design system styling.
 // It draws a simple radio button -- useful for testing and as a base reference.
+//
+// DefaultPainter also implements [LayoutMetrics], providing the default spatial
+// values used when a painter does not implement that interface.
 type DefaultPainter struct{}
 
 // PaintRadio renders a minimal radio item with gray colors.
@@ -87,3 +109,27 @@ func resolveLabelColor(state PaintState, hasScheme bool) widget.Color {
 	}
 	return defaultLabelColor
 }
+
+// RadioCircleRadius returns the default outer circle radius.
+func (DefaultPainter) RadioCircleRadius() float32 { return outerRadius }
+
+// RadioLabelGap returns the default gap between circle and label.
+func (DefaultPainter) RadioLabelGap() float32 { return labelGap }
+
+// RadioFontSize returns the default font size for the label.
+func (DefaultPainter) RadioFontSize() float32 { return defaultFontSize }
+
+// RadioItemPadding returns the default padding around each radio item.
+func (DefaultPainter) RadioItemPadding() float32 { return itemPadding }
+
+// resolveRadioLayoutMetrics returns the LayoutMetrics from the painter if it
+// implements that interface, otherwise returns DefaultPainter metrics.
+func resolveRadioLayoutMetrics(p Painter) LayoutMetrics {
+	if lm, ok := p.(LayoutMetrics); ok {
+		return lm
+	}
+	return DefaultPainter{}
+}
+
+// Compile-time checks.
+var _ LayoutMetrics = DefaultPainter{}

--- a/core/slider/painter.go
+++ b/core/slider/painter.go
@@ -43,8 +43,24 @@ type SliderColorScheme struct {
 	MarkColor     widget.Color // tick mark color
 }
 
+// LayoutMetrics allows theme painters to provide spatial metrics used by the
+// widget's Layout method to compute thumb and track dimensions.
+//
+// Painters that implement this interface provide custom metrics.
+// Painters that do not implement it get default values from [DefaultPainter].
+type LayoutMetrics interface {
+	// SliderThumbRadius returns the thumb circle radius in logical pixels.
+	SliderThumbRadius() float32
+
+	// SliderTrackHeight returns the track bar height in logical pixels.
+	SliderTrackHeight() float32
+}
+
 // DefaultPainter provides a minimal fallback painter with no design system styling.
 // It draws a simple slider -- useful for testing and as a base reference.
+//
+// DefaultPainter also implements [LayoutMetrics], providing the default spatial
+// values used when a painter does not implement that interface.
 type DefaultPainter struct{}
 
 // PaintSlider renders a minimal slider with gray track, blue active segment,
@@ -247,6 +263,24 @@ func applyStateModifier(base widget.Color, hovered, pressed bool) widget.Color {
 	}
 	return base
 }
+
+// SliderThumbRadius returns the default thumb radius.
+func (DefaultPainter) SliderThumbRadius() float32 { return thumbRadius }
+
+// SliderTrackHeight returns the default track height.
+func (DefaultPainter) SliderTrackHeight() float32 { return trackHeight }
+
+// resolveSliderLayoutMetrics returns the LayoutMetrics from the painter if it
+// implements that interface, otherwise returns DefaultPainter metrics.
+func resolveSliderLayoutMetrics(p Painter) LayoutMetrics {
+	if lm, ok := p.(LayoutMetrics); ok {
+		return lm
+	}
+	return DefaultPainter{}
+}
+
+// Compile-time checks.
+var _ LayoutMetrics = DefaultPainter{}
 
 // Painting constants.
 const (

--- a/core/slider/widget.go
+++ b/core/slider/widget.go
@@ -81,20 +81,24 @@ func (w *Widget) IsFocusable() bool {
 
 // Layout calculates the slider's preferred size within the given constraints.
 func (w *Widget) Layout(_ widget.Context, constraints geometry.Constraints) geometry.Size {
+	// Query LayoutMetrics from painter (type assert with default fallback).
+	lm := resolveSliderLayoutMetrics(w.painter)
+	tr := lm.SliderThumbRadius()
+
 	if w.cfg.orientation == Vertical {
 		height := constraints.MaxHeight
 		if height <= 0 || height == geometry.Infinity {
 			height = verticalDefaultHeight + w.padding*2
 		}
 		return constraints.Constrain(geometry.Sz(
-			thumbRadius*2+w.padding*2, height))
+			tr*2+w.padding*2, height))
 	}
 	width := constraints.MaxWidth
 	if width <= 0 || width == geometry.Infinity {
 		width = horizontalDefaultWidth + w.padding*2
 	}
 	return constraints.Constrain(geometry.Sz(
-		width, thumbRadius*2+w.padding*2))
+		width, tr*2+w.padding*2))
 }
 
 // Layout dimension constants.

--- a/core/textfield/event.go
+++ b/core/textfield/event.go
@@ -109,18 +109,35 @@ func handleDoubleClick(w *Widget, ctx widget.Context, e *event.MouseEvent) bool 
 }
 
 // positionFromMouse converts a mouse position to a rune index in the text.
+// Uses cached text metrics from the last Draw call for accurate hit-testing.
+// Falls back to proportional approximation when no cached metrics are available
+// (e.g., before the first draw).
 func positionFromMouse(w *Widget, e *event.MouseEvent) int {
+	runes := w.textRunes()
+
+	// Use cached metrics from last Draw if available.
+	if w.cachedMetrics != nil {
+		return w.cachedMetrics.RuneIndexFromX(
+			w.cachedContentRect,
+			w.cachedDisplayText,
+			e.Position.X,
+		)
+	}
+
+	// Fallback: approximate using layout metrics padding.
+	lm := resolveLayoutMetrics(w.painter)
+	hPad, _ := lm.ContentPadding()
 	bounds := w.Bounds()
-	localX := e.Position.X - bounds.Min.X - contentPaddingH
+	localX := e.Position.X - bounds.Min.X - hPad
 
 	if localX <= 0 {
 		return 0
 	}
 
-	charW := defaultFontSize * charWidthRatio
+	// Approximate proportional positioning.
+	fontSize := lm.TextFieldFontSize()
+	charW := fontSize * 0.55 // approximate average character width
 	pos := int(localX / charW)
-
-	runes := w.textRunes()
 	return clampPos(pos, len(runes))
 }
 

--- a/core/textfield/painter.go
+++ b/core/textfield/painter.go
@@ -11,11 +11,17 @@ import (
 //
 // If no Painter is set, the text field uses [DefaultPainter].
 type Painter interface {
-	PaintTextField(canvas widget.Canvas, state PaintState)
+	PaintTextField(canvas widget.Canvas, state *PaintState)
 }
 
 // PaintState provides the current text field state to the painter.
+//
+// Pre-computed geometry fields (DisplayText, ContentRect, CursorRect,
+// SelectionRect) are calculated by the widget using [LayoutMetrics] from
+// the painter. Painters should use these fields for positioning rather than
+// computing their own cursor/selection coordinates.
 type PaintState struct {
+	// Legacy fields (kept for backward compatibility).
 	Text        string
 	Placeholder string
 	Focused     bool
@@ -28,6 +34,51 @@ type PaintState struct {
 	SelectEnd   int
 	InputType   InputType
 	Bounds      geometry.Rect
+
+	// Pre-computed fields (widget computes, painter draws).
+
+	// DisplayText is the text to render, already masked if password.
+	DisplayText string
+
+	// ContentRect is the inner text area (bounds minus theme padding).
+	ContentRect geometry.Rect
+
+	// CursorRect is the cursor line rectangle (zero if no cursor).
+	CursorRect geometry.Rect
+
+	// SelectionRect is the selection highlight rectangle (zero if no selection).
+	SelectionRect geometry.Rect
+
+	// ShowCursor is true when the cursor should be drawn (focused, no selection, enabled).
+	ShowCursor bool
+
+	// ShowSelection is true when a selection highlight should be drawn.
+	ShowSelection bool
+
+	// FontSize is the font size to use for text rendering.
+	FontSize float32
+
+	// ColorScheme provides theme-derived colors. Zero value means use built-in defaults.
+	ColorScheme TextFieldColorScheme
+}
+
+// LayoutMetrics allows theme painters to provide spatial metrics used by the
+// widget to compute pre-computed PaintState fields (ContentRect, CursorRect, etc.).
+//
+// Painters that implement this interface provide custom padding, font size, etc.
+// Painters that do not implement it get default values from [DefaultPainter].
+type LayoutMetrics interface {
+	// ContentPadding returns horizontal and vertical padding inside the text field.
+	ContentPadding() (horizontal, vertical float32)
+
+	// TextFieldFontSize returns the font size for the text content.
+	TextFieldFontSize() float32
+
+	// TextFieldCursorWidth returns the cursor line width in pixels.
+	TextFieldCursorWidth() float32
+
+	// TextFieldCornerRadius returns the corner radius for the text field border.
+	TextFieldCornerRadius() float32
 }
 
 // TextFieldColorScheme provides theme-derived colors for text field painting.
@@ -48,156 +99,111 @@ type TextFieldColorScheme struct {
 
 // DefaultPainter provides a minimal fallback painter with no design system styling.
 // It draws a simple outlined text field suitable for testing and prototyping.
+//
+// DefaultPainter also implements [LayoutMetrics], providing the default spatial
+// values used when a painter does not implement that interface.
 type DefaultPainter struct{}
 
+// ContentPadding returns the default horizontal and vertical padding.
+func (DefaultPainter) ContentPadding() (float32, float32) {
+	return contentPaddingH, contentPaddingV
+}
+
+// TextFieldFontSize returns the default font size.
+func (DefaultPainter) TextFieldFontSize() float32 { return defaultFontSize }
+
+// TextFieldCursorWidth returns the default cursor width.
+func (DefaultPainter) TextFieldCursorWidth() float32 { return cursorWidth }
+
+// TextFieldCornerRadius returns the default corner radius.
+func (DefaultPainter) TextFieldCornerRadius() float32 { return defaultCornerRadius }
+
 // PaintTextField renders a minimal text field with gray outline.
-// If the state has a non-zero ColorScheme (via the M3 painter), use those colors.
-func (p DefaultPainter) PaintTextField(canvas widget.Canvas, st PaintState) {
+// It uses the pre-computed fields from PaintState for cursor/selection positioning.
+func (p DefaultPainter) PaintTextField(canvas widget.Canvas, st *PaintState) {
 	if st.Bounds.IsEmpty() {
 		return
 	}
 
-	paintBackground(canvas, st)
-	paintBorder(canvas, st)
-	paintContent(canvas, st)
-	paintCursor(canvas, st)
+	colors := st.ColorScheme
+	if colors == (TextFieldColorScheme{}) {
+		colors = defaultColorScheme
+	}
+	fontSize := st.FontSize
+	if fontSize <= 0 {
+		fontSize = defaultFontSize
+	}
+
+	paintBackground(canvas, st, colors)
+	paintBorder(canvas, st, colors)
+	paintContent(canvas, st, colors, fontSize)
+	paintCursorFromState(canvas, st, colors)
 }
 
 // paintBackground fills the text field background.
-func paintBackground(canvas widget.Canvas, st PaintState) {
-	bg := defaultBg
+func paintBackground(canvas widget.Canvas, st *PaintState, colors TextFieldColorScheme) {
+	bg := colors.Background
 	if st.Disabled {
-		bg = defaultDisabledBg
+		bg = colors.DisabledBg
 	}
 	canvas.DrawRoundRect(st.Bounds, bg, defaultCornerRadius)
 }
 
 // paintBorder draws the text field outline.
-func paintBorder(canvas widget.Canvas, st PaintState) {
-	borderColor := defaultBorderColor
+func paintBorder(canvas widget.Canvas, st *PaintState, colors TextFieldColorScheme) {
+	borderColor := colors.Border
 	strokeWidth := defaultBorderWidth
 
 	switch {
 	case st.Disabled:
-		borderColor = defaultDisabledBorderColor
+		borderColor = colors.DisabledFg
 	case st.HasError:
-		borderColor = defaultErrorColor
+		borderColor = colors.ErrorBorder
 	case st.Focused:
-		borderColor = defaultFocusBorderColor
+		borderColor = colors.FocusBorder
 		strokeWidth = defaultFocusBorderWidth
 	case st.Hovered:
-		borderColor = defaultHoverBorderColor
+		borderColor = colors.TextColor
 	}
 
 	canvas.StrokeRoundRect(st.Bounds, borderColor, defaultCornerRadius, strokeWidth)
 }
 
 // paintContent renders either the placeholder or the displayed text.
-func paintContent(canvas widget.Canvas, st PaintState) {
-	contentBounds := contentRect(st.Bounds)
-
-	// Clip to content area.
-	canvas.PushClip(contentBounds)
+func paintContent(canvas widget.Canvas, st *PaintState, colors TextFieldColorScheme, fontSize float32) {
+	canvas.PushClip(st.ContentRect)
 	defer canvas.PopClip()
 
-	displayText := st.Text
-	if st.InputType == TypePassword {
-		displayText = maskText(len([]rune(st.Text)))
-	}
-
-	if displayText == "" && !st.Focused {
-		// Draw placeholder.
-		color := defaultPlaceholderColor
+	if st.DisplayText == "" && !st.Focused {
+		color := colors.Placeholder
 		if st.Disabled {
-			color = defaultDisabledFg
+			color = colors.DisabledFg
 		}
-		canvas.DrawText(st.Placeholder, contentBounds, defaultFontSize, color, false, textAlignLeft)
+		canvas.DrawText(st.Placeholder, st.ContentRect, fontSize, color, false, textAlignLeft)
 		return
 	}
 
-	// Draw text.
-	textColor := defaultTextColor
+	textColor := colors.TextColor
 	if st.Disabled {
-		textColor = defaultDisabledFg
+		textColor = colors.DisabledFg
 	}
 
-	// Draw selection background if present.
-	if st.SelectStart != st.SelectEnd {
-		paintSelection(canvas, contentBounds, st)
+	if st.ShowSelection {
+		canvas.DrawRect(st.SelectionRect, colors.SelectionBg)
 	}
 
-	canvas.DrawText(displayText, contentBounds, defaultFontSize, textColor, false, textAlignLeft)
+	canvas.DrawText(st.DisplayText, st.ContentRect, fontSize, textColor, false, textAlignLeft)
 }
 
-// paintSelection draws the selection highlight rectangle.
-func paintSelection(canvas widget.Canvas, contentBounds geometry.Rect, st PaintState) {
-	selStart := st.SelectStart
-	selEnd := st.SelectEnd
-	if selStart > selEnd {
-		selStart, selEnd = selEnd, selStart
-	}
-
-	// Determine the display text for measurement.
-	displayText := st.Text
-	if st.InputType == TypePassword {
-		displayText = maskText(len([]rune(st.Text)))
-	}
-	runes := []rune(displayText)
-
-	// Measure actual text width up to selection boundaries for accurate placement.
-	x1 := contentBounds.Min.X + canvas.MeasureText(string(runes[:selStart]), defaultFontSize, false)
-	x2 := contentBounds.Min.X + canvas.MeasureText(string(runes[:selEnd]), defaultFontSize, false)
-
-	// Clamp to content bounds.
-	if x2 > contentBounds.Max.X {
-		x2 = contentBounds.Max.X
-	}
-
-	selRect := geometry.Rect{
-		Min: geometry.Pt(x1, contentBounds.Min.Y),
-		Max: geometry.Pt(x2, contentBounds.Max.Y),
-	}
-	canvas.DrawRect(selRect, defaultSelectionBg)
-}
-
-// paintCursor draws the blinking caret when the field is focused.
-func paintCursor(canvas widget.Canvas, st PaintState) {
-	if !st.Focused || st.Disabled {
-		return
-	}
-	// No cursor when there is a selection.
-	if st.SelectStart != st.SelectEnd {
+// paintCursorFromState draws the cursor using pre-computed CursorRect.
+func paintCursorFromState(canvas widget.Canvas, st *PaintState, colors TextFieldColorScheme) {
+	if !st.ShowCursor {
 		return
 	}
 
-	content := contentRect(st.Bounds)
-
-	// Determine the display text for measurement.
-	displayText := st.Text
-	if st.InputType == TypePassword {
-		displayText = maskText(len([]rune(st.Text)))
-	}
-
-	// Measure actual text width up to cursor position for accurate placement.
-	textBeforeCursor := string([]rune(displayText)[:st.CursorPos])
-	cursorX := content.Min.X + canvas.MeasureText(textBeforeCursor, defaultFontSize, false)
-
-	// Clamp cursor to content area.
-	if cursorX > content.Max.X {
-		cursorX = content.Max.X
-	}
-
-	top := geometry.Pt(cursorX, content.Min.Y+cursorTopPadding)
-	bottom := geometry.Pt(cursorX, content.Max.Y-cursorBottomPadding)
-	canvas.DrawLine(top, bottom, defaultCursorColor, cursorWidth)
-}
-
-// contentRect returns the inner content area after padding.
-func contentRect(bounds geometry.Rect) geometry.Rect {
-	return geometry.Rect{
-		Min: geometry.Pt(bounds.Min.X+contentPaddingH, bounds.Min.Y+contentPaddingV),
-		Max: geometry.Pt(bounds.Max.X-contentPaddingH, bounds.Max.Y-contentPaddingV),
-	}
+	top := geometry.Pt(st.CursorRect.Min.X, st.CursorRect.Min.Y)
+	bottom := geometry.Pt(st.CursorRect.Min.X, st.CursorRect.Max.Y)
+	canvas.DrawLine(top, bottom, colors.CursorColor, st.CursorRect.Width())
 }
 
 // maskText returns a string of dots with the given length.
@@ -217,26 +223,27 @@ const (
 	defaultFocusBorderWidth float32 = 2
 	contentPaddingH         float32 = 12
 	contentPaddingV         float32 = 8
-	charWidthRatio          float32 = 0.55
 	textAlignLeft                   = widget.TextAlignLeft
 	cursorWidth             float32 = 1.5
-	cursorTopPadding        float32 = 2
-	cursorBottomPadding     float32 = 2
 	passwordMaskChar                = '\u2022' // bullet character
 )
 
-// Default colors for DefaultPainter.
+// Compile-time checks.
 var (
-	defaultBg                  = widget.ColorWhite
-	defaultBorderColor         = widget.RGBA(0.45, 0.45, 0.45, 1.0)
-	defaultFocusBorderColor    = widget.Hex(0x6750A4)
-	defaultHoverBorderColor    = widget.RGBA(0.2, 0.2, 0.2, 1.0)
-	defaultDisabledBorderColor = widget.RGBA(0.45, 0.45, 0.45, 0.38)
-	defaultErrorColor          = widget.Hex(0xB3261E)
-	defaultTextColor           = widget.RGBA(0.1, 0.1, 0.1, 1.0)
-	defaultPlaceholderColor    = widget.RGBA(0.45, 0.45, 0.45, 1.0)
-	defaultCursorColor         = widget.Hex(0x6750A4)
-	defaultDisabledBg          = widget.RGBA(0.95, 0.95, 0.95, 1.0)
-	defaultDisabledFg          = widget.RGBA(0.12, 0.12, 0.13, 0.38)
-	defaultSelectionBg         = widget.Hex(0x6750A4).WithAlpha(0.2)
+	_ LayoutMetrics = DefaultPainter{}
 )
+
+// defaultColorScheme is the color scheme for DefaultPainter.
+var defaultColorScheme = TextFieldColorScheme{
+	Background:  widget.ColorWhite,
+	Border:      widget.RGBA(0.45, 0.45, 0.45, 1.0),
+	FocusBorder: widget.Hex(0x6750A4),
+	ErrorBorder: widget.Hex(0xB3261E),
+	TextColor:   widget.RGBA(0.1, 0.1, 0.1, 1.0),
+	Placeholder: widget.RGBA(0.45, 0.45, 0.45, 1.0),
+	CursorColor: widget.Hex(0x6750A4),
+	DisabledBg:  widget.RGBA(0.95, 0.95, 0.95, 1.0),
+	DisabledFg:  widget.RGBA(0.12, 0.12, 0.13, 0.38),
+	SelectionBg: widget.Hex(0x6750A4).WithAlpha(0.2),
+	ErrorText:   widget.Hex(0xB3261E),
+}

--- a/core/textfield/textfield_test.go
+++ b/core/textfield/textfield_test.go
@@ -807,6 +807,192 @@ func TestDraw_DoesNotPanicWithBounds(t *testing.T) {
 	tf.Draw(ctx, canvas)
 }
 
+// --- Pre-computed PaintState Tests (ADR-034) ---
+
+func TestDraw_PrecomputedDisplayText(t *testing.T) {
+	p := &testPainter{}
+	tf := textfield.New(
+		textfield.InitialValue("secret"),
+		textfield.InputTypeOpt(textfield.TypePassword),
+		textfield.PainterOpt(p),
+	)
+	tf.SetBounds(geometry.NewRect(0, 0, 300, 48))
+	ctx := widget.NewContext()
+	canvas := &mockCanvas{}
+
+	tf.Draw(ctx, canvas)
+
+	if p.state.DisplayText == "secret" {
+		t.Error("password DisplayText should be masked, not plaintext")
+	}
+	if len([]rune(p.state.DisplayText)) != 6 {
+		t.Errorf("password DisplayText should have 6 bullets, got %d runes", len([]rune(p.state.DisplayText)))
+	}
+}
+
+func TestDraw_PrecomputedDisplayText_PlainText(t *testing.T) {
+	p := &testPainter{}
+	tf := textfield.New(
+		textfield.InitialValue("hello"),
+		textfield.PainterOpt(p),
+	)
+	tf.SetBounds(geometry.NewRect(0, 0, 300, 48))
+	ctx := widget.NewContext()
+	canvas := &mockCanvas{}
+
+	tf.Draw(ctx, canvas)
+
+	if p.state.DisplayText != "hello" {
+		t.Errorf("DisplayText = %q, want %q", p.state.DisplayText, "hello")
+	}
+}
+
+func TestDraw_PrecomputedContentRect(t *testing.T) {
+	p := &testPainter{}
+	tf := textfield.New(
+		textfield.InitialValue("test"),
+		textfield.PainterOpt(p),
+	)
+	tf.SetBounds(geometry.NewRect(10, 20, 300, 48))
+	ctx := widget.NewContext()
+	canvas := &mockCanvas{}
+
+	tf.Draw(ctx, canvas)
+
+	cr := p.state.ContentRect
+	if cr.IsEmpty() {
+		t.Error("ContentRect should not be empty")
+	}
+	// ContentRect should be inside bounds (inset by padding).
+	bounds := tf.Bounds()
+	if cr.Min.X <= bounds.Min.X || cr.Min.Y <= bounds.Min.Y {
+		t.Errorf("ContentRect.Min should be inset from bounds: cr=%v, bounds=%v", cr, bounds)
+	}
+	if cr.Max.X >= bounds.Max.X || cr.Max.Y >= bounds.Max.Y {
+		t.Errorf("ContentRect.Max should be inset from bounds: cr=%v, bounds=%v", cr, bounds)
+	}
+}
+
+func TestDraw_PrecomputedShowCursor_Focused(t *testing.T) {
+	p := &testPainter{}
+	tf := textfield.New(
+		textfield.InitialValue("hello"),
+		textfield.PainterOpt(p),
+	)
+	tf.SetBounds(geometry.NewRect(0, 0, 300, 48))
+	tf.SetFocused(true)
+	ctx := widget.NewContext()
+	canvas := &mockCanvas{}
+
+	tf.Draw(ctx, canvas)
+
+	if !p.state.ShowCursor {
+		t.Error("ShowCursor should be true when focused with no selection")
+	}
+	if p.state.CursorRect.IsEmpty() {
+		t.Error("CursorRect should not be empty when ShowCursor is true")
+	}
+}
+
+func TestDraw_PrecomputedShowCursor_Unfocused(t *testing.T) {
+	p := &testPainter{}
+	tf := textfield.New(
+		textfield.InitialValue("hello"),
+		textfield.PainterOpt(p),
+	)
+	tf.SetBounds(geometry.NewRect(0, 0, 300, 48))
+	// Not focused.
+	ctx := widget.NewContext()
+	canvas := &mockCanvas{}
+
+	tf.Draw(ctx, canvas)
+
+	if p.state.ShowCursor {
+		t.Error("ShowCursor should be false when not focused")
+	}
+}
+
+func TestDraw_PrecomputedShowCursor_Disabled(t *testing.T) {
+	p := &testPainter{}
+	tf := textfield.New(
+		textfield.InitialValue("hello"),
+		textfield.Disabled(true),
+		textfield.PainterOpt(p),
+	)
+	tf.SetBounds(geometry.NewRect(0, 0, 300, 48))
+	tf.SetFocused(true)
+	ctx := widget.NewContext()
+	canvas := &mockCanvas{}
+
+	tf.Draw(ctx, canvas)
+
+	if p.state.ShowCursor {
+		t.Error("ShowCursor should be false when disabled")
+	}
+}
+
+func TestDraw_PrecomputedSelection(t *testing.T) {
+	p := &testPainter{}
+	tf := textfield.New(
+		textfield.InitialValue("hello"),
+		textfield.PainterOpt(p),
+	)
+	tf.SetBounds(geometry.NewRect(0, 0, 300, 48))
+	tf.SetFocused(true)
+	ctx := widget.NewContext()
+
+	// Select last 2 chars.
+	pressKey(tf, ctx, event.KeyLeft, event.ModShift)
+	pressKey(tf, ctx, event.KeyLeft, event.ModShift)
+
+	canvas := &mockCanvas{}
+	tf.Draw(ctx, canvas)
+
+	if !p.state.ShowSelection {
+		t.Error("ShowSelection should be true when selection exists")
+	}
+	if p.state.SelectionRect.IsEmpty() {
+		t.Error("SelectionRect should not be empty when ShowSelection is true")
+	}
+	if p.state.ShowCursor {
+		t.Error("ShowCursor should be false when selection exists")
+	}
+}
+
+func TestDraw_PrecomputedFontSize(t *testing.T) {
+	p := &testPainter{}
+	tf := textfield.New(
+		textfield.PainterOpt(p),
+	)
+	tf.SetBounds(geometry.NewRect(0, 0, 300, 48))
+	ctx := widget.NewContext()
+	canvas := &mockCanvas{}
+
+	tf.Draw(ctx, canvas)
+
+	if p.state.FontSize <= 0 {
+		t.Errorf("FontSize = %v, want > 0", p.state.FontSize)
+	}
+}
+
+func TestLayoutMetrics_DefaultPainter(t *testing.T) {
+	var lm textfield.LayoutMetrics = textfield.DefaultPainter{}
+
+	h, v := lm.ContentPadding()
+	if h <= 0 || v <= 0 {
+		t.Errorf("ContentPadding = (%v, %v), want positive values", h, v)
+	}
+	if lm.TextFieldFontSize() <= 0 {
+		t.Errorf("TextFieldFontSize = %v, want > 0", lm.TextFieldFontSize())
+	}
+	if lm.TextFieldCursorWidth() <= 0 {
+		t.Errorf("TextFieldCursorWidth = %v, want > 0", lm.TextFieldCursorWidth())
+	}
+	if lm.TextFieldCornerRadius() <= 0 {
+		t.Errorf("TextFieldCornerRadius = %v, want > 0", lm.TextFieldCornerRadius())
+	}
+}
+
 // --- Widget Interface Compliance ---
 
 func TestWidgetInterface(t *testing.T) {
@@ -995,9 +1181,9 @@ type testPainter struct {
 	state  textfield.PaintState
 }
 
-func (p *testPainter) PaintTextField(_ widget.Canvas, ps textfield.PaintState) {
+func (p *testPainter) PaintTextField(_ widget.Canvas, ps *textfield.PaintState) {
 	p.called = true
-	p.state = ps
+	p.state = *ps
 }
 
 // --- recordingCanvas records draw calls for verification ---

--- a/core/textfield/widget.go
+++ b/core/textfield/widget.go
@@ -3,6 +3,7 @@ package textfield
 import (
 	"github.com/gogpu/ui/event"
 	"github.com/gogpu/ui/geometry"
+	"github.com/gogpu/ui/internal/textmetrics"
 	"github.com/gogpu/ui/state"
 	"github.com/gogpu/ui/widget"
 )
@@ -37,6 +38,14 @@ type Widget struct {
 
 	// Styling overrides set via fluent methods.
 	padding float32
+
+	// Cached text metrics from last Draw call, used by event handlers
+	// (positionFromMouse) that don't have access to canvas.
+	cachedMetrics *textmetrics.Metrics
+	// Cached layout values from last Draw call.
+	cachedContentRect geometry.Rect
+	cachedDisplayText string
+	cachedFontSize    float32
 }
 
 // New creates a new text field Widget with the given options.
@@ -113,20 +122,86 @@ func (w *Widget) Draw(_ widget.Context, canvas widget.Canvas) {
 		}
 	}
 
-	w.painter.PaintTextField(canvas, PaintState{
-		Text:        w.resolvedText(),
+	// Query LayoutMetrics from painter (type assert with default fallback).
+	lm := resolveLayoutMetrics(w.painter)
+
+	// Compute pre-computed fields.
+	text := w.resolvedText()
+	bounds := w.Bounds()
+	focused := w.IsFocused()
+	disabled := w.cfg.ResolvedDisabled()
+	hasSelection := w.sel.anchor != w.sel.cursor
+
+	displayText := text
+	if w.cfg.inputType == TypePassword {
+		displayText = maskText(len([]rune(text)))
+	}
+
+	hPad, vPad := lm.ContentPadding()
+	contentRect := geometry.Rect{
+		Min: geometry.Pt(bounds.Min.X+hPad, bounds.Min.Y+vPad),
+		Max: geometry.Pt(bounds.Max.X-hPad, bounds.Max.Y-vPad),
+	}
+
+	fontSize := lm.TextFieldFontSize()
+	cw := lm.TextFieldCursorWidth()
+
+	// Build text metrics for cursor/selection computation.
+	tm := &textmetrics.Metrics{Canvas: canvas, FontSize: fontSize}
+
+	// Cache for event handlers (positionFromMouse).
+	w.cachedMetrics = tm
+	w.cachedContentRect = contentRect
+	w.cachedDisplayText = displayText
+	w.cachedFontSize = fontSize
+
+	// Compute cursor rect (if applicable).
+	showCursor := focused && !disabled && !hasSelection
+	var cursorRect geometry.Rect
+	if showCursor {
+		cursorRect = tm.CursorRect(contentRect, displayText, w.sel.cursor, cw)
+	}
+
+	// Compute selection rect (if applicable).
+	showSelection := hasSelection
+	var selectionRect geometry.Rect
+	if showSelection {
+		selectionRect = tm.SelectionRect(contentRect, displayText, w.sel.anchor, w.sel.cursor)
+	}
+
+	w.painter.PaintTextField(canvas, &PaintState{
+		// Legacy fields.
+		Text:        text,
 		Placeholder: w.cfg.placeholder,
-		Focused:     w.IsFocused(),
+		Focused:     focused,
 		Hovered:     w.hovered,
-		Disabled:    w.cfg.ResolvedDisabled(),
+		Disabled:    disabled,
 		HasError:    w.errorMsg != "",
 		ErrorMsg:    w.errorMsg,
 		CursorPos:   w.sel.cursor,
 		SelectStart: w.sel.anchor,
 		SelectEnd:   w.sel.cursor,
 		InputType:   w.cfg.inputType,
-		Bounds:      w.Bounds(),
+		Bounds:      bounds,
+
+		// Pre-computed fields.
+		DisplayText:   displayText,
+		ContentRect:   contentRect,
+		CursorRect:    cursorRect,
+		SelectionRect: selectionRect,
+		ShowCursor:    showCursor,
+		ShowSelection: showSelection,
+		FontSize:      fontSize,
 	})
+}
+
+// resolveLayoutMetrics returns the LayoutMetrics from the painter if it
+// implements that interface, otherwise returns DefaultPainter metrics.
+func resolveLayoutMetrics(p Painter) LayoutMetrics {
+	if lm, ok := p.(LayoutMetrics); ok {
+		return lm
+	}
+	return DefaultPainter{}
 }
 
 // Event handles an input event and returns true if consumed.

--- a/core/titlebar/painter.go
+++ b/core/titlebar/painter.go
@@ -11,11 +11,11 @@ import (
 //
 // If no Painter is set, the title bar uses [DefaultPainter].
 type Painter interface {
-	// DrawBackground draws the title bar background.
-	DrawBackground(canvas widget.Canvas, bounds geometry.Rect, state BackgroundState)
+	// PaintBackground draws the title bar background.
+	PaintBackground(canvas widget.Canvas, bounds geometry.Rect, state BackgroundState)
 
-	// DrawControlButton draws a window control button (minimize, maximize, close).
-	DrawControlButton(canvas widget.Canvas, bounds geometry.Rect, control ControlType, state ControlState)
+	// PaintControlButton draws a window control button (minimize, maximize, close).
+	PaintControlButton(canvas widget.Canvas, bounds geometry.Rect, control ControlType, state ControlState)
 }
 
 // ControlType identifies a window control button.
@@ -70,16 +70,16 @@ type ControlState struct {
 // It draws a simple dark bar with basic window controls.
 type DefaultPainter struct{}
 
-// DrawBackground renders a dark background bar.
-func (p DefaultPainter) DrawBackground(canvas widget.Canvas, bounds geometry.Rect, _ BackgroundState) {
+// PaintBackground renders a dark background bar.
+func (p DefaultPainter) PaintBackground(canvas widget.Canvas, bounds geometry.Rect, _ BackgroundState) {
 	if bounds.IsEmpty() {
 		return
 	}
 	canvas.DrawRect(bounds, defaultBarBg)
 }
 
-// DrawControlButton renders a minimal window control button.
-func (p DefaultPainter) DrawControlButton(canvas widget.Canvas, bounds geometry.Rect, control ControlType, state ControlState) {
+// PaintControlButton renders a minimal window control button.
+func (p DefaultPainter) PaintControlButton(canvas widget.Canvas, bounds geometry.Rect, control ControlType, state ControlState) {
 	if bounds.IsEmpty() {
 		return
 	}

--- a/core/titlebar/titlebar.go
+++ b/core/titlebar/titlebar.go
@@ -347,7 +347,7 @@ func (w *Widget) Draw(ctx widget.Context, canvas widget.Canvas) {
 	bounds := w.Bounds()
 
 	// Draw background.
-	w.painter.DrawBackground(canvas, bounds, BackgroundState{
+	w.painter.PaintBackground(canvas, bounds, BackgroundState{
 		Focused: w.cfg.focused,
 	})
 
@@ -383,7 +383,7 @@ func (w *Widget) Draw(ctx widget.Context, canvas widget.Canvas) {
 	if w.cfg.chrome != nil {
 		for i := 0; i < controlCount; i++ {
 			ct := w.controlTypeForIndex(i)
-			w.painter.DrawControlButton(canvas, w.controlBounds[i], ct, ControlState{
+			w.painter.PaintControlButton(canvas, w.controlBounds[i], ct, ControlState{
 				Hovered: w.controlStates[i] == stateHover,
 				Pressed: w.controlStates[i] == statePressed,
 			})

--- a/core/titlebar/titlebar_test.go
+++ b/core/titlebar/titlebar_test.go
@@ -247,10 +247,10 @@ func TestDraw_CallsPainter(t *testing.T) {
 	tb.Draw(ctx, canvas)
 
 	if !p.bgPainted {
-		t.Error("DrawBackground should have been called")
+		t.Error("PaintBackground should have been called")
 	}
 	if p.controlCount != controlCount {
-		t.Errorf("DrawControlButton called %d times, want %d", p.controlCount, controlCount)
+		t.Errorf("PaintControlButton called %d times, want %d", p.controlCount, controlCount)
 	}
 }
 
@@ -265,7 +265,7 @@ func TestDraw_NoChrome_NoControls(t *testing.T) {
 	tb.Draw(ctx, canvas)
 
 	if p.controlCount != 0 {
-		t.Errorf("DrawControlButton called %d times, want 0 (no chrome)", p.controlCount)
+		t.Errorf("PaintControlButton called %d times, want 0 (no chrome)", p.controlCount)
 	}
 }
 
@@ -748,64 +748,64 @@ func TestAccessibilityActions_Nil(t *testing.T) {
 
 // --- DefaultPainter Tests ---
 
-func TestDefaultPainter_DrawBackground_EmptyBounds(t *testing.T) {
+func TestDefaultPainter_PaintBackground_EmptyBounds(t *testing.T) {
 	p := DefaultPainter{}
 	canvas := &mockCanvas{}
-	p.DrawBackground(canvas, geometry.Rect{}, BackgroundState{})
+	p.PaintBackground(canvas, geometry.Rect{}, BackgroundState{})
 
 	if len(canvas.drawRects) > 0 {
 		t.Error("should not paint with empty bounds")
 	}
 }
 
-func TestDefaultPainter_DrawBackground(t *testing.T) {
+func TestDefaultPainter_PaintBackground(t *testing.T) {
 	p := DefaultPainter{}
 	canvas := &mockCanvas{}
 	bounds := geometry.NewRect(0, 0, 800, 40)
-	p.DrawBackground(canvas, bounds, BackgroundState{Focused: true})
+	p.PaintBackground(canvas, bounds, BackgroundState{Focused: true})
 
 	if len(canvas.drawRects) == 0 {
 		t.Error("should draw background rect")
 	}
 }
 
-func TestDefaultPainter_DrawControlButton_EmptyBounds(t *testing.T) {
+func TestDefaultPainter_PaintControlButton_EmptyBounds(t *testing.T) {
 	p := DefaultPainter{}
 	canvas := &mockCanvas{}
-	p.DrawControlButton(canvas, geometry.Rect{}, ControlClose, ControlState{})
+	p.PaintControlButton(canvas, geometry.Rect{}, ControlClose, ControlState{})
 
 	if len(canvas.drawRects) > 0 || len(canvas.drawLines) > 0 {
 		t.Error("should not paint with empty bounds")
 	}
 }
 
-func TestDefaultPainter_DrawControlButton_Minimize(t *testing.T) {
+func TestDefaultPainter_PaintControlButton_Minimize(t *testing.T) {
 	p := DefaultPainter{}
 	canvas := &mockCanvas{}
 	bounds := geometry.NewRect(0, 0, 46, 40)
-	p.DrawControlButton(canvas, bounds, ControlMinimize, ControlState{})
+	p.PaintControlButton(canvas, bounds, ControlMinimize, ControlState{})
 
 	if len(canvas.drawLines) == 0 {
 		t.Error("minimize should draw a line")
 	}
 }
 
-func TestDefaultPainter_DrawControlButton_Maximize(t *testing.T) {
+func TestDefaultPainter_PaintControlButton_Maximize(t *testing.T) {
 	p := DefaultPainter{}
 	canvas := &mockCanvas{}
 	bounds := geometry.NewRect(0, 0, 46, 40)
-	p.DrawControlButton(canvas, bounds, ControlMaximize, ControlState{})
+	p.PaintControlButton(canvas, bounds, ControlMaximize, ControlState{})
 
 	if len(canvas.strokeRects) == 0 {
 		t.Error("maximize should draw a stroked rect")
 	}
 }
 
-func TestDefaultPainter_DrawControlButton_Restore(t *testing.T) {
+func TestDefaultPainter_PaintControlButton_Restore(t *testing.T) {
 	p := DefaultPainter{}
 	canvas := &mockCanvas{}
 	bounds := geometry.NewRect(0, 0, 46, 40)
-	p.DrawControlButton(canvas, bounds, ControlRestore, ControlState{})
+	p.PaintControlButton(canvas, bounds, ControlRestore, ControlState{})
 
 	// Restore draws two rects.
 	if len(canvas.strokeRects) < 2 {
@@ -813,11 +813,11 @@ func TestDefaultPainter_DrawControlButton_Restore(t *testing.T) {
 	}
 }
 
-func TestDefaultPainter_DrawControlButton_Close(t *testing.T) {
+func TestDefaultPainter_PaintControlButton_Close(t *testing.T) {
 	p := DefaultPainter{}
 	canvas := &mockCanvas{}
 	bounds := geometry.NewRect(0, 0, 46, 40)
-	p.DrawControlButton(canvas, bounds, ControlClose, ControlState{})
+	p.PaintControlButton(canvas, bounds, ControlClose, ControlState{})
 
 	// Close draws 2 lines (X shape).
 	if len(canvas.drawLines) != 2 {
@@ -825,11 +825,11 @@ func TestDefaultPainter_DrawControlButton_Close(t *testing.T) {
 	}
 }
 
-func TestDefaultPainter_DrawControlButton_CloseHover(t *testing.T) {
+func TestDefaultPainter_PaintControlButton_CloseHover(t *testing.T) {
 	p := DefaultPainter{}
 	canvas := &mockCanvas{}
 	bounds := geometry.NewRect(0, 0, 46, 40)
-	p.DrawControlButton(canvas, bounds, ControlClose, ControlState{Hovered: true})
+	p.PaintControlButton(canvas, bounds, ControlClose, ControlState{Hovered: true})
 
 	// Should draw red background.
 	if len(canvas.drawRects) == 0 {
@@ -837,11 +837,11 @@ func TestDefaultPainter_DrawControlButton_CloseHover(t *testing.T) {
 	}
 }
 
-func TestDefaultPainter_DrawControlButton_MinimizeHover(t *testing.T) {
+func TestDefaultPainter_PaintControlButton_MinimizeHover(t *testing.T) {
 	p := DefaultPainter{}
 	canvas := &mockCanvas{}
 	bounds := geometry.NewRect(0, 0, 46, 40)
-	p.DrawControlButton(canvas, bounds, ControlMinimize, ControlState{Hovered: true})
+	p.PaintControlButton(canvas, bounds, ControlMinimize, ControlState{Hovered: true})
 
 	// Should draw hover background.
 	if len(canvas.drawRects) == 0 {
@@ -849,22 +849,22 @@ func TestDefaultPainter_DrawControlButton_MinimizeHover(t *testing.T) {
 	}
 }
 
-func TestDefaultPainter_DrawControlButton_Pressed(t *testing.T) {
+func TestDefaultPainter_PaintControlButton_Pressed(t *testing.T) {
 	p := DefaultPainter{}
 	canvas := &mockCanvas{}
 	bounds := geometry.NewRect(0, 0, 46, 40)
-	p.DrawControlButton(canvas, bounds, ControlMinimize, ControlState{Pressed: true})
+	p.PaintControlButton(canvas, bounds, ControlMinimize, ControlState{Pressed: true})
 
 	if len(canvas.drawRects) == 0 {
 		t.Error("pressed control should draw background rect")
 	}
 }
 
-func TestDefaultPainter_DrawControlButton_ClosePressed(t *testing.T) {
+func TestDefaultPainter_PaintControlButton_ClosePressed(t *testing.T) {
 	p := DefaultPainter{}
 	canvas := &mockCanvas{}
 	bounds := geometry.NewRect(0, 0, 46, 40)
-	p.DrawControlButton(canvas, bounds, ControlClose, ControlState{Pressed: true})
+	p.PaintControlButton(canvas, bounds, ControlClose, ControlState{Pressed: true})
 
 	if len(canvas.drawRects) == 0 {
 		t.Error("close pressed should draw dark red background")
@@ -1206,11 +1206,11 @@ type testPainter struct {
 	controls     []ControlType
 }
 
-func (p *testPainter) DrawBackground(_ widget.Canvas, _ geometry.Rect, _ BackgroundState) {
+func (p *testPainter) PaintBackground(_ widget.Canvas, _ geometry.Rect, _ BackgroundState) {
 	p.bgPainted = true
 }
 
-func (p *testPainter) DrawControlButton(_ widget.Canvas, _ geometry.Rect, control ControlType, _ ControlState) {
+func (p *testPainter) PaintControlButton(_ widget.Canvas, _ geometry.Rect, control ControlType, _ ControlState) {
 	p.controlCount++
 	p.controls = append(p.controls, control)
 }

--- a/core/toolbar/painter.go
+++ b/core/toolbar/painter.go
@@ -37,6 +37,12 @@ type PaintButtonState struct {
 	Focused   bool
 	Disabled  bool
 	Bounds    geometry.Rect
+
+	// Pre-computed icon/label positions (ADR-034 Phase 4).
+	// The widget computes these during its draw loop. Painters should use
+	// these instead of calling iconBoundsForItem/textBoundsForItem.
+	IconBounds geometry.Rect // pre-computed icon position
+	TextBounds geometry.Rect // pre-computed label position (zero if no label)
 }
 
 // DefaultPainter provides a minimal fallback painter with no design system styling.
@@ -76,14 +82,20 @@ func (p DefaultPainter) PaintButtonItem(canvas widget.Canvas, state PaintButtonS
 		fg = defaultDisabledColor
 	}
 
-	// Draw icon centered in the button area.
-	iconBounds := iconBoundsForItem(state.Bounds, state.ShowLabel)
-	icon.Draw(canvas, state.Icon, iconBounds, fg)
+	// Use pre-computed bounds when available (ADR-034 Phase 4).
+	iBounds := state.IconBounds
+	if iBounds.IsEmpty() {
+		iBounds = iconBoundsForItem(state.Bounds, state.ShowLabel)
+	}
+	icon.Draw(canvas, state.Icon, iBounds, fg)
 
 	// Draw label text if ShowLabel is true.
 	if state.ShowLabel && state.Label != "" {
-		textBounds := textBoundsForItem(state.Bounds, iconBounds)
-		canvas.DrawText(state.Label, textBounds, defaultFontSize, fg, false, widget.TextAlignLeft)
+		tBounds := state.TextBounds
+		if tBounds.IsEmpty() {
+			tBounds = textBoundsForItem(state.Bounds, iBounds)
+		}
+		canvas.DrawText(state.Label, tBounds, defaultFontSize, fg, false, widget.TextAlignLeft)
 	}
 
 	// Focus ring.

--- a/core/toolbar/toolbar.go
+++ b/core/toolbar/toolbar.go
@@ -305,15 +305,23 @@ func (w *Widget) Draw(ctx widget.Context, canvas widget.Canvas) {
 
 		switch item.Kind {
 		case ItemButton:
+			// Pre-compute icon/text bounds (ADR-034 Phase 4).
+			iBounds := iconBoundsForItem(itemBounds, item.ShowLabel)
+			var tBounds geometry.Rect
+			if item.ShowLabel && item.Label != "" {
+				tBounds = textBoundsForItem(itemBounds, iBounds)
+			}
 			w.painter.PaintButtonItem(canvas, PaintButtonState{
-				Label:     item.Label,
-				Icon:      item.Icon,
-				ShowLabel: item.ShowLabel,
-				Hovered:   w.itemStates[i].interaction == stateHover,
-				Pressed:   w.itemStates[i].interaction == statePressed,
-				Focused:   w.focusIndex == i,
-				Disabled:  !item.Enabled,
-				Bounds:    itemBounds,
+				Label:      item.Label,
+				Icon:       item.Icon,
+				ShowLabel:  item.ShowLabel,
+				Hovered:    w.itemStates[i].interaction == stateHover,
+				Pressed:    w.itemStates[i].interaction == statePressed,
+				Focused:    w.focusIndex == i,
+				Disabled:   !item.Enabled,
+				Bounds:     itemBounds,
+				IconBounds: iBounds,
+				TextBounds: tBounds,
 			})
 		case ItemSeparator:
 			w.painter.PaintSeparator(canvas, itemBounds)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1504,6 +1504,12 @@ Generic widgets in `core/` define behavior and delegate visual rendering to a `P
 
 This lets the same widget render as Material 3, Fluent, or Cupertino by swapping the Painter. Colors flow as a value struct (`ButtonColorScheme`) -- no import cycle between `core/` and `theme/`.
 
+**Behavior/Styling separation (ADR-034):** Painters are draw-only — they receive pre-computed geometry (cursor rects, selection rects, action button positions) via PaintState and render with theme colors. Behavioral logic (text measurement, cursor positioning, hit-testing, animation easing) stays in the core widget. This enables community theme authoring without duplicating behavior.
+
+**LayoutMetrics (ADR-034):** Widgets define an optional `LayoutMetrics` interface that painters can implement to control spatial metrics (height, padding, font size, corner radius). Widgets query via type assertion with DefaultPainter fallback. This is the Qt `QStyle::pixelMetric` pattern — themes control dimensions without touching behavior.
+
+**ThemeBundle:** `theme.Bundle` interface packages all painters for complete theme installation. Community themes implement `Bundle` to provide a full design system via `app.WithThemeBundle()`.
+
 ### 6. Opt-in Lifecycle for Signal Binding
 
 Widgets that use reactive signals implement `Lifecycle` (opt-in via type assertion). This follows the Flutter `initState`/`dispose` pattern — explicit lifecycle hooks for resource management:

--- a/examples/gallery/main.go
+++ b/examples/gallery/main.go
@@ -31,8 +31,6 @@ import (
 	"github.com/gogpu/gogpu"
 	"github.com/gogpu/ui/app"
 	"github.com/gogpu/ui/core/button"
-	"github.com/gogpu/ui/event"
-	"github.com/gogpu/ui/geometry"
 	"github.com/gogpu/ui/core/checkbox"
 	"github.com/gogpu/ui/core/collapsible"
 	"github.com/gogpu/ui/core/datatable"
@@ -51,6 +49,8 @@ import (
 	"github.com/gogpu/ui/core/toolbar"
 	"github.com/gogpu/ui/core/treeview"
 	"github.com/gogpu/ui/desktop"
+	"github.com/gogpu/ui/event"
+	"github.com/gogpu/ui/geometry"
 	"github.com/gogpu/ui/icon"
 	"github.com/gogpu/ui/primitives"
 	"github.com/gogpu/ui/theme"
@@ -973,9 +973,9 @@ func smoothWalk(current, lo, hi, step float64) float64 {
 // from Event and forwards to dialog.Show.
 type dialogTrigger struct {
 	widget.WidgetBase
-	dlg    *dialog.Widget
-	btn    *button.Widget
-	label  string
+	dlg   *dialog.Widget
+	btn   *button.Widget
+	label string
 }
 
 func newDialogTrigger(dlg *dialog.Widget, label string, ps painterSet) *dialogTrigger {

--- a/examples/gallery/main.go
+++ b/examples/gallery/main.go
@@ -54,7 +54,9 @@ import (
 	"github.com/gogpu/ui/icon"
 	"github.com/gogpu/ui/primitives"
 	"github.com/gogpu/ui/theme"
+	"github.com/gogpu/ui/theme/cupertino"
 	"github.com/gogpu/ui/theme/devtools"
+	"github.com/gogpu/ui/theme/fluent"
 	"github.com/gogpu/ui/theme/material3"
 	"github.com/gogpu/ui/widget"
 )
@@ -143,6 +145,40 @@ func dtPainters(dt *devtools.Theme) painterSet {
 	}
 }
 
+// flPainters creates a painterSet from a Fluent theme.
+// Widgets without Fluent-specific painters use DefaultPainter (zero value).
+func flPainters(fl *fluent.Theme) painterSet {
+	return painterSet{
+		button:    fluent.ButtonPainter{Theme: fl},
+		checkbox:  fluent.CheckboxPainter{Theme: fl},
+		radio:     fluent.RadioPainter{Theme: fl},
+		textfield: fluent.TextFieldPainter{Theme: fl},
+		dropdown:  fluent.DropdownPainter{Theme: fl},
+		slider:    fluent.SliderPainter{Theme: fl},
+		dialog:    fluent.DialogPainter{Theme: fl},
+		scrollbar: fluent.ScrollbarPainter{Theme: fl},
+		tabview:   fluent.TabViewPainter{Theme: fl},
+		isDark:    fl.IsDark(),
+	}
+}
+
+// cupPainters creates a painterSet from a Cupertino theme.
+// Widgets without Cupertino-specific painters use DefaultPainter (zero value).
+func cupPainters(cup *cupertino.Theme) painterSet {
+	return painterSet{
+		button:    cupertino.ButtonPainter{Theme: cup},
+		checkbox:  cupertino.CheckboxPainter{Theme: cup},
+		radio:     cupertino.RadioPainter{Theme: cup},
+		textfield: cupertino.TextFieldPainter{Theme: cup},
+		dropdown:  cupertino.DropdownPainter{Theme: cup},
+		slider:    cupertino.SliderPainter{Theme: cup},
+		dialog:    cupertino.DialogPainter{Theme: cup},
+		scrollbar: cupertino.ScrollbarPainter{Theme: cup},
+		tabview:   cupertino.TabViewPainter{Theme: cup},
+		isDark:    cup.IsDark(),
+	}
+}
+
 // galleryState holds mutable state for the gallery demo.
 type galleryState struct {
 	chart       *linechart.Widget
@@ -155,6 +191,7 @@ type galleryState struct {
 var themeNames = []string{
 	"M3 Purple", "M3 Blue", "M3 Green", "M3 Orange",
 	"DevTools Dark", "DevTools Light",
+	"Fluent", "Cupertino",
 }
 
 func main() {
@@ -204,6 +241,10 @@ func switchTheme(idx int) painterSet {
 		return dtPainters(devtools.NewDarkTheme())
 	case idx == 5: //nolint:mnd // DevTools Light
 		return dtPainters(devtools.NewTheme())
+	case idx == 6: //nolint:mnd // Fluent
+		return flPainters(fluent.NewTheme())
+	case idx == 7: //nolint:mnd // Cupertino
+		return cupPainters(cupertino.NewTheme())
 	default:
 		return m3Painters(material3.New(widget.Hex(0x6750A4)))
 	}
@@ -220,6 +261,10 @@ func switchUITheme(idx int) *theme.Theme {
 		return devtools.NewDarkTheme().AsTheme()
 	case idx == 5: //nolint:mnd // DevTools Light
 		return devtools.NewTheme().AsTheme()
+	case idx == 6: //nolint:mnd // Fluent
+		return fluent.NewTheme().AsTheme()
+	case idx == 7: //nolint:mnd // Cupertino
+		return material3.New(widget.Hex(0x007AFF)).AsTheme() // Apple blue as base
 	default:
 		return material3.New(widget.Hex(0x6750A4)).AsTheme()
 	}

--- a/internal/textmetrics/textmetrics.go
+++ b/internal/textmetrics/textmetrics.go
@@ -1,0 +1,90 @@
+// Package textmetrics provides text-to-pixel coordinate mapping for text
+// editing widgets. It is the single source of truth for cursor positioning,
+// selection highlighting, and mouse-click-to-rune conversion.
+//
+// All methods use [widget.Canvas.MeasureText] for accurate measurement,
+// replacing the approximate charWidthRatio constants that were previously
+// hardcoded in individual theme painters.
+//
+// This package is INTERNAL — not part of the public API. Widget implementations
+// (TextField, future Editor) use it; theme painters do not.
+package textmetrics
+
+import (
+	"github.com/gogpu/ui/geometry"
+	"github.com/gogpu/ui/widget"
+)
+
+// Metrics provides text measurement for a specific canvas and font size.
+type Metrics struct {
+	Canvas   widget.Canvas
+	FontSize float32
+}
+
+// CursorX returns the X coordinate for a cursor at the given rune position
+// within the content rect. Uses MeasureText for accurate positioning.
+func (m *Metrics) CursorX(contentRect geometry.Rect, displayText string, runePos int) float32 {
+	runes := []rune(displayText)
+	if runePos > len(runes) {
+		runePos = len(runes)
+	}
+	if runePos <= 0 {
+		return contentRect.Min.X
+	}
+	textBefore := string(runes[:runePos])
+	x := contentRect.Min.X + m.Canvas.MeasureText(textBefore, m.FontSize, false)
+	if x > contentRect.Max.X {
+		x = contentRect.Max.X
+	}
+	return x
+}
+
+// RuneIndexFromX converts an X coordinate to a rune index (for hit-testing).
+// Returns the rune position closest to the given X within the content rect.
+func (m *Metrics) RuneIndexFromX(contentRect geometry.Rect, displayText string, x float32) int {
+	localX := x - contentRect.Min.X
+	if localX <= 0 {
+		return 0
+	}
+	runes := []rune(displayText)
+	for i := 1; i <= len(runes); i++ {
+		w := m.Canvas.MeasureText(string(runes[:i]), m.FontSize, false)
+		if w > localX {
+			prevW := float32(0)
+			if i > 1 {
+				prevW = m.Canvas.MeasureText(string(runes[:i-1]), m.FontSize, false)
+			}
+			if localX-prevW < w-localX {
+				return i - 1
+			}
+			return i
+		}
+	}
+	return len(runes)
+}
+
+// CursorRect returns the cursor line rectangle for the given rune position.
+// Height is based on fontSize * lineHeightRatio, vertically centered in contentRect.
+func (m *Metrics) CursorRect(contentRect geometry.Rect, displayText string, runePos int, cursorWidth float32) geometry.Rect {
+	x := m.CursorX(contentRect, displayText, runePos)
+	lineHeight := m.FontSize * 1.4
+	centerY := (contentRect.Min.Y + contentRect.Max.Y) / 2
+	return geometry.NewRect(x, centerY-lineHeight/2, cursorWidth, lineHeight)
+}
+
+// SelectionRect returns the selection highlight rectangle for the given
+// rune range [start, end). Vertically spans the full content rect height.
+func (m *Metrics) SelectionRect(contentRect geometry.Rect, displayText string, start, end int) geometry.Rect {
+	if start > end {
+		start, end = end, start
+	}
+	x1 := m.CursorX(contentRect, displayText, start)
+	x2 := m.CursorX(contentRect, displayText, end)
+	if x2 > contentRect.Max.X {
+		x2 = contentRect.Max.X
+	}
+	return geometry.Rect{
+		Min: geometry.Pt(x1, contentRect.Min.Y),
+		Max: geometry.Pt(x2, contentRect.Max.Y),
+	}
+}

--- a/internal/textmetrics/textmetrics.go
+++ b/internal/textmetrics/textmetrics.go
@@ -63,13 +63,22 @@ func (m *Metrics) RuneIndexFromX(contentRect geometry.Rect, displayText string, 
 	return len(runes)
 }
 
+// caretHeightOffset is the amount by which the cursor is inset on each side
+// relative to the full line height. This matches Flutter's _kCaretHeightOffset
+// constant, making the cursor 2px shorter on top and bottom for a cleaner look.
+const caretHeightOffset float32 = 2.0
+
 // CursorRect returns the cursor line rectangle for the given rune position.
-// Height is based on fontSize * lineHeightRatio, vertically centered in contentRect.
+// Height is based on fontSize * lineHeightRatio minus caretHeightOffset on
+// each side (Flutter _kCaretHeightOffset pattern), vertically centered in
+// contentRect.
 func (m *Metrics) CursorRect(contentRect geometry.Rect, displayText string, runePos int, cursorWidth float32) geometry.Rect {
 	x := m.CursorX(contentRect, displayText, runePos)
 	lineHeight := m.FontSize * 1.4
 	centerY := (contentRect.Min.Y + contentRect.Max.Y) / 2
-	return geometry.NewRect(x, centerY-lineHeight/2, cursorWidth, lineHeight)
+	top := centerY - lineHeight/2 + caretHeightOffset
+	bottom := centerY + lineHeight/2 - caretHeightOffset
+	return geometry.NewRect(x, top, cursorWidth, bottom-top)
 }
 
 // SelectionRect returns the selection highlight rectangle for the given

--- a/internal/textmetrics/textmetrics_test.go
+++ b/internal/textmetrics/textmetrics_test.go
@@ -1,0 +1,290 @@
+package textmetrics
+
+import (
+	"image"
+	"testing"
+
+	"github.com/gogpu/gg/scene"
+	"github.com/gogpu/ui/geometry"
+	"github.com/gogpu/ui/widget"
+)
+
+// mockCanvas provides MeasureText using a fixed character width ratio.
+type mockCanvas struct {
+	charWidthRatio float32
+}
+
+func (c *mockCanvas) MeasureText(text string, fontSize float32, _ bool) float32 {
+	return float32(len([]rune(text))) * fontSize * c.charWidthRatio
+}
+
+func (c *mockCanvas) Clear(_ widget.Color)                                                  {}
+func (c *mockCanvas) DrawRect(_ geometry.Rect, _ widget.Color)                              {}
+func (c *mockCanvas) FillRectDirect(_ geometry.Rect, _ widget.Color)                        {}
+func (c *mockCanvas) StrokeRect(_ geometry.Rect, _ widget.Color, _ float32)                 {}
+func (c *mockCanvas) DrawRoundRect(_ geometry.Rect, _ widget.Color, _ float32)              {}
+func (c *mockCanvas) StrokeRoundRect(_ geometry.Rect, _ widget.Color, _ float32, _ float32) {}
+func (c *mockCanvas) DrawCircle(_ geometry.Point, _ float32, _ widget.Color)                {}
+func (c *mockCanvas) StrokeCircle(_ geometry.Point, _ float32, _ widget.Color, _ float32)   {}
+
+func (c *mockCanvas) StrokeArc(_ geometry.Point, _ float32, _, _ float64, _ widget.Color, _ float32) {
+}
+
+func (c *mockCanvas) DrawLine(_, _ geometry.Point, _ widget.Color, _ float32) {}
+func (c *mockCanvas) DrawText(_ string, _ geometry.Rect, _ float32, _ widget.Color, _ bool, _ widget.TextAlign) {
+}
+func (c *mockCanvas) DrawImage(_ image.Image, _ geometry.Point)    {}
+func (c *mockCanvas) PushClip(_ geometry.Rect)                     {}
+func (c *mockCanvas) PushClipRoundRect(_ geometry.Rect, _ float32) {}
+func (c *mockCanvas) PopClip()                                     {}
+func (c *mockCanvas) PushTransform(_ geometry.Point)               {}
+func (c *mockCanvas) PopTransform()                                {}
+func (c *mockCanvas) TransformOffset() geometry.Point              { return geometry.Point{} }
+func (c *mockCanvas) ScreenOriginBase() geometry.Point             { return geometry.Point{} }
+func (c *mockCanvas) ClipBounds() geometry.Rect                    { return geometry.NewRect(0, 0, 10000, 10000) }
+func (c *mockCanvas) ReplayScene(_ *scene.Scene)                   {}
+
+func newMetrics() *Metrics {
+	return &Metrics{
+		Canvas:   &mockCanvas{charWidthRatio: 0.5},
+		FontSize: 14,
+	}
+}
+
+func testContentRect() geometry.Rect {
+	return geometry.NewRect(10, 5, 200, 30)
+}
+
+// --- CursorX Tests ---
+
+func TestCursorX_AtStart(t *testing.T) {
+	m := newMetrics()
+	cr := testContentRect()
+
+	x := m.CursorX(cr, "Hello", 0)
+	if x != cr.Min.X {
+		t.Errorf("CursorX(0) = %v, want %v", x, cr.Min.X)
+	}
+}
+
+func TestCursorX_AtEnd(t *testing.T) {
+	m := newMetrics()
+	cr := testContentRect()
+
+	x := m.CursorX(cr, "Hi", 2)
+	// "Hi" = 2 runes * 14 * 0.5 = 14px
+	want := cr.Min.X + 14
+	if x != want {
+		t.Errorf("CursorX(2) = %v, want %v", x, want)
+	}
+}
+
+func TestCursorX_BeyondTextLength(t *testing.T) {
+	m := newMetrics()
+	cr := testContentRect()
+
+	// Position beyond text length should clamp to text length.
+	x := m.CursorX(cr, "Hi", 10)
+	want := cr.Min.X + 14 // same as end of "Hi"
+	if x != want {
+		t.Errorf("CursorX(10) = %v, want %v (clamped to text end)", x, want)
+	}
+}
+
+func TestCursorX_NegativePosition(t *testing.T) {
+	m := newMetrics()
+	cr := testContentRect()
+
+	x := m.CursorX(cr, "Hello", -1)
+	if x != cr.Min.X {
+		t.Errorf("CursorX(-1) = %v, want %v (clamped to start)", x, cr.Min.X)
+	}
+}
+
+func TestCursorX_EmptyText(t *testing.T) {
+	m := newMetrics()
+	cr := testContentRect()
+
+	x := m.CursorX(cr, "", 0)
+	if x != cr.Min.X {
+		t.Errorf("CursorX empty = %v, want %v", x, cr.Min.X)
+	}
+}
+
+// --- RuneIndexFromX Tests ---
+
+func TestRuneIndexFromX_AtStart(t *testing.T) {
+	m := newMetrics()
+	cr := testContentRect()
+
+	idx := m.RuneIndexFromX(cr, "Hello", cr.Min.X)
+	if idx != 0 {
+		t.Errorf("RuneIndexFromX(start) = %d, want 0", idx)
+	}
+}
+
+func TestRuneIndexFromX_BeforeStart(t *testing.T) {
+	m := newMetrics()
+	cr := testContentRect()
+
+	idx := m.RuneIndexFromX(cr, "Hello", cr.Min.X-10)
+	if idx != 0 {
+		t.Errorf("RuneIndexFromX(before start) = %d, want 0", idx)
+	}
+}
+
+func TestRuneIndexFromX_AfterEnd(t *testing.T) {
+	m := newMetrics()
+	cr := testContentRect()
+
+	// Well past the end of text.
+	idx := m.RuneIndexFromX(cr, "Hi", cr.Min.X+1000)
+	if idx != 2 {
+		t.Errorf("RuneIndexFromX(past end) = %d, want 2", idx)
+	}
+}
+
+func TestRuneIndexFromX_MiddleOfChar(t *testing.T) {
+	m := newMetrics()
+	cr := testContentRect()
+
+	// Each char = 14*0.5 = 7px. Halfway through first char = 3.5px.
+	// At 3px -> closer to start (0) than end of char (7) -> index 0.
+	idx := m.RuneIndexFromX(cr, "Hello", cr.Min.X+3)
+	if idx != 0 {
+		t.Errorf("RuneIndexFromX(3px in) = %d, want 0", idx)
+	}
+
+	// At 5px -> closer to end of char (7) than start (0) -> index 1.
+	idx = m.RuneIndexFromX(cr, "Hello", cr.Min.X+5)
+	if idx != 1 {
+		t.Errorf("RuneIndexFromX(5px in) = %d, want 1", idx)
+	}
+}
+
+func TestRuneIndexFromX_Unicode(t *testing.T) {
+	m := newMetrics()
+	cr := testContentRect()
+
+	// Unicode bullets (6 chars), each 7px wide.
+	text := string([]rune{'\u2022', '\u2022', '\u2022', '\u2022', '\u2022', '\u2022'})
+	idx := m.RuneIndexFromX(cr, text, cr.Min.X+21) // 21px = 3 chars
+	if idx != 3 {
+		t.Errorf("RuneIndexFromX(unicode 21px) = %d, want 3", idx)
+	}
+}
+
+// --- CursorRect Tests ---
+
+func TestCursorRect_Basic(t *testing.T) {
+	m := newMetrics()
+	cr := testContentRect()
+
+	rect := m.CursorRect(cr, "Hello", 2, 2.0)
+
+	// X should be at position 2 = 2*7 = 14px from content start.
+	wantX := cr.Min.X + 14
+	if rect.Min.X != wantX {
+		t.Errorf("CursorRect.Min.X = %v, want %v", rect.Min.X, wantX)
+	}
+
+	// Width should be cursor width.
+	if rect.Width() != 2.0 {
+		t.Errorf("CursorRect.Width = %v, want 2.0", rect.Width())
+	}
+
+	// Height should be based on lineHeight (fontSize * 1.4).
+	lineHeight := m.FontSize * 1.4
+	wantHeight := lineHeight
+	gotHeight := rect.Height()
+	if gotHeight < wantHeight-0.1 || gotHeight > wantHeight+0.1 {
+		t.Errorf("CursorRect.Height = %v, want ~%v", gotHeight, wantHeight)
+	}
+}
+
+func TestCursorRect_VerticallyCentered(t *testing.T) {
+	m := newMetrics()
+	cr := testContentRect()
+
+	rect := m.CursorRect(cr, "Hi", 0, 1.0)
+
+	centerY := (cr.Min.Y + cr.Max.Y) / 2
+	rectCenterY := (rect.Min.Y + rect.Max.Y) / 2
+	if rectCenterY < centerY-0.5 || rectCenterY > centerY+0.5 {
+		t.Errorf("CursorRect center Y = %v, want ~%v (vertically centered)", rectCenterY, centerY)
+	}
+}
+
+// --- SelectionRect Tests ---
+
+func TestSelectionRect_Basic(t *testing.T) {
+	m := newMetrics()
+	cr := testContentRect()
+
+	rect := m.SelectionRect(cr, "Hello", 1, 3)
+
+	// Start X: 1 char = 7px, End X: 3 chars = 21px.
+	wantX1 := cr.Min.X + 7
+	wantX2 := cr.Min.X + 21
+
+	if rect.Min.X != wantX1 {
+		t.Errorf("SelectionRect.Min.X = %v, want %v", rect.Min.X, wantX1)
+	}
+	if rect.Max.X != wantX2 {
+		t.Errorf("SelectionRect.Max.X = %v, want %v", rect.Max.X, wantX2)
+	}
+
+	// Y should span full content rect height.
+	if rect.Min.Y != cr.Min.Y {
+		t.Errorf("SelectionRect.Min.Y = %v, want %v", rect.Min.Y, cr.Min.Y)
+	}
+	if rect.Max.Y != cr.Max.Y {
+		t.Errorf("SelectionRect.Max.Y = %v, want %v", rect.Max.Y, cr.Max.Y)
+	}
+}
+
+func TestSelectionRect_ReversedRange(t *testing.T) {
+	m := newMetrics()
+	cr := testContentRect()
+
+	// Start > end should be handled (reversed).
+	rect := m.SelectionRect(cr, "Hello", 3, 1)
+
+	wantX1 := cr.Min.X + 7 // min(1,3) = 1 -> 7px
+	wantX2 := cr.Min.X + 21
+
+	if rect.Min.X != wantX1 {
+		t.Errorf("SelectionRect(reversed).Min.X = %v, want %v", rect.Min.X, wantX1)
+	}
+	if rect.Max.X != wantX2 {
+		t.Errorf("SelectionRect(reversed).Max.X = %v, want %v", rect.Max.X, wantX2)
+	}
+}
+
+func TestSelectionRect_FullText(t *testing.T) {
+	m := newMetrics()
+	cr := testContentRect()
+
+	rect := m.SelectionRect(cr, "Hi", 0, 2)
+
+	if rect.Min.X != cr.Min.X {
+		t.Errorf("SelectionRect(all).Min.X = %v, want %v", rect.Min.X, cr.Min.X)
+	}
+	wantX2 := cr.Min.X + 14 // 2 chars * 7px
+	if rect.Max.X != wantX2 {
+		t.Errorf("SelectionRect(all).Max.X = %v, want %v", rect.Max.X, wantX2)
+	}
+}
+
+func TestSelectionRect_ClampedToContentRect(t *testing.T) {
+	m := newMetrics()
+	// Small content rect to test clamping.
+	cr := geometry.NewRect(10, 5, 20, 30)
+
+	// 10 chars * 7px = 70px > 20px width.
+	rect := m.SelectionRect(cr, "HelloWorld", 0, 10)
+
+	if rect.Max.X > cr.Max.X {
+		t.Errorf("SelectionRect.Max.X = %v, should be clamped to %v", rect.Max.X, cr.Max.X)
+	}
+}

--- a/internal/textmetrics/textmetrics_test.go
+++ b/internal/textmetrics/textmetrics_test.go
@@ -193,9 +193,10 @@ func TestCursorRect_Basic(t *testing.T) {
 		t.Errorf("CursorRect.Width = %v, want 2.0", rect.Width())
 	}
 
-	// Height should be based on lineHeight (fontSize * 1.4).
+	// Height should be based on lineHeight (fontSize * 1.4) minus
+	// 2*caretHeightOffset (Flutter _kCaretHeightOffset = 2.0).
 	lineHeight := m.FontSize * 1.4
-	wantHeight := lineHeight
+	wantHeight := lineHeight - 2*caretHeightOffset
 	gotHeight := rect.Height()
 	if gotHeight < wantHeight-0.1 || gotHeight > wantHeight+0.1 {
 		t.Errorf("CursorRect.Height = %v, want ~%v", gotHeight, wantHeight)

--- a/theme/bundle.go
+++ b/theme/bundle.go
@@ -1,0 +1,53 @@
+package theme
+
+// Bundle provides a complete set of painters for all core widgets
+// from a single design system.
+//
+// Each design system (Material 3, DevTools, Fluent, Cupertino) implements
+// Bundle to offer one-call creation of all widget painters. This replaces
+// ad-hoc painter-set structs in application code and enables design-system
+// switching with a single variable swap.
+//
+// Painter values are typed as any to avoid import cycles between theme/
+// and core/ packages. Consumer code type-asserts to the concrete painter
+// interface defined by each widget:
+//
+//	bundle := material3.NewBundle(theme)
+//	btn := button.New(button.PainterOpt(bundle.Painter("button").(button.Painter)))
+//
+// Or use the convenience map for bulk painter assignment:
+//
+//	for name, painter := range bundle.Painters() {
+//	    registry.SetPainter(name, painter)
+//	}
+//
+// Bundle implementations should use the widget package name (lowercase) as
+// the painter key: "button", "checkbox", "radio", "textfield", etc.
+type Bundle interface {
+	// Name returns a human-readable name for the design system.
+	//
+	// Examples: "Material 3", "DevTools Dark", "Fluent Light", "Cupertino"
+	Name() string
+
+	// BaseTheme returns the underlying Theme for color and typography access.
+	//
+	// This allows consumers to read theme tokens (Colors.Primary, Typography,
+	// Spacing) without importing the design-system-specific theme struct.
+	BaseTheme() *Theme
+
+	// Painter returns a single painter by widget name, or nil if the design
+	// system does not provide a painter for that widget.
+	//
+	// Standard widget names (matching core/ package names):
+	//   "badge", "button", "checkbox", "chip", "collapsible", "datatable",
+	//   "dialog", "docking", "dropdown", "gridview", "linechart", "listview",
+	//   "menu", "popover", "progress", "progressbar", "radio", "scrollview",
+	//   "slider", "splitview", "stripe", "tabview", "textfield", "titlebar",
+	//   "toolbar", "treeview"
+	Painter(widget string) any
+
+	// Painters returns all painters as a map from widget name to painter.
+	//
+	// The returned map is a snapshot -- mutations do not affect the bundle.
+	Painters() map[string]any
+}

--- a/theme/bundle_test.go
+++ b/theme/bundle_test.go
@@ -1,0 +1,81 @@
+package theme
+
+import "testing"
+
+// testBundle is a minimal Bundle implementation for testing the interface.
+type testBundle struct {
+	name     string
+	theme    *Theme
+	painters map[string]any
+}
+
+func (b *testBundle) Name() string      { return b.name }
+func (b *testBundle) BaseTheme() *Theme { return b.theme }
+func (b *testBundle) Painter(w string) any {
+	return b.painters[w]
+}
+func (b *testBundle) Painters() map[string]any {
+	out := make(map[string]any, len(b.painters))
+	for k, v := range b.painters {
+		out[k] = v
+	}
+	return out
+}
+
+func TestBundle_Interface(t *testing.T) {
+	th := DefaultLight()
+	b := &testBundle{
+		name:  "Test Bundle",
+		theme: th,
+		painters: map[string]any{
+			"button":   "mock-button-painter",
+			"checkbox": "mock-checkbox-painter",
+		},
+	}
+
+	// Compile-time interface satisfaction.
+	var _ Bundle = b
+
+	if b.Name() != "Test Bundle" {
+		t.Errorf("Name() = %q, want %q", b.Name(), "Test Bundle")
+	}
+
+	if b.BaseTheme() != th {
+		t.Error("BaseTheme() should return the provided theme")
+	}
+
+	if b.Painter("button") != "mock-button-painter" {
+		t.Errorf("Painter(button) = %v, want mock-button-painter", b.Painter("button"))
+	}
+
+	if b.Painter("nonexistent") != nil {
+		t.Errorf("Painter(nonexistent) = %v, want nil", b.Painter("nonexistent"))
+	}
+
+	painters := b.Painters()
+	if len(painters) != 2 {
+		t.Errorf("Painters() returned %d entries, want 2", len(painters))
+	}
+
+	// Verify snapshot semantics: mutating returned map doesn't affect bundle.
+	painters["extra"] = "should-not-leak"
+	if b.Painter("extra") != nil {
+		t.Error("mutating Painters() result should not affect bundle")
+	}
+}
+
+func TestBundle_EmptyPainters(t *testing.T) {
+	b := &testBundle{
+		name:     "Empty",
+		theme:    DefaultDark(),
+		painters: map[string]any{},
+	}
+
+	if len(b.Painters()) != 0 {
+		t.Error("empty bundle should return empty map")
+	}
+
+	if b.Painter("button") != nil {
+		t.Error("empty bundle should return nil for any widget")
+	}
+}

--- a/theme/cupertino/button.go
+++ b/theme/cupertino/button.go
@@ -197,5 +197,40 @@ const (
 	cupBtnFocusAlpha      float32 = 0.6
 )
 
-// Compile-time check that ButtonPainter implements Painter.
-var _ button.Painter = ButtonPainter{}
+// ButtonHeight returns the Cupertino height for the given button size.
+func (ButtonPainter) ButtonHeight(size button.Size) float32 {
+	switch size {
+	case button.Small:
+		return 30
+	case button.Large:
+		return 50
+	default:
+		return 44
+	}
+}
+
+// ButtonPadding returns the Cupertino horizontal and vertical padding.
+func (ButtonPainter) ButtonPadding(size button.Size) (float32, float32) {
+	switch size {
+	case button.Small:
+		return 10, 6
+	case button.Large:
+		return 24, 14
+	default:
+		return 20, 10
+	}
+}
+
+// ButtonFontSize returns the Cupertino font size for the given button size.
+func (ButtonPainter) ButtonFontSize(size button.Size) float32 {
+	return cupBtnFontSize(size)
+}
+
+// ButtonRadius returns the Cupertino default corner radius.
+func (ButtonPainter) ButtonRadius() float32 { return cupBtnDefaultRadius }
+
+// Compile-time checks.
+var (
+	_ button.Painter       = ButtonPainter{}
+	_ button.LayoutMetrics = ButtonPainter{}
+)

--- a/theme/cupertino/checkbox.go
+++ b/theme/cupertino/checkbox.go
@@ -208,5 +208,19 @@ const (
 	cupCbDashStroke       float32 = 2
 )
 
-// Compile-time check that CheckboxPainter implements Painter.
-var _ checkbox.Painter = CheckboxPainter{}
+// CheckboxBoxSize returns the Cupertino toggle track width.
+// The Cupertino checkbox renders as a toggle switch, so the "box size"
+// represents the track width for layout purposes.
+func (CheckboxPainter) CheckboxBoxSize() float32 { return cupCbTrackWidth }
+
+// CheckboxLabelGap returns the Cupertino gap between toggle and label.
+func (CheckboxPainter) CheckboxLabelGap() float32 { return cupCbLabelGap }
+
+// CheckboxFontSize returns the Cupertino label font size.
+func (CheckboxPainter) CheckboxFontSize() float32 { return cupCbFontSize }
+
+// Compile-time checks.
+var (
+	_ checkbox.Painter       = CheckboxPainter{}
+	_ checkbox.LayoutMetrics = CheckboxPainter{}
+)

--- a/theme/cupertino/chip.go
+++ b/theme/cupertino/chip.go
@@ -55,10 +55,29 @@ var cupDefaultChipColors = chip.ChipColorScheme{
 	DisabledLabel:      widget.RGBA(0.235, 0.235, 0.263, 0.3),      // TertiaryLabel
 }
 
+// ChipFontSize returns the Cupertino chip font size.
+func (ChipPainter) ChipFontSize() float32 { return cupChipFontSize }
+
+// ChipMinWidth returns the Cupertino minimum chip width.
+func (ChipPainter) ChipMinWidth() float32 { return cupChipMinWidth }
+
+// ChipPadding returns the Cupertino chip horizontal padding.
+func (ChipPainter) ChipPadding() float32 { return cupChipPadding }
+
+// ChipRadius returns the Cupertino chip corner radius.
+func (ChipPainter) ChipRadius() float32 { return cupChipRadius }
+
 // Cupertino chip constants.
 const (
 	cupChipSelectedAlpha float32 = 0.15 // Apple HIG tint alpha for selected tags
+	cupChipFontSize      float32 = 15   // SF Pro body
+	cupChipMinWidth      float32 = 44   // Apple HIG touch target
+	cupChipPadding       float32 = 14   // Apple HIG horizontal padding
+	cupChipRadius        float32 = 10   // Apple HIG rounded pill
 )
 
-// Compile-time check that ChipPainter implements chip.Painter.
-var _ chip.Painter = ChipPainter{}
+// Compile-time checks.
+var (
+	_ chip.Painter       = ChipPainter{}
+	_ chip.LayoutMetrics = ChipPainter{}
+)

--- a/theme/cupertino/cupertino_test.go
+++ b/theme/cupertino/cupertino_test.go
@@ -623,7 +623,7 @@ func TestPaintTextFieldEmptyBounds(t *testing.T) {
 	canvas := &recordCanvas{}
 	painter := cupertino.TextFieldPainter{}
 
-	painter.PaintTextField(canvas, textfield.PaintState{Bounds: geometry.Rect{}})
+	painter.PaintTextField(canvas, &textfield.PaintState{Bounds: geometry.Rect{}})
 
 	if len(canvas.calls) != 0 {
 		t.Errorf("empty bounds should produce no draw calls, got %d", len(canvas.calls))
@@ -634,7 +634,7 @@ func TestPaintTextFieldNormal(t *testing.T) {
 	canvas := &recordCanvas{}
 	painter := cupertino.TextFieldPainter{}
 
-	painter.PaintTextField(canvas, textfield.PaintState{
+	painter.PaintTextField(canvas, &textfield.PaintState{
 		Text:   "Hello",
 		Bounds: testBounds(),
 	})
@@ -655,7 +655,7 @@ func TestPaintTextFieldPlaceholder(t *testing.T) {
 	canvas := &recordCanvas{}
 	painter := cupertino.TextFieldPainter{}
 
-	painter.PaintTextField(canvas, textfield.PaintState{
+	painter.PaintTextField(canvas, &textfield.PaintState{
 		Text:        "",
 		Placeholder: "Enter text...",
 		Bounds:      testBounds(),
@@ -675,7 +675,7 @@ func TestPaintTextFieldWithTheme(t *testing.T) {
 	painter := cupertino.TextFieldPainter{Theme: theme}
 	canvas := &recordCanvas{}
 
-	painter.PaintTextField(canvas, textfield.PaintState{
+	painter.PaintTextField(canvas, &textfield.PaintState{
 		Text:   "Themed",
 		Bounds: testBounds(),
 	})

--- a/theme/cupertino/dialog.go
+++ b/theme/cupertino/dialog.go
@@ -73,6 +73,15 @@ func (p DialogPainter) paintActions(canvas widget.Canvas, ps dialog.PaintState, 
 		return
 	}
 
+	// Use pre-computed ActionRects when available (ADR-034 Phase 4).
+	if len(ps.ActionRects) == len(ps.Actions) {
+		for i, action := range ps.Actions {
+			canvas.DrawText(action.Label, ps.ActionRects[i], cupDlgActionFontSize, colors.ActionFg, false, cupDlgTextAlignCenter)
+		}
+		return
+	}
+
+	// Legacy fallback.
 	x := ps.Bounds.Max.X - cupDlgPadding
 	y := ps.Bounds.Max.Y - cupDlgPadding - cupDlgActionHeight
 

--- a/theme/cupertino/dialog.go
+++ b/theme/cupertino/dialog.go
@@ -117,7 +117,20 @@ const (
 	cupDlgFocusRingOffset float32 = 3
 	cupDlgFocusRingStroke float32 = 2.5
 	cupDlgFocusRingAlpha  float32 = 0.6
+	cupDlgMaxWidth        float32 = 480
 )
 
-// Compile-time check that DialogPainter implements Painter.
-var _ dialog.Painter = DialogPainter{}
+// DialogPadding returns the Cupertino dialog padding.
+func (DialogPainter) DialogPadding() float32 { return cupDlgPadding }
+
+// DialogTitleHeight returns the Cupertino dialog title height.
+func (DialogPainter) DialogTitleHeight() float32 { return cupDlgTitleHeight }
+
+// DialogMaxWidth returns the Cupertino default maximum dialog width.
+func (DialogPainter) DialogMaxWidth() float32 { return cupDlgMaxWidth }
+
+// Compile-time checks.
+var (
+	_ dialog.Painter       = DialogPainter{}
+	_ dialog.LayoutMetrics = DialogPainter{}
+)

--- a/theme/cupertino/radio.go
+++ b/theme/cupertino/radio.go
@@ -148,7 +148,23 @@ const (
 	cupRadioFocusAlpha      float32 = 0.6
 	cupRadioHoverLighten    float32 = 0.08
 	cupRadioPressedDarken   float32 = 0.12
+	cupRadioItemPadding     float32 = 4
 )
 
-// Compile-time check that RadioPainter implements Painter.
-var _ radio.Painter = RadioPainter{}
+// RadioCircleRadius returns the Cupertino outer circle radius.
+func (RadioPainter) RadioCircleRadius() float32 { return cupRadioOuterRadius }
+
+// RadioLabelGap returns the Cupertino gap between circle and label.
+func (RadioPainter) RadioLabelGap() float32 { return cupRadioLabelGap }
+
+// RadioFontSize returns the Cupertino label font size.
+func (RadioPainter) RadioFontSize() float32 { return cupRadioFontSize }
+
+// RadioItemPadding returns the Cupertino radio item padding.
+func (RadioPainter) RadioItemPadding() float32 { return cupRadioItemPadding }
+
+// Compile-time checks.
+var (
+	_ radio.Painter       = RadioPainter{}
+	_ radio.LayoutMetrics = RadioPainter{}
+)

--- a/theme/cupertino/slider.go
+++ b/theme/cupertino/slider.go
@@ -217,5 +217,14 @@ const (
 	cupSliderFocusAlpha       float32 = 0.6
 )
 
-// Compile-time check that SliderPainter implements Painter.
-var _ slider.Painter = SliderPainter{}
+// SliderThumbRadius returns the Cupertino thumb radius.
+func (SliderPainter) SliderThumbRadius() float32 { return cupSliderThumbRadius }
+
+// SliderTrackHeight returns the Cupertino track height.
+func (SliderPainter) SliderTrackHeight() float32 { return cupSliderTrackHeight }
+
+// Compile-time checks.
+var (
+	_ slider.Painter       = SliderPainter{}
+	_ slider.LayoutMetrics = SliderPainter{}
+)

--- a/theme/cupertino/textfield.go
+++ b/theme/cupertino/textfield.go
@@ -10,10 +10,28 @@ import (
 // Cupertino text fields use a rounded rectangle with a light background
 // and subtle border, following iOS text field conventions.
 //
+// TextFieldPainter implements [textfield.LayoutMetrics] to provide Cupertino
+// spatial metrics (15px font, 12/10px padding, 2px cursor) used by the widget
+// to compute pre-computed PaintState fields.
+//
 // If Theme is nil, TextFieldPainter falls back to the default system blue palette.
 type TextFieldPainter struct {
 	Theme *Theme // nil uses default system blue fallback
 }
+
+// ContentPadding returns the Cupertino horizontal and vertical padding.
+func (TextFieldPainter) ContentPadding() (float32, float32) {
+	return cupTFContentPaddingH, cupTFContentPaddingV
+}
+
+// TextFieldFontSize returns the Cupertino font size.
+func (TextFieldPainter) TextFieldFontSize() float32 { return cupTFFontSize }
+
+// TextFieldCursorWidth returns the Cupertino cursor width.
+func (TextFieldPainter) TextFieldCursorWidth() float32 { return cupTFCursorWidth }
+
+// TextFieldCornerRadius returns the Cupertino corner radius.
+func (TextFieldPainter) TextFieldCornerRadius() float32 { return cupTFCornerRadius }
 
 // resolveColors returns the TextFieldColorScheme derived from the painter's Theme.
 func (p TextFieldPainter) resolveColors() textfield.TextFieldColorScheme {
@@ -37,21 +55,27 @@ func (p TextFieldPainter) resolveColors() textfield.TextFieldColorScheme {
 }
 
 // PaintTextField renders a text field according to Apple HIG specifications.
-func (p TextFieldPainter) PaintTextField(canvas widget.Canvas, st textfield.PaintState) {
+// Cursor and selection positions come from pre-computed PaintState fields.
+func (p TextFieldPainter) PaintTextField(canvas widget.Canvas, st *textfield.PaintState) {
 	if st.Bounds.IsEmpty() {
 		return
 	}
 
 	colors := p.resolveColors()
+	fontSize := st.FontSize
+	if fontSize <= 0 {
+		fontSize = cupTFFontSize
+	}
+
 	cupPaintTFBackground(canvas, st, colors)
 	cupPaintTFBorder(canvas, st, colors)
-	cupPaintTFContent(canvas, st, colors)
-	cupPaintTFCursor(canvas, st, colors)
+	cupPaintTFContent(canvas, st, colors, fontSize)
+	cupPaintTFCursorFromState(canvas, st, colors)
 	cupPaintTFError(canvas, st, colors)
 }
 
 // cupPaintTFBackground draws the text field background.
-func cupPaintTFBackground(canvas widget.Canvas, st textfield.PaintState, colors textfield.TextFieldColorScheme) {
+func cupPaintTFBackground(canvas widget.Canvas, st *textfield.PaintState, colors textfield.TextFieldColorScheme) {
 	bg := colors.Background
 	if st.Disabled {
 		bg = colors.DisabledBg
@@ -60,7 +84,7 @@ func cupPaintTFBackground(canvas widget.Canvas, st textfield.PaintState, colors 
 }
 
 // cupPaintTFBorder draws the text field outline.
-func cupPaintTFBorder(canvas widget.Canvas, st textfield.PaintState, colors textfield.TextFieldColorScheme) {
+func cupPaintTFBorder(canvas widget.Canvas, st *textfield.PaintState, colors textfield.TextFieldColorScheme) {
 	borderColor := colors.Border
 	strokeWidth := cupTFBorderWidth
 
@@ -80,24 +104,17 @@ func cupPaintTFBorder(canvas widget.Canvas, st textfield.PaintState, colors text
 	canvas.StrokeRoundRect(st.Bounds, borderColor, cupTFCornerRadius, strokeWidth)
 }
 
-// cupPaintTFContent draws the text or placeholder.
-func cupPaintTFContent(canvas widget.Canvas, st textfield.PaintState, colors textfield.TextFieldColorScheme) {
-	contentBounds := cupTFContentRect(st.Bounds)
-
-	canvas.PushClip(contentBounds)
+// cupPaintTFContent draws the text or placeholder using pre-computed fields.
+func cupPaintTFContent(canvas widget.Canvas, st *textfield.PaintState, colors textfield.TextFieldColorScheme, fontSize float32) {
+	canvas.PushClip(st.ContentRect)
 	defer canvas.PopClip()
 
-	displayText := st.Text
-	if st.InputType == textfield.TypePassword {
-		displayText = cupMaskText(len([]rune(st.Text)))
-	}
-
-	if displayText == "" && !st.Focused {
+	if st.DisplayText == "" && !st.Focused {
 		color := colors.Placeholder
 		if st.Disabled {
 			color = colors.DisabledFg
 		}
-		canvas.DrawText(st.Placeholder, contentBounds, cupTFFontSize, color, false, cupTFTextAlignLeft)
+		canvas.DrawText(st.Placeholder, st.ContentRect, fontSize, color, false, cupTFTextAlignLeft)
 		return
 	}
 
@@ -106,57 +123,26 @@ func cupPaintTFContent(canvas widget.Canvas, st textfield.PaintState, colors tex
 		textColor = colors.DisabledFg
 	}
 
-	if st.SelectStart != st.SelectEnd {
-		cupPaintTFSelection(canvas, contentBounds, st, colors)
+	if st.ShowSelection {
+		canvas.DrawRect(st.SelectionRect, colors.SelectionBg)
 	}
 
-	canvas.DrawText(displayText, contentBounds, cupTFFontSize, textColor, false, cupTFTextAlignLeft)
+	canvas.DrawText(st.DisplayText, st.ContentRect, fontSize, textColor, false, cupTFTextAlignLeft)
 }
 
-// cupPaintTFSelection draws the selection highlight.
-func cupPaintTFSelection(canvas widget.Canvas, contentBounds geometry.Rect, st textfield.PaintState, colors textfield.TextFieldColorScheme) {
-	selStart := st.SelectStart
-	selEnd := st.SelectEnd
-	if selStart > selEnd {
-		selStart, selEnd = selEnd, selStart
-	}
-
-	charWidth := cupTFFontSize * cupTFCharWidthRatio
-	x1 := contentBounds.Min.X + float32(selStart)*charWidth
-	x2 := contentBounds.Min.X + float32(selEnd)*charWidth
-
-	if x2 > contentBounds.Max.X {
-		x2 = contentBounds.Max.X
-	}
-
-	selRect := geometry.Rect{
-		Min: geometry.Pt(x1, contentBounds.Min.Y),
-		Max: geometry.Pt(x2, contentBounds.Max.Y),
-	}
-	canvas.DrawRect(selRect, colors.SelectionBg)
-}
-
-// cupPaintTFCursor draws the blinking caret.
-func cupPaintTFCursor(canvas widget.Canvas, st textfield.PaintState, colors textfield.TextFieldColorScheme) {
-	if !st.Focused || st.Disabled || st.SelectStart != st.SelectEnd {
+// cupPaintTFCursorFromState draws the cursor using pre-computed CursorRect.
+func cupPaintTFCursorFromState(canvas widget.Canvas, st *textfield.PaintState, colors textfield.TextFieldColorScheme) {
+	if !st.ShowCursor {
 		return
 	}
 
-	content := cupTFContentRect(st.Bounds)
-	charWidth := cupTFFontSize * cupTFCharWidthRatio
-	cursorX := content.Min.X + float32(st.CursorPos)*charWidth
-
-	if cursorX > content.Max.X {
-		cursorX = content.Max.X
-	}
-
-	top := geometry.Pt(cursorX, content.Min.Y+cupTFCursorPadding)
-	bottom := geometry.Pt(cursorX, content.Max.Y-cupTFCursorPadding)
-	canvas.DrawLine(top, bottom, colors.CursorColor, cupTFCursorWidth)
+	top := geometry.Pt(st.CursorRect.Min.X, st.CursorRect.Min.Y)
+	bottom := geometry.Pt(st.CursorRect.Min.X, st.CursorRect.Max.Y)
+	canvas.DrawLine(top, bottom, colors.CursorColor, st.CursorRect.Width())
 }
 
 // cupPaintTFError draws the error message below the text field.
-func cupPaintTFError(canvas widget.Canvas, st textfield.PaintState, colors textfield.TextFieldColorScheme) {
+func cupPaintTFError(canvas widget.Canvas, st *textfield.PaintState, colors textfield.TextFieldColorScheme) {
 	if !st.HasError || st.ErrorMsg == "" {
 		return
 	}
@@ -166,23 +152,6 @@ func cupPaintTFError(canvas widget.Canvas, st textfield.PaintState, colors textf
 		Max: geometry.Pt(st.Bounds.Max.X, st.Bounds.Max.Y+cupTFErrorTopGap+cupTFErrorFontSize+cupTFErrorBottomPad),
 	}
 	canvas.DrawText(st.ErrorMsg, errBounds, cupTFErrorFontSize, colors.ErrorText, false, cupTFTextAlignLeft)
-}
-
-// cupTFContentRect returns the inner content area for text.
-func cupTFContentRect(bounds geometry.Rect) geometry.Rect {
-	return geometry.Rect{
-		Min: geometry.Pt(bounds.Min.X+cupTFContentPaddingH, bounds.Min.Y+cupTFContentPaddingV),
-		Max: geometry.Pt(bounds.Max.X-cupTFContentPaddingH, bounds.Max.Y-cupTFContentPaddingV),
-	}
-}
-
-// cupMaskText returns a string of bullet characters with the given length.
-func cupMaskText(length int) string {
-	runes := make([]rune, length)
-	for i := range runes {
-		runes[i] = '\u2022'
-	}
-	return string(runes)
 }
 
 // cupDefaultTextFieldColors holds the default Cupertino text field color scheme.
@@ -208,15 +177,16 @@ const (
 	cupTFContentPaddingH  float32 = 12
 	cupTFContentPaddingV  float32 = 10
 	cupTFFontSize         float32 = 15
-	cupTFCharWidthRatio   float32 = 0.55
 	cupTFTextAlignLeft            = widget.TextAlignLeft
 	cupTFCursorWidth      float32 = 2
-	cupTFCursorPadding    float32 = 2
 	cupTFErrorFontSize    float32 = 12
 	cupTFErrorTopGap      float32 = 4
 	cupTFErrorBottomPad   float32 = 4
 	cupTFSelectionAlpha   float32 = 0.2
 )
 
-// Compile-time check that TextFieldPainter implements Painter.
-var _ textfield.Painter = TextFieldPainter{}
+// Compile-time checks.
+var (
+	_ textfield.Painter       = TextFieldPainter{}
+	_ textfield.LayoutMetrics = TextFieldPainter{}
+)

--- a/theme/devtools/button.go
+++ b/theme/devtools/button.go
@@ -189,5 +189,41 @@ const (
 	dtPressedDarkenFactor  float32 = 0.10
 )
 
-// Compile-time check that ButtonPainter implements Painter.
-var _ button.Painter = ButtonPainter{}
+// ButtonHeight returns the DevTools height for the given button size.
+// DevTools buttons are more compact than M3 (28px default).
+func (ButtonPainter) ButtonHeight(size button.Size) float32 {
+	switch size {
+	case button.Small:
+		return 24
+	case button.Large:
+		return 36
+	default:
+		return 28
+	}
+}
+
+// ButtonPadding returns the DevTools horizontal and vertical padding.
+func (ButtonPainter) ButtonPadding(size button.Size) (float32, float32) {
+	switch size {
+	case button.Small:
+		return 8, 4
+	case button.Large:
+		return 16, 8
+	default:
+		return 12, 6
+	}
+}
+
+// ButtonFontSize returns the DevTools font size for the given button size.
+func (ButtonPainter) ButtonFontSize(size button.Size) float32 {
+	return dtButtonFontSize(size)
+}
+
+// ButtonRadius returns the DevTools default corner radius.
+func (ButtonPainter) ButtonRadius() float32 { return dtButtonRadius }
+
+// Compile-time checks.
+var (
+	_ button.Painter       = ButtonPainter{}
+	_ button.LayoutMetrics = ButtonPainter{}
+)

--- a/theme/devtools/checkbox.go
+++ b/theme/devtools/checkbox.go
@@ -186,5 +186,17 @@ const (
 	dtDashStrokeWidth float32 = 1.5
 )
 
-// Compile-time check that CheckboxPainter implements Painter.
-var _ checkbox.Painter = CheckboxPainter{}
+// CheckboxBoxSize returns the DevTools checkbox box size.
+func (CheckboxPainter) CheckboxBoxSize() float32 { return dtCBBoxSize }
+
+// CheckboxLabelGap returns the DevTools gap between box and label.
+func (CheckboxPainter) CheckboxLabelGap() float32 { return dtCBLabelGap }
+
+// CheckboxFontSize returns the DevTools label font size.
+func (CheckboxPainter) CheckboxFontSize() float32 { return dtCBFontSize }
+
+// Compile-time checks.
+var (
+	_ checkbox.Painter       = CheckboxPainter{}
+	_ checkbox.LayoutMetrics = CheckboxPainter{}
+)

--- a/theme/devtools/chip.go
+++ b/theme/devtools/chip.go
@@ -55,5 +55,28 @@ var dtDefaultChipColors = chip.ChipColorScheme{
 	DisabledLabel:      widget.Hex(0x6F737A), // Gray7
 }
 
-// Compile-time check that ChipPainter implements chip.Painter.
-var _ chip.Painter = ChipPainter{}
+// ChipFontSize returns the DevTools chip font size.
+func (ChipPainter) ChipFontSize() float32 { return dtChipFontSize }
+
+// ChipMinWidth returns the DevTools minimum chip width.
+func (ChipPainter) ChipMinWidth() float32 { return dtChipMinWidth }
+
+// ChipPadding returns the DevTools chip horizontal padding.
+func (ChipPainter) ChipPadding() float32 { return dtChipPadding }
+
+// ChipRadius returns the DevTools chip corner radius.
+func (ChipPainter) ChipRadius() float32 { return dtChipRadius }
+
+// DevTools chip layout constants.
+const (
+	dtChipFontSize float32 = 13 // JetBrains Int UI body
+	dtChipMinWidth float32 = 32 // compact touch target
+	dtChipPadding  float32 = 8  // compact padding
+	dtChipRadius   float32 = 4  // JetBrains Int UI small radius
+)
+
+// Compile-time checks.
+var (
+	_ chip.Painter       = ChipPainter{}
+	_ chip.LayoutMetrics = ChipPainter{}
+)

--- a/theme/devtools/dialog.go
+++ b/theme/devtools/dialog.go
@@ -73,6 +73,15 @@ func (p DialogPainter) paintActions(canvas widget.Canvas, ps dialog.PaintState, 
 		return
 	}
 
+	// Use pre-computed ActionRects when available (ADR-034 Phase 4).
+	if len(ps.ActionRects) == len(ps.Actions) {
+		for i, action := range ps.Actions {
+			canvas.DrawText(action.Label, ps.ActionRects[i], dtDialogActionFontSize, colors.ActionFg, false, dtDialogTextAlignCenter)
+		}
+		return
+	}
+
+	// Legacy fallback.
 	x := ps.Bounds.Max.X - dtDialogPadding
 	y := ps.Bounds.Max.Y - dtDialogPadding - dtDialogActionHeight
 

--- a/theme/devtools/dialog.go
+++ b/theme/devtools/dialog.go
@@ -100,6 +100,7 @@ const (
 	dtDialogActionCharWidth float32 = 7
 	dtDialogActionPaddingX  float32 = 12
 	dtDialogActionSpacing   float32 = 8
+	dtDialogMaxWidth        float32 = 480
 	dtDialogTextAlignLeft           = widget.TextAlignLeft
 	dtDialogTextAlignCenter         = widget.TextAlignCenter
 )
@@ -116,5 +117,17 @@ var dtDefaultDialogColors = dialog.DialogColorScheme{
 	ActionBg: DefaultAccentColor,
 }
 
-// Compile-time check that DialogPainter implements Painter.
-var _ dialog.Painter = DialogPainter{}
+// DialogPadding returns the DevTools dialog padding.
+func (DialogPainter) DialogPadding() float32 { return dtDialogPadding }
+
+// DialogTitleHeight returns the DevTools dialog title height.
+func (DialogPainter) DialogTitleHeight() float32 { return dtDialogTitleHeight }
+
+// DialogMaxWidth returns the DevTools default maximum dialog width.
+func (DialogPainter) DialogMaxWidth() float32 { return dtDialogMaxWidth }
+
+// Compile-time checks.
+var (
+	_ dialog.Painter       = DialogPainter{}
+	_ dialog.LayoutMetrics = DialogPainter{}
+)

--- a/theme/devtools/linechart.go
+++ b/theme/devtools/linechart.go
@@ -31,7 +31,8 @@ func (p LineChartPainter) resolveColors() dtLineChartColors {
 }
 
 // PaintChart renders a line chart according to DevTools specifications.
-func (p LineChartPainter) PaintChart(canvas widget.Canvas, bounds geometry.Rect, state linechart.PaintState) {
+func (p LineChartPainter) PaintChart(canvas widget.Canvas, state linechart.PaintState) {
+	bounds := state.Bounds
 	if bounds.IsEmpty() {
 		return
 	}

--- a/theme/devtools/linechart.go
+++ b/theme/devtools/linechart.go
@@ -46,8 +46,11 @@ func (p LineChartPainter) PaintChart(canvas widget.Canvas, state linechart.Paint
 	}
 	canvas.DrawRect(bounds, bg)
 
-	// Compute the plot area (inset for labels if enabled).
-	plotArea := dtChartPlotArea(bounds, state.ShowLabels)
+	// Use pre-computed plot area (ADR-034 Phase 4).
+	plotArea := state.PlotArea
+	if plotArea.IsEmpty() {
+		plotArea = dtChartPlotArea(bounds, state.ShowLabels)
+	}
 	if plotArea.Width() <= 0 || plotArea.Height() <= 0 {
 		return
 	}
@@ -62,21 +65,68 @@ func (p LineChartPainter) PaintChart(canvas widget.Canvas, state linechart.Paint
 		if gridColor == (widget.Color{}) {
 			gridColor = colors.GridColor
 		}
-		dtChartDrawGrid(canvas, plotArea, gridColor)
+		if len(state.GridLines) > 0 {
+			dtChartDrawPrecomputedGrid(canvas, plotArea, state.GridLines, gridColor)
+		} else {
+			dtChartDrawGrid(canvas, plotArea, gridColor)
+		}
 	}
 
 	// Y-axis labels.
 	if state.ShowLabels {
-		dtChartDrawLabels(canvas, bounds, plotArea, state, colors.LabelColor)
+		if len(state.GridLines) > 0 {
+			dtChartDrawPrecomputedLabels(canvas, bounds, state.GridLines, colors.LabelColor)
+		} else {
+			dtChartDrawLabels(canvas, bounds, plotArea, state, colors.LabelColor)
+		}
 	}
 
 	// Data lines.
-	for _, series := range state.Series {
-		lineColor := series.Color
-		if lineColor == (widget.Color{}) {
-			lineColor = colors.LineColor
+	if len(state.SeriesLines) == len(state.Series) {
+		for i, series := range state.Series {
+			lineColor := series.Color
+			if lineColor == (widget.Color{}) {
+				lineColor = colors.LineColor
+			}
+			dtChartDrawPrecomputedSeries(canvas, state.SeriesLines[i], lineColor)
 		}
-		dtChartDrawSeries(canvas, plotArea, series, state, lineColor)
+	} else {
+		for _, series := range state.Series {
+			lineColor := series.Color
+			if lineColor == (widget.Color{}) {
+				lineColor = colors.LineColor
+			}
+			dtChartDrawSeries(canvas, plotArea, series, state, lineColor)
+		}
+	}
+}
+
+// dtChartDrawPrecomputedGrid draws grid lines at pre-computed Y positions.
+func dtChartDrawPrecomputedGrid(canvas widget.Canvas, plotArea geometry.Rect, gridLines []linechart.GridLine, color widget.Color) {
+	for _, gl := range gridLines {
+		from := geometry.Pt(plotArea.Min.X, gl.Y)
+		to := geometry.Pt(plotArea.Max.X, gl.Y)
+		canvas.DrawLine(from, to, color, dtChartGridLineWidth)
+	}
+}
+
+// dtChartDrawPrecomputedLabels draws labels at pre-computed grid line positions.
+func dtChartDrawPrecomputedLabels(canvas widget.Canvas, bounds geometry.Rect, gridLines []linechart.GridLine, color widget.Color) {
+	for _, gl := range gridLines {
+		labelBounds := geometry.NewRect(
+			bounds.Min.X,
+			gl.Y-dtChartLabelFontSize/2,
+			dtChartLabelAreaWidth-dtChartLabelPadding,
+			dtChartLabelFontSize,
+		)
+		canvas.DrawText(gl.Label, labelBounds, dtChartLabelFontSize, color, false, widget.TextAlignRight)
+	}
+}
+
+// dtChartDrawPrecomputedSeries draws connected line segments from pre-computed coordinates.
+func dtChartDrawPrecomputedSeries(canvas widget.Canvas, points []geometry.Point, color widget.Color) {
+	for i := 1; i < len(points); i++ {
+		canvas.DrawLine(points[i-1], points[i], color, dtChartLineWidth)
 	}
 }
 

--- a/theme/devtools/painters_enterprise_test.go
+++ b/theme/devtools/painters_enterprise_test.go
@@ -965,7 +965,7 @@ func TestLineChartPainterImplementsInterface(t *testing.T) {
 func TestLineChartPaintChartEmpty(t *testing.T) {
 	canvas := &recordCanvas{}
 	painter := devtools.LineChartPainter{}
-	painter.PaintChart(canvas, geometry.Rect{}, linechart.PaintState{})
+	painter.PaintChart(canvas, linechart.PaintState{})
 	if len(canvas.calls) != 0 {
 		t.Errorf("empty bounds should produce no calls, got %d", len(canvas.calls))
 	}
@@ -974,7 +974,8 @@ func TestLineChartPaintChartEmpty(t *testing.T) {
 func TestLineChartPaintChart(t *testing.T) {
 	canvas := &recordCanvas{}
 	painter := devtools.LineChartPainter{}
-	painter.PaintChart(canvas, geometry.NewRect(0, 0, 300, 200), linechart.PaintState{
+	painter.PaintChart(canvas, linechart.PaintState{
+		Bounds: geometry.NewRect(0, 0, 300, 200),
 		Series: []linechart.Series{
 			{
 				Color: widget.Hex(0x3574F0),
@@ -1006,7 +1007,8 @@ func TestLineChartPaintChart(t *testing.T) {
 func TestLineChartPaintChartNoData(t *testing.T) {
 	canvas := &recordCanvas{}
 	painter := devtools.LineChartPainter{}
-	painter.PaintChart(canvas, geometry.NewRect(0, 0, 300, 200), linechart.PaintState{
+	painter.PaintChart(canvas, linechart.PaintState{
+		Bounds:    geometry.NewRect(0, 0, 300, 200),
 		MaxPoints: 100,
 		YMin:      0,
 		YMax:      100,
@@ -1023,7 +1025,8 @@ func TestLineChartPainterWithTheme(t *testing.T) {
 	painter := devtools.LineChartPainter{Theme: theme}
 	canvas := &recordCanvas{}
 
-	painter.PaintChart(canvas, geometry.NewRect(0, 0, 300, 200), linechart.PaintState{
+	painter.PaintChart(canvas, linechart.PaintState{
+		Bounds:    geometry.NewRect(0, 0, 300, 200),
 		MaxPoints: 100,
 		YMin:      0,
 		YMax:      100,
@@ -1218,8 +1221,8 @@ func TestAllEnterprisePaintersWithLightTheme(t *testing.T) {
 			})
 		}},
 		{"LineChartPainter", func(c *recordCanvas) {
-			devtools.LineChartPainter{Theme: theme}.PaintChart(c, geometry.NewRect(0, 0, 300, 200), linechart.PaintState{
-				MaxPoints: 100, YMin: 0, YMax: 100, ShowGrid: true,
+			devtools.LineChartPainter{Theme: theme}.PaintChart(c, linechart.PaintState{
+				Bounds: geometry.NewRect(0, 0, 300, 200), MaxPoints: 100, YMin: 0, YMax: 100, ShowGrid: true,
 			})
 		}},
 		{"ListViewPainter", func(c *recordCanvas) {

--- a/theme/devtools/painters_test.go
+++ b/theme/devtools/painters_test.go
@@ -509,7 +509,7 @@ func TestTextFieldPainterImplementsInterface(t *testing.T) {
 func TestPaintTextField(t *testing.T) {
 	canvas := &recordCanvas{}
 	painter := devtools.TextFieldPainter{}
-	painter.PaintTextField(canvas, textfield.PaintState{
+	painter.PaintTextField(canvas, &textfield.PaintState{
 		Text:   "Hello",
 		Bounds: testBounds(),
 	})
@@ -528,7 +528,7 @@ func TestPaintTextField(t *testing.T) {
 func TestPaintTextFieldEmpty(t *testing.T) {
 	canvas := &recordCanvas{}
 	painter := devtools.TextFieldPainter{}
-	painter.PaintTextField(canvas, textfield.PaintState{Bounds: geometry.Rect{}})
+	painter.PaintTextField(canvas, &textfield.PaintState{Bounds: geometry.Rect{}})
 	if len(canvas.calls) != 0 {
 		t.Errorf("empty bounds should produce no calls, got %d", len(canvas.calls))
 	}
@@ -537,7 +537,7 @@ func TestPaintTextFieldEmpty(t *testing.T) {
 func TestPaintTextFieldPlaceholder(t *testing.T) {
 	canvas := &recordCanvas{}
 	painter := devtools.TextFieldPainter{}
-	painter.PaintTextField(canvas, textfield.PaintState{
+	painter.PaintTextField(canvas, &textfield.PaintState{
 		Text:        "",
 		Placeholder: "Enter value...",
 		Bounds:      testBounds(),
@@ -555,10 +555,16 @@ func TestPaintTextFieldPlaceholder(t *testing.T) {
 func TestPaintTextFieldFocused(t *testing.T) {
 	canvas := &recordCanvas{}
 	painter := devtools.TextFieldPainter{}
-	painter.PaintTextField(canvas, textfield.PaintState{
-		Text:    "Focus",
-		Bounds:  testBounds(),
-		Focused: true,
+	bounds := testBounds()
+	painter.PaintTextField(canvas, &textfield.PaintState{
+		Text:        "Focus",
+		DisplayText: "Focus",
+		Bounds:      bounds,
+		ContentRect: geometry.NewRect(bounds.Min.X+8, bounds.Min.Y+6, bounds.Width()-16, bounds.Height()-12),
+		Focused:     true,
+		ShowCursor:  true,
+		CursorRect:  geometry.NewRect(bounds.Min.X+8, bounds.Min.Y+6, 1, 18),
+		FontSize:    13,
 	})
 
 	// Should draw cursor line when focused.
@@ -571,7 +577,7 @@ func TestPaintTextFieldFocused(t *testing.T) {
 func TestPaintTextFieldError(t *testing.T) {
 	canvas := &recordCanvas{}
 	painter := devtools.TextFieldPainter{}
-	painter.PaintTextField(canvas, textfield.PaintState{
+	painter.PaintTextField(canvas, &textfield.PaintState{
 		Text:     "Bad",
 		Bounds:   testBounds(),
 		HasError: true,
@@ -596,7 +602,7 @@ func TestPaintTextFieldWithTheme(t *testing.T) {
 	painter := devtools.TextFieldPainter{Theme: theme}
 	canvas := &recordCanvas{}
 
-	painter.PaintTextField(canvas, textfield.PaintState{
+	painter.PaintTextField(canvas, &textfield.PaintState{
 		Text:   "Themed",
 		Bounds: testBounds(),
 	})
@@ -1153,7 +1159,7 @@ func TestPaintRadioDisabled(t *testing.T) {
 func TestPaintTextFieldPassword(t *testing.T) {
 	canvas := &recordCanvas{}
 	painter := devtools.TextFieldPainter{}
-	painter.PaintTextField(canvas, textfield.PaintState{
+	painter.PaintTextField(canvas, &textfield.PaintState{
 		Text:      "secret",
 		InputType: textfield.TypePassword,
 		Bounds:    testBounds(),
@@ -1172,12 +1178,19 @@ func TestPaintTextFieldPassword(t *testing.T) {
 func TestPaintTextFieldSelection(t *testing.T) {
 	canvas := &recordCanvas{}
 	painter := devtools.TextFieldPainter{}
-	painter.PaintTextField(canvas, textfield.PaintState{
-		Text:        "Hello World",
-		Bounds:      testBounds(),
-		Focused:     true,
-		SelectStart: 0,
-		SelectEnd:   5,
+	bounds := testBounds()
+	contentRect := geometry.NewRect(bounds.Min.X+8, bounds.Min.Y+6, bounds.Width()-16, bounds.Height()-12)
+	painter.PaintTextField(canvas, &textfield.PaintState{
+		Text:          "Hello World",
+		DisplayText:   "Hello World",
+		Bounds:        bounds,
+		ContentRect:   contentRect,
+		Focused:       true,
+		SelectStart:   0,
+		SelectEnd:     5,
+		ShowSelection: true,
+		SelectionRect: geometry.NewRect(contentRect.Min.X, contentRect.Min.Y, 30, contentRect.Height()),
+		FontSize:      13,
 	})
 
 	// Should draw selection rectangle.
@@ -1190,7 +1203,7 @@ func TestPaintTextFieldSelection(t *testing.T) {
 func TestPaintTextFieldDisabled(t *testing.T) {
 	canvas := &recordCanvas{}
 	painter := devtools.TextFieldPainter{}
-	painter.PaintTextField(canvas, textfield.PaintState{
+	painter.PaintTextField(canvas, &textfield.PaintState{
 		Text:     "Disabled",
 		Bounds:   testBounds(),
 		Disabled: true,
@@ -1204,7 +1217,7 @@ func TestPaintTextFieldDisabled(t *testing.T) {
 func TestPaintTextFieldDisabledPlaceholder(t *testing.T) {
 	canvas := &recordCanvas{}
 	painter := devtools.TextFieldPainter{}
-	painter.PaintTextField(canvas, textfield.PaintState{
+	painter.PaintTextField(canvas, &textfield.PaintState{
 		Text:        "",
 		Placeholder: "Disabled placeholder",
 		Bounds:      testBounds(),
@@ -1220,7 +1233,7 @@ func TestPaintTextFieldDisabledPlaceholder(t *testing.T) {
 func TestPaintTextFieldHovered(t *testing.T) {
 	canvas := &recordCanvas{}
 	painter := devtools.TextFieldPainter{}
-	painter.PaintTextField(canvas, textfield.PaintState{
+	painter.PaintTextField(canvas, &textfield.PaintState{
 		Text:    "Hovered",
 		Bounds:  testBounds(),
 		Hovered: true,
@@ -1371,7 +1384,7 @@ func TestAllPaintersWithLightTheme(t *testing.T) {
 			})
 		}},
 		{"TextFieldPainter", func(c *recordCanvas) {
-			devtools.TextFieldPainter{Theme: theme}.PaintTextField(c, textfield.PaintState{
+			devtools.TextFieldPainter{Theme: theme}.PaintTextField(c, &textfield.PaintState{
 				Text: "Light", Bounds: testBounds(),
 			})
 		}},

--- a/theme/devtools/radio.go
+++ b/theme/devtools/radio.go
@@ -138,7 +138,23 @@ const (
 	dtRadioTextAlignLeft                = widget.TextAlignLeft
 	dtRadioFocusRingOffset      float32 = 2
 	dtRadioFocusRingStrokeWidth float32 = 1
+	dtRadioItemPadding          float32 = 4
 )
 
-// Compile-time check that RadioPainter implements Painter.
-var _ radio.Painter = RadioPainter{}
+// RadioCircleRadius returns the DevTools outer circle radius.
+func (RadioPainter) RadioCircleRadius() float32 { return dtRadioOuterRadius }
+
+// RadioLabelGap returns the DevTools gap between circle and label.
+func (RadioPainter) RadioLabelGap() float32 { return dtRadioLabelGap }
+
+// RadioFontSize returns the DevTools label font size.
+func (RadioPainter) RadioFontSize() float32 { return dtRadioFontSize }
+
+// RadioItemPadding returns the DevTools radio item padding.
+func (RadioPainter) RadioItemPadding() float32 { return dtRadioItemPadding }
+
+// Compile-time checks.
+var (
+	_ radio.Painter       = RadioPainter{}
+	_ radio.LayoutMetrics = RadioPainter{}
+)

--- a/theme/devtools/slider.go
+++ b/theme/devtools/slider.go
@@ -198,5 +198,14 @@ const (
 	dtSliderMarkRadius           float32 = 2
 )
 
-// Compile-time check that SliderPainter implements Painter.
-var _ slider.Painter = SliderPainter{}
+// SliderThumbRadius returns the DevTools thumb radius.
+func (SliderPainter) SliderThumbRadius() float32 { return dtSliderThumbRadius }
+
+// SliderTrackHeight returns the DevTools track height.
+func (SliderPainter) SliderTrackHeight() float32 { return dtSliderTrackHeight }
+
+// Compile-time checks.
+var (
+	_ slider.Painter       = SliderPainter{}
+	_ slider.LayoutMetrics = SliderPainter{}
+)

--- a/theme/devtools/textfield.go
+++ b/theme/devtools/textfield.go
@@ -8,13 +8,31 @@ import (
 
 // TextFieldPainter renders text fields using DevTools design tokens.
 // DevTools text fields use a deep InputBackground (#1E1F22) with 4px radius,
-// subtle Gray5 border, and Blue6 border on focus — matching JetBrains IDE
+// subtle Gray5 border, and Blue6 border on focus -- matching JetBrains IDE
 // input field styling.
+//
+// TextFieldPainter implements [textfield.LayoutMetrics] to provide DevTools
+// spatial metrics (13px font, 8/6px padding, 1px cursor) used by the widget
+// to compute pre-computed PaintState fields.
 //
 // If Theme is nil, TextFieldPainter falls back to the default DevTools dark palette.
 type TextFieldPainter struct {
 	Theme *Theme // nil uses default DevTools dark fallback
 }
+
+// ContentPadding returns the DevTools horizontal and vertical padding.
+func (TextFieldPainter) ContentPadding() (float32, float32) {
+	return dtTFContentPaddingH, dtTFContentPaddingV
+}
+
+// TextFieldFontSize returns the DevTools font size.
+func (TextFieldPainter) TextFieldFontSize() float32 { return dtTFFontSize }
+
+// TextFieldCursorWidth returns the DevTools cursor width.
+func (TextFieldPainter) TextFieldCursorWidth() float32 { return dtTFCursorWidth }
+
+// TextFieldCornerRadius returns the DevTools corner radius.
+func (TextFieldPainter) TextFieldCornerRadius() float32 { return dtTFCornerRadius }
 
 // resolveColors returns the TextFieldColorScheme derived from the painter's Theme.
 func (p TextFieldPainter) resolveColors() textfield.TextFieldColorScheme {
@@ -38,21 +56,27 @@ func (p TextFieldPainter) resolveColors() textfield.TextFieldColorScheme {
 }
 
 // PaintTextField renders a text field according to DevTools design specifications.
-func (p TextFieldPainter) PaintTextField(canvas widget.Canvas, st textfield.PaintState) {
+// Cursor and selection positions come from pre-computed PaintState fields.
+func (p TextFieldPainter) PaintTextField(canvas widget.Canvas, st *textfield.PaintState) {
 	if st.Bounds.IsEmpty() {
 		return
 	}
 
 	colors := p.resolveColors()
+	fontSize := st.FontSize
+	if fontSize <= 0 {
+		fontSize = dtTFFontSize
+	}
+
 	dtPaintTFBackground(canvas, st, colors)
 	dtPaintTFBorder(canvas, st, colors)
-	dtPaintTFContent(canvas, st, colors)
-	dtPaintTFCursor(canvas, st, colors)
+	dtPaintTFContent(canvas, st, colors, fontSize)
+	dtPaintTFCursorFromState(canvas, st, colors)
 	dtPaintTFError(canvas, st, colors)
 }
 
 // dtPaintTFBackground draws the text field background.
-func dtPaintTFBackground(canvas widget.Canvas, st textfield.PaintState, colors textfield.TextFieldColorScheme) {
+func dtPaintTFBackground(canvas widget.Canvas, st *textfield.PaintState, colors textfield.TextFieldColorScheme) {
 	bg := colors.Background
 	if st.Disabled {
 		bg = colors.DisabledBg
@@ -61,7 +85,7 @@ func dtPaintTFBackground(canvas widget.Canvas, st textfield.PaintState, colors t
 }
 
 // dtPaintTFBorder draws the text field outline.
-func dtPaintTFBorder(canvas widget.Canvas, st textfield.PaintState, colors textfield.TextFieldColorScheme) {
+func dtPaintTFBorder(canvas widget.Canvas, st *textfield.PaintState, colors textfield.TextFieldColorScheme) {
 	borderColor := colors.Border
 	strokeWidth := dtTFBorderWidth
 
@@ -81,24 +105,17 @@ func dtPaintTFBorder(canvas widget.Canvas, st textfield.PaintState, colors textf
 	canvas.StrokeRoundRect(st.Bounds, borderColor, dtTFCornerRadius, strokeWidth)
 }
 
-// dtPaintTFContent draws the text or placeholder.
-func dtPaintTFContent(canvas widget.Canvas, st textfield.PaintState, colors textfield.TextFieldColorScheme) {
-	contentBounds := dtTFContentRect(st.Bounds)
-
-	canvas.PushClip(contentBounds)
+// dtPaintTFContent draws the text or placeholder using pre-computed fields.
+func dtPaintTFContent(canvas widget.Canvas, st *textfield.PaintState, colors textfield.TextFieldColorScheme, fontSize float32) {
+	canvas.PushClip(st.ContentRect)
 	defer canvas.PopClip()
 
-	displayText := st.Text
-	if st.InputType == textfield.TypePassword {
-		displayText = dtMaskText(len([]rune(st.Text)))
-	}
-
-	if displayText == "" && !st.Focused {
+	if st.DisplayText == "" && !st.Focused {
 		color := colors.Placeholder
 		if st.Disabled {
 			color = colors.DisabledFg
 		}
-		canvas.DrawText(st.Placeholder, contentBounds, dtTFFontSize, color, false, dtTFTextAlignLeft)
+		canvas.DrawText(st.Placeholder, st.ContentRect, fontSize, color, false, dtTFTextAlignLeft)
 		return
 	}
 
@@ -107,58 +124,27 @@ func dtPaintTFContent(canvas widget.Canvas, st textfield.PaintState, colors text
 		textColor = colors.DisabledFg
 	}
 
-	// Selection highlight.
-	if st.SelectStart != st.SelectEnd {
-		dtPaintTFSelection(canvas, contentBounds, st, colors)
+	// Selection highlight from pre-computed rect.
+	if st.ShowSelection {
+		canvas.DrawRect(st.SelectionRect, colors.SelectionBg)
 	}
 
-	canvas.DrawText(displayText, contentBounds, dtTFFontSize, textColor, false, dtTFTextAlignLeft)
+	canvas.DrawText(st.DisplayText, st.ContentRect, fontSize, textColor, false, dtTFTextAlignLeft)
 }
 
-// dtPaintTFSelection draws the selection highlight.
-func dtPaintTFSelection(canvas widget.Canvas, contentBounds geometry.Rect, st textfield.PaintState, colors textfield.TextFieldColorScheme) {
-	selStart := st.SelectStart
-	selEnd := st.SelectEnd
-	if selStart > selEnd {
-		selStart, selEnd = selEnd, selStart
-	}
-
-	charWidth := dtTFFontSize * dtTFCharWidthRatio
-	x1 := contentBounds.Min.X + float32(selStart)*charWidth
-	x2 := contentBounds.Min.X + float32(selEnd)*charWidth
-
-	if x2 > contentBounds.Max.X {
-		x2 = contentBounds.Max.X
-	}
-
-	selRect := geometry.Rect{
-		Min: geometry.Pt(x1, contentBounds.Min.Y),
-		Max: geometry.Pt(x2, contentBounds.Max.Y),
-	}
-	canvas.DrawRect(selRect, colors.SelectionBg)
-}
-
-// dtPaintTFCursor draws the blinking caret.
-func dtPaintTFCursor(canvas widget.Canvas, st textfield.PaintState, colors textfield.TextFieldColorScheme) {
-	if !st.Focused || st.Disabled || st.SelectStart != st.SelectEnd {
+// dtPaintTFCursorFromState draws the cursor using pre-computed CursorRect.
+func dtPaintTFCursorFromState(canvas widget.Canvas, st *textfield.PaintState, colors textfield.TextFieldColorScheme) {
+	if !st.ShowCursor {
 		return
 	}
 
-	content := dtTFContentRect(st.Bounds)
-	charWidth := dtTFFontSize * dtTFCharWidthRatio
-	cursorX := content.Min.X + float32(st.CursorPos)*charWidth
-
-	if cursorX > content.Max.X {
-		cursorX = content.Max.X
-	}
-
-	top := geometry.Pt(cursorX, content.Min.Y+dtTFCursorPadding)
-	bottom := geometry.Pt(cursorX, content.Max.Y-dtTFCursorPadding)
-	canvas.DrawLine(top, bottom, colors.CursorColor, dtTFCursorWidth)
+	top := geometry.Pt(st.CursorRect.Min.X, st.CursorRect.Min.Y)
+	bottom := geometry.Pt(st.CursorRect.Min.X, st.CursorRect.Max.Y)
+	canvas.DrawLine(top, bottom, colors.CursorColor, st.CursorRect.Width())
 }
 
 // dtPaintTFError draws the error message below the text field.
-func dtPaintTFError(canvas widget.Canvas, st textfield.PaintState, colors textfield.TextFieldColorScheme) {
+func dtPaintTFError(canvas widget.Canvas, st *textfield.PaintState, colors textfield.TextFieldColorScheme) {
 	if !st.HasError || st.ErrorMsg == "" {
 		return
 	}
@@ -168,23 +154,6 @@ func dtPaintTFError(canvas widget.Canvas, st textfield.PaintState, colors textfi
 		Max: geometry.Pt(st.Bounds.Max.X, st.Bounds.Max.Y+dtTFErrorTopGap+dtTFErrorFontSize+dtTFErrorBottomPad),
 	}
 	canvas.DrawText(st.ErrorMsg, errBounds, dtTFErrorFontSize, colors.ErrorText, false, dtTFTextAlignLeft)
-}
-
-// dtTFContentRect returns the inner content area for text.
-func dtTFContentRect(bounds geometry.Rect) geometry.Rect {
-	return geometry.Rect{
-		Min: geometry.Pt(bounds.Min.X+dtTFContentPaddingH, bounds.Min.Y+dtTFContentPaddingV),
-		Max: geometry.Pt(bounds.Max.X-dtTFContentPaddingH, bounds.Max.Y-dtTFContentPaddingV),
-	}
-}
-
-// dtMaskText returns a string of bullet characters.
-func dtMaskText(length int) string {
-	runes := make([]rune, length)
-	for i := range runes {
-		runes[i] = '\u2022'
-	}
-	return string(runes)
 }
 
 // dtDefaultTextFieldColors holds the default DevTools dark text field color scheme.
@@ -210,7 +179,6 @@ const (
 	dtTFContentPaddingH  float32 = 8
 	dtTFContentPaddingV  float32 = 6
 	dtTFFontSize         float32 = 13
-	dtTFCharWidthRatio   float32 = 0.55
 	dtTFTextAlignLeft            = widget.TextAlignLeft
 	dtTFCursorWidth      float32 = 1
 	dtTFCursorPadding    float32 = 2
@@ -219,5 +187,8 @@ const (
 	dtTFErrorBottomPad   float32 = 2
 )
 
-// Compile-time check that TextFieldPainter implements Painter.
-var _ textfield.Painter = TextFieldPainter{}
+// Compile-time checks.
+var (
+	_ textfield.Painter       = TextFieldPainter{}
+	_ textfield.LayoutMetrics = TextFieldPainter{}
+)

--- a/theme/devtools/titlebar.go
+++ b/theme/devtools/titlebar.go
@@ -35,8 +35,8 @@ func (p TitleBarPainter) resolveColors() dtTitleBarColors {
 	}
 }
 
-// DrawBackground renders the dark header background with a 1px bottom border.
-func (p TitleBarPainter) DrawBackground(canvas widget.Canvas, bounds geometry.Rect, _ titlebar.BackgroundState) {
+// PaintBackground renders the dark header background with a 1px bottom border.
+func (p TitleBarPainter) PaintBackground(canvas widget.Canvas, bounds geometry.Rect, _ titlebar.BackgroundState) {
 	if bounds.IsEmpty() {
 		return
 	}
@@ -55,8 +55,8 @@ func (p TitleBarPainter) DrawBackground(canvas widget.Canvas, bounds geometry.Re
 	canvas.DrawRect(borderRect, colors.BorderColor)
 }
 
-// DrawControlButton renders a window control button with Windows-style hover.
-func (p TitleBarPainter) DrawControlButton(canvas widget.Canvas, bounds geometry.Rect, control titlebar.ControlType, state titlebar.ControlState) {
+// PaintControlButton renders a window control button with Windows-style hover.
+func (p TitleBarPainter) PaintControlButton(canvas widget.Canvas, bounds geometry.Rect, control titlebar.ControlType, state titlebar.ControlState) {
 	if bounds.IsEmpty() {
 		return
 	}

--- a/theme/devtools/titlebar_test.go
+++ b/theme/devtools/titlebar_test.go
@@ -12,106 +12,106 @@ import (
 
 // --- TitleBarPainter Tests ---
 
-func TestTitleBarPainter_DrawBackground(t *testing.T) {
+func TestTitleBarPainter_PaintBackground(t *testing.T) {
 	p := TitleBarPainter{Theme: NewDarkTheme()}
 	canvas := &tbMockCanvas{}
 	bounds := geometry.NewRect(0, 0, 800, 40)
 
-	p.DrawBackground(canvas, bounds, titlebar.BackgroundState{Focused: true})
+	p.PaintBackground(canvas, bounds, titlebar.BackgroundState{Focused: true})
 
 	if len(canvas.drawRects) < 2 {
 		t.Error("should draw background + bottom border (at least 2 rects)")
 	}
 }
 
-func TestTitleBarPainter_DrawBackground_EmptyBounds(t *testing.T) {
+func TestTitleBarPainter_PaintBackground_EmptyBounds(t *testing.T) {
 	p := TitleBarPainter{Theme: NewDarkTheme()}
 	canvas := &tbMockCanvas{}
 
-	p.DrawBackground(canvas, geometry.Rect{}, titlebar.BackgroundState{})
+	p.PaintBackground(canvas, geometry.Rect{}, titlebar.BackgroundState{})
 
 	if len(canvas.drawRects) > 0 {
 		t.Error("should not draw with empty bounds")
 	}
 }
 
-func TestTitleBarPainter_DrawBackground_NilTheme(t *testing.T) {
+func TestTitleBarPainter_PaintBackground_NilTheme(t *testing.T) {
 	p := TitleBarPainter{Theme: nil}
 	canvas := &tbMockCanvas{}
 	bounds := geometry.NewRect(0, 0, 800, 40)
 
-	p.DrawBackground(canvas, bounds, titlebar.BackgroundState{})
+	p.PaintBackground(canvas, bounds, titlebar.BackgroundState{})
 
 	if len(canvas.drawRects) < 2 {
 		t.Error("nil theme should use default dark colors and draw background + border")
 	}
 }
 
-func TestTitleBarPainter_DrawControlButton_EmptyBounds(t *testing.T) {
+func TestTitleBarPainter_PaintControlButton_EmptyBounds(t *testing.T) {
 	p := TitleBarPainter{Theme: NewDarkTheme()}
 	canvas := &tbMockCanvas{}
 
-	p.DrawControlButton(canvas, geometry.Rect{}, titlebar.ControlClose, titlebar.ControlState{})
+	p.PaintControlButton(canvas, geometry.Rect{}, titlebar.ControlClose, titlebar.ControlState{})
 
 	if len(canvas.drawRects) > 0 || len(canvas.drawLines) > 0 {
 		t.Error("should not draw with empty bounds")
 	}
 }
 
-func TestTitleBarPainter_DrawControlButton_Minimize(t *testing.T) {
+func TestTitleBarPainter_PaintControlButton_Minimize(t *testing.T) {
 	p := TitleBarPainter{Theme: NewDarkTheme()}
 	canvas := &tbMockCanvas{}
 	bounds := geometry.NewRect(0, 0, 46, 40)
 
-	p.DrawControlButton(canvas, bounds, titlebar.ControlMinimize, titlebar.ControlState{})
+	p.PaintControlButton(canvas, bounds, titlebar.ControlMinimize, titlebar.ControlState{})
 
 	if len(canvas.drawLines) == 0 {
 		t.Error("minimize should draw a line")
 	}
 }
 
-func TestTitleBarPainter_DrawControlButton_Maximize(t *testing.T) {
+func TestTitleBarPainter_PaintControlButton_Maximize(t *testing.T) {
 	p := TitleBarPainter{Theme: NewDarkTheme()}
 	canvas := &tbMockCanvas{}
 	bounds := geometry.NewRect(0, 0, 46, 40)
 
-	p.DrawControlButton(canvas, bounds, titlebar.ControlMaximize, titlebar.ControlState{})
+	p.PaintControlButton(canvas, bounds, titlebar.ControlMaximize, titlebar.ControlState{})
 
 	if len(canvas.strokeRects) == 0 {
 		t.Error("maximize should draw a stroked rect")
 	}
 }
 
-func TestTitleBarPainter_DrawControlButton_Restore(t *testing.T) {
+func TestTitleBarPainter_PaintControlButton_Restore(t *testing.T) {
 	p := TitleBarPainter{Theme: NewDarkTheme()}
 	canvas := &tbMockCanvas{}
 	bounds := geometry.NewRect(0, 0, 46, 40)
 
-	p.DrawControlButton(canvas, bounds, titlebar.ControlRestore, titlebar.ControlState{})
+	p.PaintControlButton(canvas, bounds, titlebar.ControlRestore, titlebar.ControlState{})
 
 	if len(canvas.strokeRects) < 2 {
 		t.Errorf("restore should draw 2 stroked rects, got %d", len(canvas.strokeRects))
 	}
 }
 
-func TestTitleBarPainter_DrawControlButton_Close(t *testing.T) {
+func TestTitleBarPainter_PaintControlButton_Close(t *testing.T) {
 	p := TitleBarPainter{Theme: NewDarkTheme()}
 	canvas := &tbMockCanvas{}
 	bounds := geometry.NewRect(0, 0, 46, 40)
 
-	p.DrawControlButton(canvas, bounds, titlebar.ControlClose, titlebar.ControlState{})
+	p.PaintControlButton(canvas, bounds, titlebar.ControlClose, titlebar.ControlState{})
 
 	if len(canvas.drawLines) != 2 {
 		t.Errorf("close should draw 2 lines (X), got %d", len(canvas.drawLines))
 	}
 }
 
-func TestTitleBarPainter_DrawControlButton_CloseHover(t *testing.T) {
+func TestTitleBarPainter_PaintControlButton_CloseHover(t *testing.T) {
 	p := TitleBarPainter{Theme: NewDarkTheme()}
 	canvas := &tbMockCanvas{}
 	bounds := geometry.NewRect(0, 0, 46, 40)
 
-	p.DrawControlButton(canvas, bounds, titlebar.ControlClose, titlebar.ControlState{Hovered: true})
+	p.PaintControlButton(canvas, bounds, titlebar.ControlClose, titlebar.ControlState{Hovered: true})
 
 	// Should draw red background.
 	if len(canvas.drawRects) == 0 {
@@ -130,12 +130,12 @@ func TestTitleBarPainter_DrawControlButton_CloseHover(t *testing.T) {
 	}
 }
 
-func TestTitleBarPainter_DrawControlButton_ClosePressed(t *testing.T) {
+func TestTitleBarPainter_PaintControlButton_ClosePressed(t *testing.T) {
 	p := TitleBarPainter{Theme: NewDarkTheme()}
 	canvas := &tbMockCanvas{}
 	bounds := geometry.NewRect(0, 0, 46, 40)
 
-	p.DrawControlButton(canvas, bounds, titlebar.ControlClose, titlebar.ControlState{Pressed: true})
+	p.PaintControlButton(canvas, bounds, titlebar.ControlClose, titlebar.ControlState{Pressed: true})
 
 	// Should draw darker red background.
 	if len(canvas.drawRects) == 0 {
@@ -143,24 +143,24 @@ func TestTitleBarPainter_DrawControlButton_ClosePressed(t *testing.T) {
 	}
 }
 
-func TestTitleBarPainter_DrawControlButton_MinimizeHover(t *testing.T) {
+func TestTitleBarPainter_PaintControlButton_MinimizeHover(t *testing.T) {
 	p := TitleBarPainter{Theme: NewDarkTheme()}
 	canvas := &tbMockCanvas{}
 	bounds := geometry.NewRect(0, 0, 46, 40)
 
-	p.DrawControlButton(canvas, bounds, titlebar.ControlMinimize, titlebar.ControlState{Hovered: true})
+	p.PaintControlButton(canvas, bounds, titlebar.ControlMinimize, titlebar.ControlState{Hovered: true})
 
 	if len(canvas.drawRects) == 0 {
 		t.Error("minimize hover should draw hover background")
 	}
 }
 
-func TestTitleBarPainter_DrawControlButton_MaximizePressed(t *testing.T) {
+func TestTitleBarPainter_PaintControlButton_MaximizePressed(t *testing.T) {
 	p := TitleBarPainter{Theme: NewDarkTheme()}
 	canvas := &tbMockCanvas{}
 	bounds := geometry.NewRect(0, 0, 46, 40)
 
-	p.DrawControlButton(canvas, bounds, titlebar.ControlMaximize, titlebar.ControlState{Pressed: true})
+	p.PaintControlButton(canvas, bounds, titlebar.ControlMaximize, titlebar.ControlState{Pressed: true})
 
 	if len(canvas.drawRects) == 0 {
 		t.Error("maximize pressed should draw pressed background")
@@ -173,8 +173,8 @@ func TestTitleBarPainter_LightTheme(t *testing.T) {
 	bounds := geometry.NewRect(0, 0, 800, 40)
 
 	// Should not panic with light theme.
-	p.DrawBackground(canvas, bounds, titlebar.BackgroundState{Focused: true})
-	p.DrawControlButton(canvas, bounds, titlebar.ControlClose, titlebar.ControlState{})
+	p.PaintBackground(canvas, bounds, titlebar.BackgroundState{Focused: true})
+	p.PaintControlButton(canvas, bounds, titlebar.ControlClose, titlebar.ControlState{})
 
 	if len(canvas.drawRects) == 0 {
 		t.Error("light theme should draw background")

--- a/theme/fluent/button.go
+++ b/theme/fluent/button.go
@@ -195,5 +195,40 @@ const (
 	flDisabledAlpha        float32 = 0.38
 )
 
-// Compile-time check that ButtonPainter implements Painter.
-var _ button.Painter = ButtonPainter{}
+// ButtonHeight returns the Fluent height for the given button size.
+func (ButtonPainter) ButtonHeight(size button.Size) float32 {
+	switch size {
+	case button.Small:
+		return 28
+	case button.Large:
+		return 44
+	default:
+		return 36
+	}
+}
+
+// ButtonPadding returns the Fluent horizontal and vertical padding.
+func (ButtonPainter) ButtonPadding(size button.Size) (float32, float32) {
+	switch size {
+	case button.Small:
+		return 10, 5
+	case button.Large:
+		return 20, 10
+	default:
+		return 16, 8
+	}
+}
+
+// ButtonFontSize returns the Fluent font size for the given button size.
+func (ButtonPainter) ButtonFontSize(size button.Size) float32 {
+	return flButtonFontSize(size)
+}
+
+// ButtonRadius returns the Fluent default corner radius.
+func (ButtonPainter) ButtonRadius() float32 { return flButtonRadius }
+
+// Compile-time checks.
+var (
+	_ button.Painter       = ButtonPainter{}
+	_ button.LayoutMetrics = ButtonPainter{}
+)

--- a/theme/fluent/checkbox.go
+++ b/theme/fluent/checkbox.go
@@ -184,5 +184,17 @@ const (
 	flDashStrokeWidth float32 = 2
 )
 
-// Compile-time check that CheckboxPainter implements Painter.
-var _ checkbox.Painter = CheckboxPainter{}
+// CheckboxBoxSize returns the Fluent checkbox box size.
+func (CheckboxPainter) CheckboxBoxSize() float32 { return flCBBoxSize }
+
+// CheckboxLabelGap returns the Fluent gap between box and label.
+func (CheckboxPainter) CheckboxLabelGap() float32 { return flCBLabelGap }
+
+// CheckboxFontSize returns the Fluent label font size.
+func (CheckboxPainter) CheckboxFontSize() float32 { return flCBFontSize }
+
+// Compile-time checks.
+var (
+	_ checkbox.Painter       = CheckboxPainter{}
+	_ checkbox.LayoutMetrics = CheckboxPainter{}
+)

--- a/theme/fluent/chip.go
+++ b/theme/fluent/chip.go
@@ -55,10 +55,29 @@ var flDefaultChipColors = chip.ChipColorScheme{
 	DisabledLabel:      widget.RGBA(0.38, 0.38, 0.38, flChipDisabledAlpha), // OnSurfaceSecond @ 38%
 }
 
+// ChipFontSize returns the Fluent chip font size.
+func (ChipPainter) ChipFontSize() float32 { return flChipFontSize }
+
+// ChipMinWidth returns the Fluent minimum chip width.
+func (ChipPainter) ChipMinWidth() float32 { return flChipMinWidth }
+
+// ChipPadding returns the Fluent chip horizontal padding.
+func (ChipPainter) ChipPadding() float32 { return flChipPadding }
+
+// ChipRadius returns the Fluent chip corner radius.
+func (ChipPainter) ChipRadius() float32 { return flChipRadius }
+
 // Fluent chip constants.
 const (
 	flChipDisabledAlpha float32 = 0.38
+	flChipFontSize      float32 = 14 // Fluent body
+	flChipMinWidth      float32 = 44 // Fluent touch target
+	flChipPadding       float32 = 12 // Fluent horizontal padding
+	flChipRadius        float32 = 4  // Fluent control radius
 )
 
-// Compile-time check that ChipPainter implements chip.Painter.
-var _ chip.Painter = ChipPainter{}
+// Compile-time checks.
+var (
+	_ chip.Painter       = ChipPainter{}
+	_ chip.LayoutMetrics = ChipPainter{}
+)

--- a/theme/fluent/dialog.go
+++ b/theme/fluent/dialog.go
@@ -72,6 +72,15 @@ func (p DialogPainter) paintActions(canvas widget.Canvas, ps dialog.PaintState, 
 		return
 	}
 
+	// Use pre-computed ActionRects when available (ADR-034 Phase 4).
+	if len(ps.ActionRects) == len(ps.Actions) {
+		for i, action := range ps.Actions {
+			canvas.DrawText(action.Label, ps.ActionRects[i], flDialogActionFontSize, colors.ActionFg, false, flDialogTextAlignCenter)
+		}
+		return
+	}
+
+	// Legacy fallback.
 	x := ps.Bounds.Max.X - flDialogPadding
 	y := ps.Bounds.Max.Y - flDialogPadding - flDialogActionHeight
 

--- a/theme/fluent/dialog.go
+++ b/theme/fluent/dialog.go
@@ -99,6 +99,7 @@ const (
 	flDialogActionCharWidth float32 = 8
 	flDialogActionPaddingX  float32 = 12
 	flDialogActionSpacing   float32 = 8
+	flDialogMaxWidth        float32 = 560
 	flDialogTextAlignLeft           = widget.TextAlignLeft
 	flDialogTextAlignCenter         = widget.TextAlignCenter
 )
@@ -115,5 +116,17 @@ var flDefaultDialogColors = dialog.DialogColorScheme{
 	ActionBg: DefaultAccentColor,
 }
 
-// Compile-time check that DialogPainter implements Painter.
-var _ dialog.Painter = DialogPainter{}
+// DialogPadding returns the Fluent dialog padding.
+func (DialogPainter) DialogPadding() float32 { return flDialogPadding }
+
+// DialogTitleHeight returns the Fluent dialog title height.
+func (DialogPainter) DialogTitleHeight() float32 { return flDialogTitleHeight }
+
+// DialogMaxWidth returns the Fluent default maximum dialog width.
+func (DialogPainter) DialogMaxWidth() float32 { return flDialogMaxWidth }
+
+// Compile-time checks.
+var (
+	_ dialog.Painter       = DialogPainter{}
+	_ dialog.LayoutMetrics = DialogPainter{}
+)

--- a/theme/fluent/fluent_test.go
+++ b/theme/fluent/fluent_test.go
@@ -507,7 +507,7 @@ func TestTextFieldPainterImplementsInterface(t *testing.T) {
 func TestPaintTextField(t *testing.T) {
 	canvas := &recordCanvas{}
 	painter := fluent.TextFieldPainter{}
-	painter.PaintTextField(canvas, textfield.PaintState{
+	painter.PaintTextField(canvas, &textfield.PaintState{
 		Text:   "Hello",
 		Bounds: testBounds(),
 	})
@@ -526,7 +526,7 @@ func TestPaintTextField(t *testing.T) {
 func TestPaintTextFieldEmpty(t *testing.T) {
 	canvas := &recordCanvas{}
 	painter := fluent.TextFieldPainter{}
-	painter.PaintTextField(canvas, textfield.PaintState{Bounds: geometry.Rect{}})
+	painter.PaintTextField(canvas, &textfield.PaintState{Bounds: geometry.Rect{}})
 	if len(canvas.calls) != 0 {
 		t.Errorf("empty bounds should produce no calls, got %d", len(canvas.calls))
 	}

--- a/theme/fluent/radio.go
+++ b/theme/fluent/radio.go
@@ -133,7 +133,23 @@ const (
 	flRadioTextAlignLeft                = widget.TextAlignLeft
 	flRadioFocusRingOffset      float32 = 2
 	flRadioFocusRingStrokeWidth float32 = 2
+	flRadioItemPadding          float32 = 4
 )
 
-// Compile-time check that RadioPainter implements Painter.
-var _ radio.Painter = RadioPainter{}
+// RadioCircleRadius returns the Fluent outer circle radius.
+func (RadioPainter) RadioCircleRadius() float32 { return flRadioOuterRadius }
+
+// RadioLabelGap returns the Fluent gap between circle and label.
+func (RadioPainter) RadioLabelGap() float32 { return flRadioLabelGap }
+
+// RadioFontSize returns the Fluent label font size.
+func (RadioPainter) RadioFontSize() float32 { return flRadioFontSize }
+
+// RadioItemPadding returns the Fluent radio item padding.
+func (RadioPainter) RadioItemPadding() float32 { return flRadioItemPadding }
+
+// Compile-time checks.
+var (
+	_ radio.Painter       = RadioPainter{}
+	_ radio.LayoutMetrics = RadioPainter{}
+)

--- a/theme/fluent/slider.go
+++ b/theme/fluent/slider.go
@@ -199,5 +199,14 @@ const (
 	flSliderMarkRadius           float32 = 2
 )
 
-// Compile-time check that SliderPainter implements Painter.
-var _ slider.Painter = SliderPainter{}
+// SliderThumbRadius returns the Fluent thumb radius.
+func (SliderPainter) SliderThumbRadius() float32 { return flSliderThumbRadius }
+
+// SliderTrackHeight returns the Fluent track height.
+func (SliderPainter) SliderTrackHeight() float32 { return flSliderTrackHeight }
+
+// Compile-time checks.
+var (
+	_ slider.Painter       = SliderPainter{}
+	_ slider.LayoutMetrics = SliderPainter{}
+)

--- a/theme/fluent/textfield.go
+++ b/theme/fluent/textfield.go
@@ -10,10 +10,28 @@ import (
 // Fluent text fields feature a subtle bottom accent border on focus
 // and clean rectangular shape with small corner radius.
 //
+// TextFieldPainter implements [textfield.LayoutMetrics] to provide Fluent
+// spatial metrics (14px font, 12/8px padding, 1.5px cursor) used by the
+// widget to compute pre-computed PaintState fields.
+//
 // If Theme is nil, TextFieldPainter falls back to the default Fluent Blue palette.
 type TextFieldPainter struct {
 	Theme *Theme // nil uses default Fluent Blue fallback
 }
+
+// ContentPadding returns the Fluent horizontal and vertical padding.
+func (TextFieldPainter) ContentPadding() (float32, float32) {
+	return flTFContentPaddingH, flTFContentPaddingV
+}
+
+// TextFieldFontSize returns the Fluent font size.
+func (TextFieldPainter) TextFieldFontSize() float32 { return flTFFontSize }
+
+// TextFieldCursorWidth returns the Fluent cursor width.
+func (TextFieldPainter) TextFieldCursorWidth() float32 { return flTFCursorWidth }
+
+// TextFieldCornerRadius returns the Fluent corner radius.
+func (TextFieldPainter) TextFieldCornerRadius() float32 { return flTFCornerRadius }
 
 // resolveColors returns the TextFieldColorScheme derived from the painter's Theme.
 func (p TextFieldPainter) resolveColors() textfield.TextFieldColorScheme {
@@ -37,21 +55,27 @@ func (p TextFieldPainter) resolveColors() textfield.TextFieldColorScheme {
 }
 
 // PaintTextField renders a text field according to Fluent Design specifications.
-func (p TextFieldPainter) PaintTextField(canvas widget.Canvas, st textfield.PaintState) {
+// Cursor and selection positions come from pre-computed PaintState fields.
+func (p TextFieldPainter) PaintTextField(canvas widget.Canvas, st *textfield.PaintState) {
 	if st.Bounds.IsEmpty() {
 		return
 	}
 
 	colors := p.resolveColors()
+	fontSize := st.FontSize
+	if fontSize <= 0 {
+		fontSize = flTFFontSize
+	}
+
 	flPaintTFBackground(canvas, st, colors)
 	flPaintTFBorder(canvas, st, colors)
-	flPaintTFContent(canvas, st, colors)
-	flPaintTFCursor(canvas, st, colors)
+	flPaintTFContent(canvas, st, colors, fontSize)
+	flPaintTFCursorFromState(canvas, st, colors)
 	flPaintTFError(canvas, st, colors)
 }
 
 // flPaintTFBackground draws the text field background.
-func flPaintTFBackground(canvas widget.Canvas, st textfield.PaintState, colors textfield.TextFieldColorScheme) {
+func flPaintTFBackground(canvas widget.Canvas, st *textfield.PaintState, colors textfield.TextFieldColorScheme) {
 	bg := colors.Background
 	if st.Disabled {
 		bg = colors.DisabledBg
@@ -60,7 +84,7 @@ func flPaintTFBackground(canvas widget.Canvas, st textfield.PaintState, colors t
 }
 
 // flPaintTFBorder draws the text field outline.
-func flPaintTFBorder(canvas widget.Canvas, st textfield.PaintState, colors textfield.TextFieldColorScheme) {
+func flPaintTFBorder(canvas widget.Canvas, st *textfield.PaintState, colors textfield.TextFieldColorScheme) {
 	borderColor := colors.Border
 	strokeWidth := flTFBorderWidth
 
@@ -80,24 +104,17 @@ func flPaintTFBorder(canvas widget.Canvas, st textfield.PaintState, colors textf
 	canvas.StrokeRoundRect(st.Bounds, borderColor, flTFCornerRadius, strokeWidth)
 }
 
-// flPaintTFContent draws the text or placeholder.
-func flPaintTFContent(canvas widget.Canvas, st textfield.PaintState, colors textfield.TextFieldColorScheme) {
-	contentBounds := flTFContentRect(st.Bounds)
-
-	canvas.PushClip(contentBounds)
+// flPaintTFContent draws the text or placeholder using pre-computed fields.
+func flPaintTFContent(canvas widget.Canvas, st *textfield.PaintState, colors textfield.TextFieldColorScheme, fontSize float32) {
+	canvas.PushClip(st.ContentRect)
 	defer canvas.PopClip()
 
-	displayText := st.Text
-	if st.InputType == textfield.TypePassword {
-		displayText = flMaskText(len([]rune(st.Text)))
-	}
-
-	if displayText == "" && !st.Focused {
+	if st.DisplayText == "" && !st.Focused {
 		color := colors.Placeholder
 		if st.Disabled {
 			color = colors.DisabledFg
 		}
-		canvas.DrawText(st.Placeholder, contentBounds, flTFFontSize, color, false, flTFTextAlignLeft)
+		canvas.DrawText(st.Placeholder, st.ContentRect, fontSize, color, false, flTFTextAlignLeft)
 		return
 	}
 
@@ -106,58 +123,27 @@ func flPaintTFContent(canvas widget.Canvas, st textfield.PaintState, colors text
 		textColor = colors.DisabledFg
 	}
 
-	// Selection highlight.
-	if st.SelectStart != st.SelectEnd {
-		flPaintTFSelection(canvas, contentBounds, st, colors)
+	// Selection highlight from pre-computed rect.
+	if st.ShowSelection {
+		canvas.DrawRect(st.SelectionRect, colors.SelectionBg)
 	}
 
-	canvas.DrawText(displayText, contentBounds, flTFFontSize, textColor, false, flTFTextAlignLeft)
+	canvas.DrawText(st.DisplayText, st.ContentRect, fontSize, textColor, false, flTFTextAlignLeft)
 }
 
-// flPaintTFSelection draws the selection highlight.
-func flPaintTFSelection(canvas widget.Canvas, contentBounds geometry.Rect, st textfield.PaintState, colors textfield.TextFieldColorScheme) {
-	selStart := st.SelectStart
-	selEnd := st.SelectEnd
-	if selStart > selEnd {
-		selStart, selEnd = selEnd, selStart
-	}
-
-	charWidth := flTFFontSize * flTFCharWidthRatio
-	x1 := contentBounds.Min.X + float32(selStart)*charWidth
-	x2 := contentBounds.Min.X + float32(selEnd)*charWidth
-
-	if x2 > contentBounds.Max.X {
-		x2 = contentBounds.Max.X
-	}
-
-	selRect := geometry.Rect{
-		Min: geometry.Pt(x1, contentBounds.Min.Y),
-		Max: geometry.Pt(x2, contentBounds.Max.Y),
-	}
-	canvas.DrawRect(selRect, colors.SelectionBg)
-}
-
-// flPaintTFCursor draws the blinking caret.
-func flPaintTFCursor(canvas widget.Canvas, st textfield.PaintState, colors textfield.TextFieldColorScheme) {
-	if !st.Focused || st.Disabled || st.SelectStart != st.SelectEnd {
+// flPaintTFCursorFromState draws the cursor using pre-computed CursorRect.
+func flPaintTFCursorFromState(canvas widget.Canvas, st *textfield.PaintState, colors textfield.TextFieldColorScheme) {
+	if !st.ShowCursor {
 		return
 	}
 
-	content := flTFContentRect(st.Bounds)
-	charWidth := flTFFontSize * flTFCharWidthRatio
-	cursorX := content.Min.X + float32(st.CursorPos)*charWidth
-
-	if cursorX > content.Max.X {
-		cursorX = content.Max.X
-	}
-
-	top := geometry.Pt(cursorX, content.Min.Y+flTFCursorPadding)
-	bottom := geometry.Pt(cursorX, content.Max.Y-flTFCursorPadding)
-	canvas.DrawLine(top, bottom, colors.CursorColor, flTFCursorWidth)
+	top := geometry.Pt(st.CursorRect.Min.X, st.CursorRect.Min.Y)
+	bottom := geometry.Pt(st.CursorRect.Min.X, st.CursorRect.Max.Y)
+	canvas.DrawLine(top, bottom, colors.CursorColor, st.CursorRect.Width())
 }
 
 // flPaintTFError draws the error message below the text field.
-func flPaintTFError(canvas widget.Canvas, st textfield.PaintState, colors textfield.TextFieldColorScheme) {
+func flPaintTFError(canvas widget.Canvas, st *textfield.PaintState, colors textfield.TextFieldColorScheme) {
 	if !st.HasError || st.ErrorMsg == "" {
 		return
 	}
@@ -167,23 +153,6 @@ func flPaintTFError(canvas widget.Canvas, st textfield.PaintState, colors textfi
 		Max: geometry.Pt(st.Bounds.Max.X, st.Bounds.Max.Y+flTFErrorTopGap+flTFErrorFontSize+flTFErrorBottomPad),
 	}
 	canvas.DrawText(st.ErrorMsg, errBounds, flTFErrorFontSize, colors.ErrorText, false, flTFTextAlignLeft)
-}
-
-// flTFContentRect returns the inner content area for text.
-func flTFContentRect(bounds geometry.Rect) geometry.Rect {
-	return geometry.Rect{
-		Min: geometry.Pt(bounds.Min.X+flTFContentPaddingH, bounds.Min.Y+flTFContentPaddingV),
-		Max: geometry.Pt(bounds.Max.X-flTFContentPaddingH, bounds.Max.Y-flTFContentPaddingV),
-	}
-}
-
-// flMaskText returns a string of bullet characters.
-func flMaskText(length int) string {
-	runes := make([]rune, length)
-	for i := range runes {
-		runes[i] = '\u2022'
-	}
-	return string(runes)
 }
 
 // flDefaultTextFieldColors holds the default Fluent text field color scheme.
@@ -209,14 +178,15 @@ const (
 	flTFContentPaddingH  float32 = 12
 	flTFContentPaddingV  float32 = 8
 	flTFFontSize         float32 = 14
-	flTFCharWidthRatio   float32 = 0.55
 	flTFTextAlignLeft            = widget.TextAlignLeft
 	flTFCursorWidth      float32 = 1.5
-	flTFCursorPadding    float32 = 2
 	flTFErrorFontSize    float32 = 12
 	flTFErrorTopGap      float32 = 4
 	flTFErrorBottomPad   float32 = 4
 )
 
-// Compile-time check that TextFieldPainter implements Painter.
-var _ textfield.Painter = TextFieldPainter{}
+// Compile-time checks.
+var (
+	_ textfield.Painter       = TextFieldPainter{}
+	_ textfield.LayoutMetrics = TextFieldPainter{}
+)

--- a/theme/material3/button.go
+++ b/theme/material3/button.go
@@ -197,5 +197,40 @@ const (
 	m3PressedDarkenFactor  float32 = 0.15
 )
 
-// Compile-time check that ButtonPainter implements Painter.
-var _ button.Painter = ButtonPainter{}
+// ButtonHeight returns the M3 height for the given button size.
+func (ButtonPainter) ButtonHeight(size button.Size) float32 {
+	switch size {
+	case button.Small:
+		return 32
+	case button.Large:
+		return 48
+	default:
+		return 40
+	}
+}
+
+// ButtonPadding returns the M3 horizontal and vertical padding.
+func (ButtonPainter) ButtonPadding(size button.Size) (float32, float32) {
+	switch size {
+	case button.Small:
+		return 12, 6
+	case button.Large:
+		return 24, 12
+	default:
+		return 16, 8
+	}
+}
+
+// ButtonFontSize returns the M3 font size for the given button size.
+func (ButtonPainter) ButtonFontSize(size button.Size) float32 {
+	return m3FontSize(size)
+}
+
+// ButtonRadius returns the M3 default corner radius.
+func (ButtonPainter) ButtonRadius() float32 { return m3DefaultRadius }
+
+// Compile-time checks.
+var (
+	_ button.Painter       = ButtonPainter{}
+	_ button.LayoutMetrics = ButtonPainter{}
+)

--- a/theme/material3/checkbox.go
+++ b/theme/material3/checkbox.go
@@ -211,5 +211,17 @@ const (
 	m3DashStrokeWidth float32 = 2
 )
 
-// Compile-time check that CheckboxPainter implements Painter.
-var _ checkbox.Painter = CheckboxPainter{}
+// CheckboxBoxSize returns the M3 checkbox box size.
+func (CheckboxPainter) CheckboxBoxSize() float32 { return m3CheckboxBoxSize }
+
+// CheckboxLabelGap returns the M3 gap between box and label.
+func (CheckboxPainter) CheckboxLabelGap() float32 { return m3CheckboxLabelGap }
+
+// CheckboxFontSize returns the M3 label font size.
+func (CheckboxPainter) CheckboxFontSize() float32 { return m3CheckboxFontSize }
+
+// Compile-time checks.
+var (
+	_ checkbox.Painter       = CheckboxPainter{}
+	_ checkbox.LayoutMetrics = CheckboxPainter{}
+)

--- a/theme/material3/chip.go
+++ b/theme/material3/chip.go
@@ -57,11 +57,30 @@ var m3DefaultChipColors = chip.ChipColorScheme{
 	DisabledLabel:      widget.RGBA(0.12, 0.12, 0.13, m3ChipDisabledFgAlpha), // M3 on-surface @ 38%
 }
 
+// ChipFontSize returns the M3 chip font size.
+func (ChipPainter) ChipFontSize() float32 { return m3ChipFontSize }
+
+// ChipMinWidth returns the M3 minimum chip width.
+func (ChipPainter) ChipMinWidth() float32 { return m3ChipMinWidth }
+
+// ChipPadding returns the M3 chip horizontal padding.
+func (ChipPainter) ChipPadding() float32 { return m3ChipPadding }
+
+// ChipRadius returns the M3 chip corner radius.
+func (ChipPainter) ChipRadius() float32 { return m3ChipRadius }
+
 // M3 chip constants.
 const (
 	m3ChipDisabledBgAlpha float32 = 0.12 // M3 disabled background opacity
 	m3ChipDisabledFgAlpha float32 = 0.38 // M3 disabled foreground opacity
+	m3ChipFontSize        float32 = 14   // M3 label-large body
+	m3ChipMinWidth        float32 = 48   // M3 min touch target
+	m3ChipPadding         float32 = 12   // M3 horizontal padding
+	m3ChipRadius          float32 = 8    // M3 corner radius
 )
 
-// Compile-time check that ChipPainter implements chip.Painter.
-var _ chip.Painter = ChipPainter{}
+// Compile-time checks.
+var (
+	_ chip.Painter       = ChipPainter{}
+	_ chip.LayoutMetrics = ChipPainter{}
+)

--- a/theme/material3/dialog.go
+++ b/theme/material3/dialog.go
@@ -75,7 +75,15 @@ func (p DialogPainter) paintActions(canvas widget.Canvas, ps dialog.PaintState, 
 		return
 	}
 
-	// Layout actions from right to left.
+	// Use pre-computed ActionRects when available (ADR-034 Phase 4).
+	if len(ps.ActionRects) == len(ps.Actions) {
+		for i, action := range ps.Actions {
+			canvas.DrawText(action.Label, ps.ActionRects[i], m3DialogActionFontSize, colors.ActionFg, false, m3DialogTextAlignCenter)
+		}
+		return
+	}
+
+	// Legacy fallback.
 	x := ps.Bounds.Max.X - m3DialogPadding
 	y := ps.Bounds.Max.Y - m3DialogPadding - m3DialogActionHeight
 

--- a/theme/material3/dialog.go
+++ b/theme/material3/dialog.go
@@ -109,6 +109,7 @@ const (
 	m3DialogFocusRingOffset float32 = 2
 	m3DialogFocusRingStroke float32 = 2
 	m3DialogFocusRingAlpha  float32 = 0.7
+	m3DialogMaxWidth        float32 = 560
 )
 
 // m3DefaultDialogColors holds the default M3 purple color scheme for dialogs.
@@ -124,5 +125,17 @@ var m3DefaultDialogColors = dialog.DialogColorScheme{
 	ActionBg: widget.Hex(0x6750A4), // M3 primary
 }
 
-// Compile-time check that DialogPainter implements Painter.
-var _ dialog.Painter = DialogPainter{}
+// DialogPadding returns the M3 dialog padding.
+func (DialogPainter) DialogPadding() float32 { return m3DialogPadding }
+
+// DialogTitleHeight returns the M3 dialog title height.
+func (DialogPainter) DialogTitleHeight() float32 { return m3DialogTitleHeight }
+
+// DialogMaxWidth returns the M3 default maximum dialog width.
+func (DialogPainter) DialogMaxWidth() float32 { return m3DialogMaxWidth }
+
+// Compile-time checks.
+var (
+	_ dialog.Painter       = DialogPainter{}
+	_ dialog.LayoutMetrics = DialogPainter{}
+)

--- a/theme/material3/linechart.go
+++ b/theme/material3/linechart.go
@@ -45,8 +45,11 @@ func (p LineChartPainter) PaintChart(canvas widget.Canvas, state linechart.Paint
 	}
 	canvas.DrawRect(bounds, bg)
 
-	// Compute the plot area (inset for labels if enabled).
-	plotArea := m3ChartPlotArea(bounds, state.ShowLabels)
+	// Use pre-computed plot area (ADR-034 Phase 4).
+	plotArea := state.PlotArea
+	if plotArea.IsEmpty() {
+		plotArea = m3ChartPlotArea(bounds, state.ShowLabels)
+	}
 	if plotArea.Width() <= 0 || plotArea.Height() <= 0 {
 		return
 	}
@@ -61,21 +64,68 @@ func (p LineChartPainter) PaintChart(canvas widget.Canvas, state linechart.Paint
 		if gridColor == (widget.Color{}) {
 			gridColor = colors.GridColor
 		}
-		m3ChartDrawGrid(canvas, plotArea, gridColor)
+		if len(state.GridLines) > 0 {
+			m3ChartDrawPrecomputedGrid(canvas, plotArea, state.GridLines, gridColor)
+		} else {
+			m3ChartDrawGrid(canvas, plotArea, gridColor)
+		}
 	}
 
 	// Y-axis labels.
 	if state.ShowLabels {
-		m3ChartDrawLabels(canvas, bounds, plotArea, state, colors.LabelColor)
+		if len(state.GridLines) > 0 {
+			m3ChartDrawPrecomputedLabels(canvas, bounds, state.GridLines, colors.LabelColor)
+		} else {
+			m3ChartDrawLabels(canvas, bounds, plotArea, state, colors.LabelColor)
+		}
 	}
 
 	// Data lines.
-	for _, series := range state.Series {
-		lineColor := series.Color
-		if lineColor == (widget.Color{}) {
-			lineColor = colors.LineColor
+	if len(state.SeriesLines) == len(state.Series) {
+		for i, series := range state.Series {
+			lineColor := series.Color
+			if lineColor == (widget.Color{}) {
+				lineColor = colors.LineColor
+			}
+			m3ChartDrawPrecomputedSeries(canvas, state.SeriesLines[i], lineColor)
 		}
-		m3ChartDrawSeries(canvas, plotArea, series, state, lineColor)
+	} else {
+		for _, series := range state.Series {
+			lineColor := series.Color
+			if lineColor == (widget.Color{}) {
+				lineColor = colors.LineColor
+			}
+			m3ChartDrawSeries(canvas, plotArea, series, state, lineColor)
+		}
+	}
+}
+
+// m3ChartDrawPrecomputedGrid draws grid lines at pre-computed Y positions.
+func m3ChartDrawPrecomputedGrid(canvas widget.Canvas, plotArea geometry.Rect, gridLines []linechart.GridLine, color widget.Color) {
+	for _, gl := range gridLines {
+		from := geometry.Pt(plotArea.Min.X, gl.Y)
+		to := geometry.Pt(plotArea.Max.X, gl.Y)
+		canvas.DrawLine(from, to, color, m3ChartGridLineWidth)
+	}
+}
+
+// m3ChartDrawPrecomputedLabels draws labels at pre-computed grid line positions.
+func m3ChartDrawPrecomputedLabels(canvas widget.Canvas, bounds geometry.Rect, gridLines []linechart.GridLine, color widget.Color) {
+	for _, gl := range gridLines {
+		labelBounds := geometry.NewRect(
+			bounds.Min.X,
+			gl.Y-m3ChartLabelFontSize/2,
+			m3ChartLabelAreaWidth-m3ChartLabelPadding,
+			m3ChartLabelFontSize,
+		)
+		canvas.DrawText(gl.Label, labelBounds, m3ChartLabelFontSize, color, false, widget.TextAlignRight)
+	}
+}
+
+// m3ChartDrawPrecomputedSeries draws connected line segments from pre-computed coordinates.
+func m3ChartDrawPrecomputedSeries(canvas widget.Canvas, points []geometry.Point, color widget.Color) {
+	for i := 1; i < len(points); i++ {
+		canvas.DrawLine(points[i-1], points[i], color, m3ChartLineWidth)
 	}
 }
 

--- a/theme/material3/linechart.go
+++ b/theme/material3/linechart.go
@@ -30,7 +30,8 @@ func (p LineChartPainter) resolveColors() lineChartColors {
 }
 
 // PaintChart renders a line chart according to Material 3 specifications.
-func (p LineChartPainter) PaintChart(canvas widget.Canvas, bounds geometry.Rect, state linechart.PaintState) {
+func (p LineChartPainter) PaintChart(canvas widget.Canvas, state linechart.PaintState) {
+	bounds := state.Bounds
 	if bounds.IsEmpty() {
 		return
 	}

--- a/theme/material3/linechart_test.go
+++ b/theme/material3/linechart_test.go
@@ -18,7 +18,7 @@ func TestLineChartPainter_EmptyBounds(t *testing.T) {
 	p := LineChartPainter{}
 	canvas := &chartMockCanvas{}
 
-	p.PaintChart(canvas, geometry.Rect{}, linechart.PaintState{})
+	p.PaintChart(canvas, linechart.PaintState{})
 
 	if canvas.drawCount > 0 {
 		t.Error("should not draw anything with empty bounds")
@@ -37,7 +37,8 @@ func TestLineChartPainter_NilTheme_UsesDefaults(t *testing.T) {
 		ShowGrid:  true,
 	}
 
-	p.PaintChart(canvas, geometry.NewRect(0, 0, 200, 100), state)
+	state.Bounds = geometry.NewRect(0, 0, 200, 100)
+	p.PaintChart(canvas, state)
 
 	if canvas.drawCount == 0 {
 		t.Error("should draw with nil theme (default colors)")
@@ -56,7 +57,8 @@ func TestLineChartPainter_WithTheme(t *testing.T) {
 		YMax:      10,
 	}
 
-	p.PaintChart(canvas, geometry.NewRect(0, 0, 200, 100), state)
+	state.Bounds = geometry.NewRect(0, 0, 200, 100)
+	p.PaintChart(canvas, state)
 
 	if canvas.drawCount == 0 {
 		t.Error("should draw with theme")
@@ -74,7 +76,8 @@ func TestLineChartPainter_WithGrid(t *testing.T) {
 		YMax:      100,
 	}
 
-	p.PaintChart(canvas, geometry.NewRect(0, 0, 200, 100), state)
+	state.Bounds = geometry.NewRect(0, 0, 200, 100)
+	p.PaintChart(canvas, state)
 
 	// Grid draws m3ChartGridDivisions+1 lines.
 	if canvas.lineCount < m3ChartGridDivisions+1 {
@@ -93,7 +96,8 @@ func TestLineChartPainter_WithLabels(t *testing.T) {
 		YMax:       100,
 	}
 
-	p.PaintChart(canvas, geometry.NewRect(0, 0, 200, 100), state)
+	state.Bounds = geometry.NewRect(0, 0, 200, 100)
+	p.PaintChart(canvas, state)
 
 	if canvas.textCount < m3ChartGridDivisions+1 {
 		t.Errorf("labels should draw at least %d texts, got %d", m3ChartGridDivisions+1, canvas.textCount)
@@ -133,7 +137,8 @@ func TestLineChartPainter_NoSeries(t *testing.T) {
 	}
 
 	// Should not panic.
-	p.PaintChart(canvas, geometry.NewRect(0, 0, 200, 100), state)
+	state.Bounds = geometry.NewRect(0, 0, 200, 100)
+	p.PaintChart(canvas, state)
 }
 
 func TestLineChartPainter_SinglePoint(t *testing.T) {
@@ -148,7 +153,8 @@ func TestLineChartPainter_SinglePoint(t *testing.T) {
 	}
 
 	// Should not draw lines for single point.
-	p.PaintChart(canvas, geometry.NewRect(0, 0, 200, 100), state)
+	state.Bounds = geometry.NewRect(0, 0, 200, 100)
+	p.PaintChart(canvas, state)
 }
 
 // --- chartMockCanvas ---

--- a/theme/material3/progress.go
+++ b/theme/material3/progress.go
@@ -23,22 +23,15 @@ func (p ProgressPainter) PaintProgress(canvas widget.Canvas, ps progress.PaintSt
 		return
 	}
 
-	bounds := ps.Bounds
-	centerX := bounds.Min.X + bounds.Width()/2
-	centerY := bounds.Min.Y + bounds.Height()/2
-	center := geometry.Pt(centerX, centerY)
-
-	// Use the smaller of width/height for the radius, minus stroke width.
-	availDiameter := ps.Diameter
-	if bounds.Width() < availDiameter {
-		availDiameter = bounds.Width()
-	}
-	if bounds.Height() < availDiameter {
-		availDiameter = bounds.Height()
-	}
-	radius := (availDiameter - ps.StrokeWidth) / 2
+	// Use pre-computed geometry when available (ADR-034 Phase 4).
+	center := ps.Center
+	radius := ps.Radius
 	if radius <= 0 {
-		return
+		// Legacy fallback: compute from bounds (for direct PaintState construction).
+		center, radius = progress.ComputeCenterRadius(ps)
+		if radius <= 0 {
+			return
+		}
 	}
 
 	if ps.Indeterminate {
@@ -76,7 +69,7 @@ func (p ProgressPainter) paintDeterminate(canvas widget.Canvas, ps progress.Pain
 }
 
 // paintIndeterminate draws a variable-length rotating arc per M3 spec.
-// The arc grows from ~0° to ~270° then shrinks back on a 1.333s cycle
+// The arc grows from ~0 to ~270 degrees then shrinks back on a 1.333s cycle
 // while continuously rotating (Flutter progress_indicator.dart reference).
 func (p ProgressPainter) paintIndeterminate(canvas widget.Canvas, ps progress.PaintState, center geometry.Point, radius float32) {
 	trackColor, indicatorColor, _ := p.resolveProgressColors(ps)
@@ -84,20 +77,13 @@ func (p ProgressPainter) paintIndeterminate(canvas widget.Canvas, ps progress.Pa
 	// Draw track circle.
 	canvas.StrokeCircle(center, radius, trackColor, ps.StrokeWidth)
 
-	// Compute head/tail using eased sawtooth.
-	// Phase 0.0-0.5: head runs ahead (arc grows), phase 0.5-1.0: tail catches up (arc shrinks).
-	phase := ps.AnimationPhase
-	headValue := m3EaseInOut(math.Min(phase*2, 1.0))
-	tailValue := m3EaseInOut(math.Max((phase-0.5)*2, 0.0))
-
-	// Arc sweep from tail to head, scaled to 3/4 turn (270°).
-	arcSweep := (headValue - tailValue) * m3MaxArcSweep
-	if arcSweep < m3MinArcSweep {
-		arcSweep = m3MinArcSweep
+	// Use pre-computed arc angles (ADR-034 Phase 4).
+	arcStart := ps.ArcStartAngle
+	arcSweep := ps.ArcSweepAngle
+	if arcSweep == 0 {
+		// Legacy fallback: compute from AnimationPhase.
+		arcStart, arcSweep = progress.ComputeArcAngles(ps.AnimationPhase, ps.Rotation)
 	}
-
-	// Arc start = base rotation + tail offset.
-	arcStart := -math.Pi/2 + ps.Rotation + tailValue*m3MaxArcSweep
 
 	strokeArcWithCap(canvas, center, radius, arcStart, arcSweep, indicatorColor, ps.StrokeWidth, widget.LineCapRound)
 }
@@ -110,15 +96,6 @@ func strokeArcWithCap(canvas widget.Canvas, center geometry.Point, radius float3
 		return
 	}
 	canvas.StrokeArc(center, radius, startAngle, sweepAngle, color, strokeWidth)
-}
-
-// m3EaseInOut applies a cubic ease-in-out curve (approximation of Flutter's fastOutSlowIn).
-func m3EaseInOut(t float64) float64 {
-	if t < 0.5 {
-		return 4 * t * t * t
-	}
-	v := -2*t + 2
-	return 1 - v*v*v/2
 }
 
 // resolveProgressColors returns track, indicator, and label colors for the current state.
@@ -155,8 +132,6 @@ var (
 const (
 	m3ProgressFontSize  float32 = 12
 	m3ProgressTextAlign         = widget.TextAlignCenter
-	m3MaxArcSweep               = math.Pi * 1.5 // 270° maximum arc sweep
-	m3MinArcSweep               = 0.05          // minimum arc to prevent visual disappearance
 )
 
 // Compile-time check that ProgressPainter implements Painter.

--- a/theme/material3/progressbar.go
+++ b/theme/material3/progressbar.go
@@ -38,7 +38,7 @@ func (p ProgressBarPainter) PaintProgressBar(canvas widget.Canvas, ps progressba
 	}
 
 	// Determine the color scheme to use.
-	colors := ps.ProgressBarColorScheme
+	colors := ps.ColorScheme
 	if colors == (progressbar.ProgressBarColorScheme{}) {
 		colors = p.resolveColors()
 	}

--- a/theme/material3/progressbar_test.go
+++ b/theme/material3/progressbar_test.go
@@ -154,11 +154,11 @@ func TestProgressBarPainter_WithColorScheme(t *testing.T) {
 	}
 
 	ps := progressbar.PaintState{
-		Value:                  0.5,
-		Bounds:                 geometry.NewRect(0, 0, 200, 20),
-		BarHeight:              8,
-		Radius:                 4,
-		ProgressBarColorScheme: scheme,
+		Value:       0.5,
+		Bounds:      geometry.NewRect(0, 0, 200, 20),
+		BarHeight:   8,
+		Radius:      4,
+		ColorScheme: scheme,
 	}
 
 	p.PaintProgressBar(canvas, ps)

--- a/theme/material3/radio.go
+++ b/theme/material3/radio.go
@@ -156,7 +156,23 @@ const (
 	m3RadioFocusRingStrokeWidth float32 = 2
 	m3RadioHoverLightenFactor   float32 = 0.1
 	m3RadioPressedDarkenFactor  float32 = 0.15
+	m3RadioItemPadding          float32 = 4
 )
 
-// Compile-time check that RadioPainter implements Painter.
-var _ radio.Painter = RadioPainter{}
+// RadioCircleRadius returns the M3 outer circle radius.
+func (RadioPainter) RadioCircleRadius() float32 { return m3RadioOuterRadius }
+
+// RadioLabelGap returns the M3 gap between circle and label.
+func (RadioPainter) RadioLabelGap() float32 { return m3RadioLabelGap }
+
+// RadioFontSize returns the M3 label font size.
+func (RadioPainter) RadioFontSize() float32 { return m3RadioFontSize }
+
+// RadioItemPadding returns the M3 radio item padding.
+func (RadioPainter) RadioItemPadding() float32 { return m3RadioItemPadding }
+
+// Compile-time checks.
+var (
+	_ radio.Painter       = RadioPainter{}
+	_ radio.LayoutMetrics = RadioPainter{}
+)

--- a/theme/material3/slider.go
+++ b/theme/material3/slider.go
@@ -216,5 +216,14 @@ const (
 	m3SliderPressedDarkenFactor  float32 = 0.15
 )
 
-// Compile-time check that SliderPainter implements Painter.
-var _ slider.Painter = SliderPainter{}
+// SliderThumbRadius returns the M3 thumb radius.
+func (SliderPainter) SliderThumbRadius() float32 { return m3SliderThumbRadius }
+
+// SliderTrackHeight returns the M3 track height.
+func (SliderPainter) SliderTrackHeight() float32 { return m3SliderTrackHeight }
+
+// Compile-time checks.
+var (
+	_ slider.Painter       = SliderPainter{}
+	_ slider.LayoutMetrics = SliderPainter{}
+)

--- a/theme/material3/textfield.go
+++ b/theme/material3/textfield.go
@@ -9,10 +9,28 @@ import (
 // TextFieldPainter renders text fields using Material 3 design tokens.
 // It implements the outlined text field variant with theme-derived colors.
 //
+// TextFieldPainter implements [textfield.LayoutMetrics] to provide M3 spatial
+// metrics (16px font, 16/12px padding, 2px cursor) used by the widget to
+// compute pre-computed PaintState fields.
+//
 // If Theme is nil, TextFieldPainter falls back to the default M3 purple palette.
 type TextFieldPainter struct {
 	Theme *Theme // nil uses default M3 purple fallback
 }
+
+// ContentPadding returns the M3 horizontal and vertical padding.
+func (TextFieldPainter) ContentPadding() (float32, float32) {
+	return m3TFContentPaddingH, m3TFContentPaddingV
+}
+
+// TextFieldFontSize returns the M3 body font size.
+func (TextFieldPainter) TextFieldFontSize() float32 { return m3TFFontSize }
+
+// TextFieldCursorWidth returns the M3 cursor width.
+func (TextFieldPainter) TextFieldCursorWidth() float32 { return m3TFCursorWidth }
+
+// TextFieldCornerRadius returns the M3 corner radius.
+func (TextFieldPainter) TextFieldCornerRadius() float32 { return m3TFCornerRadius }
 
 // resolveColors returns the TextFieldColorScheme derived from the painter's Theme.
 // If Theme is nil, it returns the default M3 text field color scheme.
@@ -37,21 +55,27 @@ func (p TextFieldPainter) resolveColors() textfield.TextFieldColorScheme {
 }
 
 // PaintTextField renders a text field according to Material 3 specifications.
-func (p TextFieldPainter) PaintTextField(canvas widget.Canvas, st textfield.PaintState) {
+// Cursor and selection positions come from pre-computed PaintState fields.
+func (p TextFieldPainter) PaintTextField(canvas widget.Canvas, st *textfield.PaintState) {
 	if st.Bounds.IsEmpty() {
 		return
 	}
 
 	colors := p.resolveColors()
+	fontSize := st.FontSize
+	if fontSize <= 0 {
+		fontSize = m3TFFontSize
+	}
+
 	m3PaintTextFieldBg(canvas, st, colors)
 	m3PaintTextFieldBorder(canvas, st, colors)
-	m3PaintTextFieldContent(canvas, st, colors)
-	m3PaintTextFieldCursor(canvas, st, colors)
+	m3PaintTextFieldContent(canvas, st, colors, fontSize)
+	m3PaintTextFieldCursorFromState(canvas, st, colors)
 	m3PaintTextFieldError(canvas, st, colors)
 }
 
 // m3PaintTextFieldBg draws the text field background.
-func m3PaintTextFieldBg(canvas widget.Canvas, st textfield.PaintState, colors textfield.TextFieldColorScheme) {
+func m3PaintTextFieldBg(canvas widget.Canvas, st *textfield.PaintState, colors textfield.TextFieldColorScheme) {
 	bg := colors.Background
 	if st.Disabled {
 		bg = colors.DisabledBg
@@ -60,7 +84,7 @@ func m3PaintTextFieldBg(canvas widget.Canvas, st textfield.PaintState, colors te
 }
 
 // m3PaintTextFieldBorder draws the text field outline.
-func m3PaintTextFieldBorder(canvas widget.Canvas, st textfield.PaintState, colors textfield.TextFieldColorScheme) {
+func m3PaintTextFieldBorder(canvas widget.Canvas, st *textfield.PaintState, colors textfield.TextFieldColorScheme) {
 	borderColor := colors.Border
 	strokeWidth := m3TFBorderWidth
 
@@ -80,24 +104,17 @@ func m3PaintTextFieldBorder(canvas widget.Canvas, st textfield.PaintState, color
 	canvas.StrokeRoundRect(st.Bounds, borderColor, m3TFCornerRadius, strokeWidth)
 }
 
-// m3PaintTextFieldContent draws the text or placeholder.
-func m3PaintTextFieldContent(canvas widget.Canvas, st textfield.PaintState, colors textfield.TextFieldColorScheme) {
-	contentBounds := m3TFContentRect(st.Bounds)
-
-	canvas.PushClip(contentBounds)
+// m3PaintTextFieldContent draws the text or placeholder using pre-computed fields.
+func m3PaintTextFieldContent(canvas widget.Canvas, st *textfield.PaintState, colors textfield.TextFieldColorScheme, fontSize float32) {
+	canvas.PushClip(st.ContentRect)
 	defer canvas.PopClip()
 
-	displayText := st.Text
-	if st.InputType == textfield.TypePassword {
-		displayText = m3MaskText(len([]rune(st.Text)))
-	}
-
-	if displayText == "" && !st.Focused {
+	if st.DisplayText == "" && !st.Focused {
 		color := colors.Placeholder
 		if st.Disabled {
 			color = colors.DisabledFg
 		}
-		canvas.DrawText(st.Placeholder, contentBounds, m3TFFontSize, color, false, m3TFTextAlignLeft)
+		canvas.DrawText(st.Placeholder, st.ContentRect, fontSize, color, false, m3TFTextAlignLeft)
 		return
 	}
 
@@ -106,73 +123,27 @@ func m3PaintTextFieldContent(canvas widget.Canvas, st textfield.PaintState, colo
 		textColor = colors.DisabledFg
 	}
 
-	// Draw selection highlight.
-	if st.SelectStart != st.SelectEnd {
-		m3PaintTextFieldSelection(canvas, contentBounds, st, colors)
+	// Draw selection highlight from pre-computed rect.
+	if st.ShowSelection {
+		canvas.DrawRect(st.SelectionRect, colors.SelectionBg)
 	}
 
-	canvas.DrawText(displayText, contentBounds, m3TFFontSize, textColor, false, m3TFTextAlignLeft)
+	canvas.DrawText(st.DisplayText, st.ContentRect, fontSize, textColor, false, m3TFTextAlignLeft)
 }
 
-// m3PaintTextFieldSelection draws the selection highlight.
-func m3PaintTextFieldSelection(canvas widget.Canvas, contentBounds geometry.Rect, st textfield.PaintState, colors textfield.TextFieldColorScheme) {
-	selStart := st.SelectStart
-	selEnd := st.SelectEnd
-	if selStart > selEnd {
-		selStart, selEnd = selEnd, selStart
-	}
-
-	// Determine the display text for measurement.
-	displayText := st.Text
-	if st.InputType == textfield.TypePassword {
-		displayText = m3MaskText(len([]rune(st.Text)))
-	}
-	runes := []rune(displayText)
-
-	// Measure actual text width up to selection boundaries.
-	x1 := contentBounds.Min.X + canvas.MeasureText(string(runes[:selStart]), m3TFFontSize, false)
-	x2 := contentBounds.Min.X + canvas.MeasureText(string(runes[:selEnd]), m3TFFontSize, false)
-
-	if x2 > contentBounds.Max.X {
-		x2 = contentBounds.Max.X
-	}
-
-	selRect := geometry.Rect{
-		Min: geometry.Pt(x1, contentBounds.Min.Y),
-		Max: geometry.Pt(x2, contentBounds.Max.Y),
-	}
-	canvas.DrawRect(selRect, colors.SelectionBg)
-}
-
-// m3PaintTextFieldCursor draws the blinking caret.
-func m3PaintTextFieldCursor(canvas widget.Canvas, st textfield.PaintState, colors textfield.TextFieldColorScheme) {
-	if !st.Focused || st.Disabled || st.SelectStart != st.SelectEnd {
+// m3PaintTextFieldCursorFromState draws the cursor using pre-computed CursorRect.
+func m3PaintTextFieldCursorFromState(canvas widget.Canvas, st *textfield.PaintState, colors textfield.TextFieldColorScheme) {
+	if !st.ShowCursor {
 		return
 	}
 
-	content := m3TFContentRect(st.Bounds)
-
-	// Determine the display text for measurement.
-	displayText := st.Text
-	if st.InputType == textfield.TypePassword {
-		displayText = m3MaskText(len([]rune(st.Text)))
-	}
-
-	// Measure actual text width up to cursor position.
-	textBeforeCursor := string([]rune(displayText)[:st.CursorPos])
-	cursorX := content.Min.X + canvas.MeasureText(textBeforeCursor, m3TFFontSize, false)
-
-	if cursorX > content.Max.X {
-		cursorX = content.Max.X
-	}
-
-	top := geometry.Pt(cursorX, content.Min.Y+m3TFCursorPadding)
-	bottom := geometry.Pt(cursorX, content.Max.Y-m3TFCursorPadding)
-	canvas.DrawLine(top, bottom, colors.CursorColor, m3TFCursorWidth)
+	top := geometry.Pt(st.CursorRect.Min.X, st.CursorRect.Min.Y)
+	bottom := geometry.Pt(st.CursorRect.Min.X, st.CursorRect.Max.Y)
+	canvas.DrawLine(top, bottom, colors.CursorColor, st.CursorRect.Width())
 }
 
 // m3PaintTextFieldError draws the error message below the text field.
-func m3PaintTextFieldError(canvas widget.Canvas, st textfield.PaintState, colors textfield.TextFieldColorScheme) {
+func m3PaintTextFieldError(canvas widget.Canvas, st *textfield.PaintState, colors textfield.TextFieldColorScheme) {
 	if !st.HasError || st.ErrorMsg == "" {
 		return
 	}
@@ -182,23 +153,6 @@ func m3PaintTextFieldError(canvas widget.Canvas, st textfield.PaintState, colors
 		Max: geometry.Pt(st.Bounds.Max.X, st.Bounds.Max.Y+m3TFErrorTopGap+m3TFErrorFontSize+m3TFErrorBottomPadding),
 	}
 	canvas.DrawText(st.ErrorMsg, errBounds, m3TFErrorFontSize, colors.ErrorText, false, m3TFTextAlignLeft)
-}
-
-// m3TFContentRect returns the inner content area for text.
-func m3TFContentRect(bounds geometry.Rect) geometry.Rect {
-	return geometry.Rect{
-		Min: geometry.Pt(bounds.Min.X+m3TFContentPaddingH, bounds.Min.Y+m3TFContentPaddingV),
-		Max: geometry.Pt(bounds.Max.X-m3TFContentPaddingH, bounds.Max.Y-m3TFContentPaddingV),
-	}
-}
-
-// m3MaskText returns a string of bullet characters with the given length.
-func m3MaskText(length int) string {
-	runes := make([]rune, length)
-	for i := range runes {
-		runes[i] = '\u2022'
-	}
-	return string(runes)
 }
 
 // m3DefaultTextFieldColors holds the default M3 text field color scheme.
@@ -226,11 +180,13 @@ const (
 	m3TFFontSize           float32 = 16
 	m3TFTextAlignLeft              = widget.TextAlignLeft
 	m3TFCursorWidth        float32 = 2
-	m3TFCursorPadding      float32 = 2
 	m3TFErrorFontSize      float32 = 12
 	m3TFErrorTopGap        float32 = 4
 	m3TFErrorBottomPadding float32 = 4
 )
 
-// Compile-time check that TextFieldPainter implements Painter.
-var _ textfield.Painter = TextFieldPainter{}
+// Compile-time checks.
+var (
+	_ textfield.Painter       = TextFieldPainter{}
+	_ textfield.LayoutMetrics = TextFieldPainter{}
+)


### PR DESCRIPTION
## Summary

- ADR-034: Move ALL behavioral logic from painters to widgets (cursor, selection, text measurement, animation, data mapping)
- LayoutMetrics optional interface for 7 widgets — community themes control spatial metrics
- ThemeBundle interface for complete theme packaging
- Gallery: 8 themes (+ Fluent, Cupertino)
- Fixes #126 (DevTools cursor wrong position)

## What changed

| Phase | Scope | Files |
|-------|-------|-------|
| Phase 1 | TextField: cursor/selection → widget, 5 painters simplified | 13 |
| Phase 2 | LayoutMetrics: button, checkbox, radio, slider, chip, dialog (35 implementations) | 30 |
| Phase 3 | ThemeBundle, naming fixes (titlebar PaintX, linechart Bounds, progressbar ColorScheme) | 11 |
| Phase 4 | Dialog buttons, Progress arcs, LineChart data, Toolbar layout, cursor caretHeightOffset | 17 |
| Gallery | Fluent + Cupertino themes added | 1 |
| Docs | CHANGELOG, ARCHITECTURE | 2 |

## Breaking changes (v0.x)

- `textfield.PaintState` → pointer receiver (`*PaintState`), 8 new fields
- `titlebar.Painter`: `DrawBackground` → `PaintBackground`, `DrawControlButton` → `PaintControlButton`
- `linechart.Painter`: Bounds moved from method arg to PaintState
- `progressbar.PaintState`: `ProgressBarColorScheme` → `ColorScheme`

## Test plan

- [x] `go build ./...`
- [x] `go test ./... -count=1` (59 packages, 0 failures)
- [x] `golangci-lint run --timeout=5m` (0 issues)
- [x] Visual: gallery tested on all 8 themes
- [x] Visual: DevTools cursor position correct (#126)
- [x] 35 LayoutMetrics compile-time checks verified