### PR TITLE
fix: Wave 2 rendering correctness (#177, #178, #180)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.1.48] — 2026-07-18
 
+### Fixed
+
+- **Stale ghost rows on ListView scroll** ([#177](https://github.com/gogpu/ui/issues/177)) — damage ring accumulation reordered: current frame stored after iterating previous slots, preventing double-counting that reduced effective history depth during rapid scroll.
+- **ListView selection content styling** ([#178](https://github.com/gogpu/ui/issues/178)) — `rebuildAffected` now unmounts old decorators and mounts new ones via `MountTree`, so signal bindings activate and selection styling updates immediately.
+- **Example goroutine leak** ([#180](https://github.com/gogpu/ui/issues/180)) — `context.Context` cancellation added to modular-compositor module goroutines.
+
+### Tests
+
+- 3 damage ring regression tests (`desktop/damage_blit_test.go`)
+- 1 selection lifecycle test (`core/listview/lifecycle_test.go`)
+
 ### Changed
 
 - **deps:** gg v0.50.7 → v0.50.8, gogpu v0.44.9 → v0.44.11, wgpu v0.30.22 → v0.30.23, naga v0.17.15 → v0.17.16

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.1.48] — 2026-07-18
+## [0.1.48] — 2026-07-27
 
 ### Fixed
 

--- a/core/listview/cache.go
+++ b/core/listview/cache.go
@@ -28,7 +28,7 @@ type widgetCache struct {
 //
 // Hover changes do NOT trigger rebuilds — the decorator reads hover state
 // from list.hoveredIndex at Draw time (visual-only, no content change).
-func (wc *widgetCache) rebuildAffected(start int, content cdk.Content[ItemContext], selectedIndex int) {
+func (wc *widgetCache) rebuildAffected(start int, content cdk.Content[ItemContext], selectedIndex int, ctx widget.Context) {
 	affectedIndices := make(map[int]bool)
 	if wc.selectedIndex != selectedIndex {
 		affectedIndices[wc.selectedIndex] = true
@@ -40,13 +40,22 @@ func (wc *widgetCache) rebuildAffected(start int, content cdk.Content[ItemContex
 		if offset < 0 || offset >= len(wc.widgets) {
 			continue
 		}
+		// Unmount old decorator to release signal bindings and lifecycle (#178).
+		cleanupWidget(wc.widgets[offset])
+
 		w := content.Render(ItemContext{
 			Index:    idx,
 			Selected: idx == selectedIndex,
 			Focused:  idx == selectedIndex,
 		})
 		if w != nil {
-			wc.widgets[offset] = newItemDecorator(w, wc.list, idx)
+			dec := newItemDecorator(w, wc.list, idx)
+			// Mount new decorator so signal bindings activate and the dirty
+			// boundary callback can be wired during recordBoundary (#178).
+			if ctx != nil {
+				widget.MountTree(dec, ctx)
+			}
+			wc.widgets[offset] = dec
 		} else {
 			wc.widgets[offset] = nil
 		}
@@ -111,7 +120,7 @@ func (wc *widgetCache) update(start, end int, content cdk.Content[ItemContext], 
 	// Android RecyclerView pattern: notifyItemChanged(pos) rebinds single ViewHolder.
 	if wc.valid && wc.startIndex == start && wc.endIndex == end && content != nil {
 		if wc.selectedIndex != selectedIndex {
-			wc.rebuildAffected(start, content, selectedIndex)
+			wc.rebuildAffected(start, content, selectedIndex, ctx)
 			wc.selectedIndex = selectedIndex
 			return
 		}

--- a/core/listview/internal_test.go
+++ b/core/listview/internal_test.go
@@ -1330,7 +1330,7 @@ func TestSelectionChangeDirtiesOnlyTwoItems(t *testing.T) {
 	}
 
 	// Change selection from 3 to 5 — should only rebuild items 3 and 5.
-	wc.rebuildAffected(0, builder, 5)
+	wc.rebuildAffected(0, builder, 5, nil)
 
 	rebuiltCount := callCount - initialCount
 	if rebuiltCount != 2 {

--- a/core/listview/lifecycle_test.go
+++ b/core/listview/lifecycle_test.go
@@ -263,3 +263,75 @@ func TestLifecycle_FullRebuildUnmountsOld(t *testing.T) {
 		}
 	}
 }
+
+func TestLifecycle_SelectionChangeMountsNewDecorator(t *testing.T) {
+	// Verifies that changing selection unmounts the old decorator's content
+	// and mounts the new decorator's content (#178). Before the fix,
+	// rebuildAffected created new decorators without MountTree, leaving
+	// signal bindings inactive until an unrelated repaint.
+	var trackers []*lifecycleTracker
+	selectedSig := state.NewSignal(-1)
+	scrollY := state.NewSignal[float32](0)
+
+	lv := listview.New(
+		listview.ItemCount(10),
+		listview.FixedItemHeight(36),
+		listview.ScrollYSignal(scrollY),
+		listview.SelectedIndexSignal(selectedSig),
+		listview.BuildItem(func(_ listview.ItemContext) widget.Widget {
+			lt := &lifecycleTracker{}
+			trackers = append(trackers, lt)
+			return lt
+		}),
+	)
+
+	ctx := widget.NewContext()
+	// Viewport fits all 10 items (10 * 36 = 360).
+	layoutAndDraw(t, lv, ctx, geometry.Sz(300, 360))
+
+	initialCount := len(trackers)
+	if initialCount == 0 {
+		t.Fatal("no trackers created on first draw")
+	}
+
+	// Select item 3.
+	selectedSig.Set(3)
+	layoutAndDraw(t, lv, ctx, geometry.Sz(300, 360))
+
+	// rebuildAffected should create new trackers for affected items.
+	afterFirstSelect := len(trackers)
+	if afterFirstSelect <= initialCount {
+		t.Fatalf("expected new trackers after selection; had %d, now %d",
+			initialCount, afterFirstSelect)
+	}
+
+	// The newly created tracker (for item 3) should be mounted.
+	newTracker := trackers[initialCount]
+	if !newTracker.mounted {
+		t.Error("new tracker for selected item should be mounted after rebuildAffected")
+	}
+	if newTracker.mountCount != 1 {
+		t.Errorf("new tracker mountCount = %d, want 1", newTracker.mountCount)
+	}
+
+	// Now change selection from 3 to 7.
+	selectedSig.Set(7)
+	layoutAndDraw(t, lv, ctx, geometry.Sz(300, 360))
+
+	afterSecondSelect := len(trackers)
+	if afterSecondSelect <= afterFirstSelect {
+		t.Fatalf("expected new trackers after second selection; had %d, now %d",
+			afterFirstSelect, afterSecondSelect)
+	}
+
+	// The tracker for the deselected item (3) should be unmounted.
+	if newTracker.unmountCount == 0 {
+		t.Error("old tracker for deselected item 3 should be unmounted")
+	}
+
+	// The newly created tracker for item 7 should be mounted.
+	secondNewTracker := trackers[afterFirstSelect]
+	if !secondNewTracker.mounted {
+		t.Error("new tracker for selected item 7 should be mounted")
+	}
+}

--- a/desktop/damage_blit_test.go
+++ b/desktop/damage_blit_test.go
@@ -301,7 +301,7 @@ func TestAccumulatedDamageRects_RapidScroll_AllFramesCovered(t *testing.T) {
 	// Simulate 6 consecutive scroll frames with different damage positions.
 	// Each frame, a ListView row at a different Y position is dirty.
 	frames := []image.Rectangle{
-		image.Rect(0, 0, 400, 50),   // frame 1: row at Y=0
+		image.Rect(0, 0, 400, 50),    // frame 1: row at Y=0
 		image.Rect(0, 50, 400, 100),  // frame 2: row at Y=50
 		image.Rect(0, 100, 400, 150), // frame 3: row at Y=100
 		image.Rect(0, 150, 400, 200), // frame 4: row at Y=150

--- a/desktop/damage_blit_test.go
+++ b/desktop/damage_blit_test.go
@@ -289,6 +289,158 @@ func TestFullRender_FillsAllRingSlots(t *testing.T) {
 	}
 }
 
+// --- #177: Rapid scroll damage ring accumulation ---
+
+func TestAccumulatedDamageRects_RapidScroll_AllFramesCovered(t *testing.T) {
+	// Simulates rapid scroll where every frame has different damage rects.
+	// With a 4-slot ring (quad-buffered swapchain), ALL 4 previous frames'
+	// damage must be included in the accumulated result. Before the fix (#177),
+	// current frame was double-counted and the oldest frame was lost.
+	rl := &renderLoop{}
+
+	// Simulate 6 consecutive scroll frames with different damage positions.
+	// Each frame, a ListView row at a different Y position is dirty.
+	frames := []image.Rectangle{
+		image.Rect(0, 0, 400, 50),   // frame 1: row at Y=0
+		image.Rect(0, 50, 400, 100),  // frame 2: row at Y=50
+		image.Rect(0, 100, 400, 150), // frame 3: row at Y=100
+		image.Rect(0, 150, 400, 200), // frame 4: row at Y=150
+		image.Rect(0, 200, 400, 250), // frame 5: row at Y=200
+		image.Rect(0, 250, 400, 300), // frame 6: row at Y=250
+	}
+
+	// Process first 5 frames to fill the ring and advance past it.
+	for i := 0; i < 5; i++ {
+		rl.frameDamageRects = []image.Rectangle{frames[i]}
+		rl.accumulatedDamageRects()
+	}
+
+	// Frame 6: the result must include frames 3,4,5 (from ring) + frame 6 (current).
+	// The ring now holds frames [2,3,4,5] after 5 calls (oldest=2 was just overwritten
+	// by frame 5's store, but let's verify the actual behavior).
+	rl.frameDamageRects = []image.Rectangle{frames[5]}
+	got := rl.accumulatedDamageRects()
+
+	// Current frame (frame 6) must always be present.
+	hasFrame6 := false
+	for _, r := range got {
+		if r == frames[5] {
+			hasFrame6 = true
+			break
+		}
+	}
+	if !hasFrame6 {
+		t.Errorf("accumulated damage must contain current frame %v, got %v", frames[5], got)
+	}
+
+	// The union of all accumulated rects must cover the full damage area.
+	// With quad-buffering, buffer was last presented 4 frames ago, so we need
+	// at least 4 frames of damage (current + 3 from ring).
+	var union image.Rectangle
+	for _, r := range got {
+		union = union.Union(r)
+	}
+	// After 6 frames, the ring holds [frame3, frame4, frame5, frame6-stored-next-call].
+	// At query time for frame 6, ring has [frame2, frame3, frame4, frame5].
+	// So union should span at least from Y=50 (frame2) to Y=300 (frame6).
+	if union.Min.Y > 50 {
+		t.Errorf("damage union.Min.Y = %d, should be ≤50 (must cover 4 previous frames)", union.Min.Y)
+	}
+	if union.Max.Y < 300 {
+		t.Errorf("damage union.Max.Y = %d, should be ≥300 (must cover current frame)", union.Max.Y)
+	}
+}
+
+func TestAccumulatedDamageRects_NoDuplicateCurrentFrame(t *testing.T) {
+	// Verifies that current frame rects are NOT double-counted (#177).
+	// Before the fix, current frame was stored in ring BEFORE iterating,
+	// causing it to appear twice in the result.
+	rl := &renderLoop{}
+
+	// Single rect, empty ring → should appear exactly once.
+	rect := image.Rect(100, 100, 200, 200)
+	rl.frameDamageRects = []image.Rectangle{rect}
+	got := rl.accumulatedDamageRects()
+
+	count := 0
+	for _, r := range got {
+		if r == rect {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("current frame rect should appear exactly once, appeared %d times in %v", count, got)
+	}
+}
+
+func TestAccumulatedDamageRects_RingPreservesHistory(t *testing.T) {
+	// Verifies the ring buffer correctly preserves N-1 previous frames (N=4).
+	// After N calls, the oldest frame should still be in the ring.
+	rl := &renderLoop{}
+
+	// 4 distinct frames filling all ring slots.
+	frame1 := image.Rect(0, 0, 10, 10)
+	frame2 := image.Rect(20, 20, 30, 30)
+	frame3 := image.Rect(40, 40, 50, 50)
+	frame4 := image.Rect(60, 60, 70, 70)
+
+	rl.frameDamageRects = []image.Rectangle{frame1}
+	rl.accumulatedDamageRects()
+	rl.frameDamageRects = []image.Rectangle{frame2}
+	rl.accumulatedDamageRects()
+	rl.frameDamageRects = []image.Rectangle{frame3}
+	rl.accumulatedDamageRects()
+
+	// Frame 4: ring should still contain frames 1, 2, 3.
+	rl.frameDamageRects = []image.Rectangle{frame4}
+	got := rl.accumulatedDamageRects()
+
+	has := func(target image.Rectangle) bool {
+		for _, r := range got {
+			if r == target {
+				return true
+			}
+		}
+		return false
+	}
+
+	if !has(frame1) {
+		t.Errorf("ring should preserve frame1 %v (3 frames ago), got %v", frame1, got)
+	}
+	if !has(frame2) {
+		t.Errorf("ring should preserve frame2 %v (2 frames ago), got %v", frame2, got)
+	}
+	if !has(frame3) {
+		t.Errorf("ring should preserve frame3 %v (1 frame ago), got %v", frame3, got)
+	}
+	if !has(frame4) {
+		t.Errorf("ring should contain current frame4 %v, got %v", frame4, got)
+	}
+
+	// Frame 5: should push frame1 out of the ring (only 4 slots).
+	frame5 := image.Rect(80, 80, 90, 90)
+	rl.frameDamageRects = []image.Rectangle{frame5}
+	got = rl.accumulatedDamageRects()
+
+	// After 5 stores into a 4-slot ring, frame1 (slot 0) was overwritten by
+	// frame5's store. It should no longer be in the accumulated result.
+	// (Not asserting absence because has() scans got which only contains
+	// ring contents at frame5 query time — frame1 is gone by then.)
+	if !has(frame5) {
+		t.Errorf("ring should contain current frame5 %v, got %v", frame5, got)
+	}
+	// Must still have frames 2, 3, 4 (slots 1, 2, 3).
+	if !has(frame2) {
+		t.Errorf("ring should preserve frame2 %v after frame5, got %v", frame2, got)
+	}
+	if !has(frame3) {
+		t.Errorf("ring should preserve frame3 %v after frame5, got %v", frame3, got)
+	}
+	if !has(frame4) {
+		t.Errorf("ring should preserve frame4 %v after frame5, got %v", frame4, got)
+	}
+}
+
 // --- #116: Orphaned boundary texture GC ---
 
 func TestGCOrphanedTextures_DeletesOrphaned(t *testing.T) {

--- a/desktop/desktop.go
+++ b/desktop/desktop.go
@@ -505,16 +505,22 @@ func (rl *renderLoop) accumulatedDamageRects() []image.Rectangle {
 	rects := make([]image.Rectangle, 0, len(rl.frameDamageRects)+8)
 	rects = append(rects, rl.frameDamageRects...)
 
+	// Accumulate with PREVIOUS frames' damage BEFORE storing current.
+	// The ring holds damage from the last N-1 frames (N = ring size).
+	// With a quad-buffered swapchain, the buffer being presented was last used
+	// 4 frames ago — we need damage from frames [N-3, N-2, N-1, current].
+	// Iterating the ring BEFORE storing current ensures it contains only
+	// previous frames, avoiding double-counting current frame rects (#177).
+	for _, prev := range rl.damageRingRects {
+		rects = append(rects, prev...)
+	}
+
 	// Store current frame rects in ring buffer (copy to avoid aliasing).
+	// This overwrites the oldest slot for the NEXT frame's accumulation.
 	stored := make([]image.Rectangle, len(rl.frameDamageRects))
 	copy(stored, rl.frameDamageRects)
 	rl.damageRingRects[rl.damageRingIdx] = stored
 	rl.damageRingIdx = (rl.damageRingIdx + 1) % len(rl.damageRingRects)
-
-	// Accumulate with previous frames' damage.
-	for _, prev := range rl.damageRingRects {
-		rects = append(rects, prev...)
-	}
 
 	// ADR-030 threshold: merge to single union when too many rects.
 	// GPU scissor state changes are cheap but not free. Enterprise

--- a/examples/modular-compositor/main.go
+++ b/examples/modular-compositor/main.go
@@ -24,6 +24,7 @@
 package main
 
 import (
+	"context"
 	"image"
 	"log"
 	"sync"
@@ -57,13 +58,16 @@ func main() {
 	var mu sync.Mutex
 	latest := make(map[string]Frame)
 
+	// Context for graceful shutdown of module goroutines (#180).
+	ctx, cancel := context.WithCancel(context.Background())
+
 	app := gogpu.NewApp(gogpu.DefaultConfig().
 		WithTitle("gogpu/ui — Modular Compositor").
 		WithSize(windowW, windowH))
 
-	// Start module goroutines.
-	go clockModule(frames)
-	go notificationModule(frames)
+	// Start module goroutines with cancellation context.
+	go clockModule(ctx, frames)
+	go notificationModule(ctx, frames)
 
 	// Drain frames into latest map and request redraw.
 	go func() {
@@ -128,6 +132,11 @@ func main() {
 	})
 
 	app.OnClose(func() {
+		// Signal module goroutines to stop, then close the frames channel
+		// so the drain goroutine exits cleanly (#180).
+		cancel()
+		close(frames)
+
 		gg.CloseAccelerator()
 		if canvas != nil {
 			_ = canvas.Close()
@@ -145,7 +154,8 @@ func main() {
 
 // clockModule renders the current time at 1 Hz and sends frames to the
 // compositor. Uses offscreen.NewRenderer to render ui widgets without a window.
-func clockModule(out chan<- Frame) {
+// Exits cleanly when ctx is canceled.
+func clockModule(ctx context.Context, out chan<- Frame) {
 	const (
 		modW = 280
 		modH = 60
@@ -171,14 +181,22 @@ func clockModule(out chan<- Frame) {
 
 		r.Render(label)
 
-		out <- Frame{
+		select {
+		case <-ctx.Done():
+			return
+		case out <- Frame{
 			ModuleID: "clock",
 			Image:    r.Image(),
 			X:        160, // centered horizontally: (600-280)/2
 			Y:        20,
+		}:
 		}
 
-		<-ticker.C
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+		}
 	}
 }
 
@@ -188,7 +206,8 @@ func clockModule(out chan<- Frame) {
 
 // notificationModule renders a notification card that slides in from the bottom
 // every 5 seconds and sends frames at 60 Hz during the animation.
-func notificationModule(out chan<- Frame) {
+// Exits cleanly when ctx is canceled.
+func notificationModule(ctx context.Context, out chan<- Frame) {
 	const (
 		modW     = 300
 		modH     = 80
@@ -240,35 +259,60 @@ func notificationModule(out chan<- Frame) {
 			ease := 1.0 - inv*inv*inv
 			y := int(float64(targetY+modH) - ease*float64(modH))
 
-			out <- Frame{
+			select {
+			case <-ctx.Done():
+				return
+			case out <- Frame{
 				ModuleID: notificationModule,
 				Image:    img,
 				X:        150, // centered: (600-300)/2
 				Y:        y,
+			}:
 			}
-			time.Sleep(16 * time.Millisecond) // ~60 Hz
+
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(16 * time.Millisecond): // ~60 Hz
+			}
 		}
 
 		// Hold at final position.
-		out <- Frame{
+		select {
+		case <-ctx.Done():
+			return
+		case out <- Frame{
 			ModuleID: notificationModule,
 			Image:    img,
 			X:        150,
 			Y:        targetY,
+		}:
 		}
 
 		// Display for a few seconds, then clear.
-		time.Sleep(displayS * time.Second)
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(displayS * time.Second):
+		}
 
-		out <- Frame{
+		select {
+		case <-ctx.Done():
+			return
+		case out <- Frame{
 			ModuleID: notificationModule,
 			Image:    nil, // hide
 			X:        150,
 			Y:        targetY,
+		}:
 		}
 
 		// Pause before next notification.
-		time.Sleep(2 * time.Second)
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(2 * time.Second):
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

Three rendering correctness fixes from TASK-UI-LIFECYCLE-001 Wave 2.

### Fixed

- **Stale ghost rows on ListView scroll** (#177) — damage ring accumulation reordered: current frame stored AFTER iterating previous slots, preventing double-counting that reduced effective history depth during rapid scroll.
- **ListView selection content styling** (#178) — `rebuildAffected` now unmounts old decorators and mounts new ones via `MountTree`, so signal bindings activate and selection styling updates immediately.
- **Example goroutine leak** (#180) — `context.Context` cancellation added to modular-compositor module goroutines. `OnClose` calls `cancel()` for clean shutdown.

### Tests

- 3 new damage ring regression tests (`desktop/damage_blit_test.go`)
- 1 new selection lifecycle test (`core/listview/lifecycle_test.go`)

## Test plan

- [x] `go build ./...` — pass
- [x] `go test ./... -count=1` — 59 packages, 0 failures
- [x] `golangci-lint run --timeout=5m` — 0 issues