### PR TITLE
docs: CHANGELOG v0.1.42, ROADMAP + README updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,16 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.1.42] — 2026-07-05
 
 ### Added
 
 - **Layout cache activation** (ADR-032 Phase 2b, [#160](https://github.com/gogpu/ui/pull/160), @TimLai666) — convert 32 parent→child Layout calls to `widget.LayoutChild` across 23 files, activating per-widget layout caching. Layout cost: O(total nodes) → O(affected subtree). Removes `MarkLayoutCleanRecursive` shim. Adds `InvalidateLayoutTree` for downward cache propagation on signal fires. `IsLayoutVerifying` sentinel for debug verifier (Flutter `debugCheckingIntrinsics` pattern).
 - **Animation tick before layout** (ADR-032 GAP-3) — `AnimationTicker` interface + `tickAnimationsInTree` walk before layout pass. Collapsible and Transition animations now tick BEFORE layout (Flutter `handleBeginFrame` → `handleDrawFrame` pattern). Layout is a pure function of constraints + widget state, required for RelayoutBoundary (Phase 5).
-
-### Fixed
-
-- **Collapsible animation glitch on Wayland** ([#152](https://github.com/gogpu/ui/issues/152)) — force final redraw after animation completes + full-window `wl_surface.damage_buffer` on root repaint. Confirmed by @porjo.
 
 ### Removed
 
@@ -23,6 +19,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **deps:** gg v0.50.1 → v0.50.2, gogpu v0.43.1 → v0.43.4, wgpu v0.30.8 → v0.30.9, goffi v0.5.5 → v0.5.6
+
+## [0.1.41] — 2026-07-01
+
+### Fixed
+
+- **Collapsible animation glitch on Wayland** ([#152](https://github.com/gogpu/ui/issues/152), [#157](https://github.com/gogpu/ui/pull/157)) — force final redraw after animation completes + full-window `wl_surface.damage_buffer` on root repaint. Confirmed by @porjo (Intel Iris Plus ICL GT2, Fedora 44, GNOME/Mutter).
+
+### Changed
+
+- **Event-driven rendering by default** (ADR-035) — removed `WithContinuousRender(false)` boilerplate from all examples. gogpu v0.43.0+ defaults to event-driven (winit 0.29 pattern).
+- **deps:** gg v0.49.2 → v0.50.1, gogpu v0.42.11 → v0.43.1, wgpu v0.30.7 → v0.30.8
 
 ## [0.1.40] — 2026-06-29
 

--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ func main() {
 
 | `compositor` | Layer Tree compositor: OffsetLayer, PictureLayer, ClipRectLayer, OpacityLayer — production render pipeline | 95%+ |
 
-**Total: ~198,000+ lines of code | 56+ packages | ~7,300+ tests | 97%+ average coverage**
+**Total: ~207,000+ lines of code | 56+ packages | ~7,500+ tests | 97%+ average coverage**
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,7 +1,7 @@
 # gogpu/ui Roadmap
 
-> **Version:** 0.1.30-dev
-> **Updated:** June 2026
+> **Version:** 0.1.42
+> **Updated:** July 2026
 > **Go Version:** 1.25+
 
 ---
@@ -10,7 +10,7 @@
 
 **gogpu/ui** is the first enterprise-grade GUI toolkit for Go — zero CGO, GPU-accelerated, signal-driven.
 
-Go has waited 17 years for a professional graphics ecosystem. We're building it: 1.1M+ LOC across the gogpu ecosystem, all platforms, native menus and dialogs, triple-backend WebGPU, shader compiler, and a complete GUI toolkit.
+Go has waited 17 years for a professional graphics ecosystem. We're building it: 1.14M+ LOC across the gogpu ecosystem, all platforms, native menus and dialogs, triple-backend WebGPU, shader compiler, and a complete GUI toolkit.
 
 **Target applications:**
 - **IDEs** — GoLand/VS Code class (docking, tabs, tree, toolbar, menus, code editor)
@@ -36,15 +36,14 @@ Go has waited 17 years for a professional graphics ecosystem. We're building it:
 | Metric | Value |
 |--------|-------|
 | Packages | 56+ |
-| Go Source Files | ~413 |
-| Test Files | ~202 |
-| Total LOC | ~198,000+ |
-| Test Functions | ~7,300+ |
+| Total LOC (scc) | ~207,000+ |
+| Test Functions | ~7,500+ |
 | Test Coverage | 97%+ |
 | Linter Issues | 0 |
-| Interactive Widgets | 22 |
+| Interactive Widgets | 24 |
 | Design Systems | 4 (M3, DevTools, Fluent, Cupertino) |
 | Painters | 61 (21 + 22 + 9 + 9) |
+| Layout Cache | Per-widget (ADR-032), O(affected subtree) |
 
 ---
 
@@ -141,6 +140,12 @@ Slider, Dialog, Animation engine (Tween, Spring, M3 motion), ScrollView, TabView
 | Custom font pipeline | FontRegistry, StyledTextDrawer |
 | PointerCapturer | ADR-031, widget-level mouse capture |
 | 34 integration tests | Multi-frame lifecycle, visibility matrix |
+| Badge widget | Notification badge (dot/count), signal bindings |
+| Chip widget | Action/filter chip (M3 spec), toggleable, two-way signal |
+| Layout cache (ADR-032) | Per-widget caching via LayoutChild, O(n)→O(subtree) |
+| Animation before layout (GAP-3) | Flutter BeginFrame pattern, layout = pure function |
+| Stripe widget | Alternating row backgrounds |
+| TitleBar widget | Window title bar widget |
 
 **Remaining Phase 4:**
 
@@ -164,8 +169,8 @@ Essential widgets for production applications.
 | **RichText** | Styled text with bold/italic/links, inline formatting | Medium | Content display, help text |
 | **NumberField** | Numeric input: spinner buttons, range, step | Low | Forms, settings |
 | **ToggleSwitch** | iOS/Material on/off switch with animation | Low | Settings, preferences |
-| **Badge** | Notification badge (dot or count) on any widget | Low | Navigation, status |
-| **Chip** | Filter/action chips (M3 spec) | Low | Tags, filters |
+| ~~**Badge**~~ | ~~Notification badge~~ | — | ✅ Done (v0.1.35) |
+| ~~**Chip**~~ | ~~Filter/action chips~~ | — | ✅ Done (v0.1.35) |
 | **SegmentedControl** | Toggle button group (iOS/Fluent style) | Medium | View switching |
 | **SearchField** | Text input with search icon, clear, suggestions | Medium | Data filtering |
 


### PR DESCRIPTION
## Summary

Release preparation for v0.1.42.

- **CHANGELOG:** add missing v0.1.41, v0.1.42 with layout cache (Phase 2b), animation before layout (GAP-3), Engine removal, deps
- **ROADMAP:** version 0.1.42, LOC 207K, 24 widgets, Badge/Chip marked done, layout cache + GAP-3 in completed features
- **README:** LOC 198K→207K, tests 7300→7500

## Test plan
- [x] `go build ./...`
- [x] `golangci-lint run --timeout=5m` (0 issues)
- [ ] CI green