### PR TITLE
feat: Viewport3D widget, OS file DnD bridge, Wave 2 fixes (#150, #177, #178, #180, #189)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.1.48] — 2026-07-27
 
+### Added
+
+- **Viewport3D widget** ([#150](https://github.com/gogpu/ui/issues/150)) — GPU viewport for 3D content, video, or custom shader output. Flutter Texture widget pattern: widget owns offscreen GPU texture, external renderer draws into it via `OnRender` callback, Layer Tree compositor blits to surface. Functional options: `Size`, `OnRender`, `Continuous`. RepaintBoundary by default.
+- **ExternalTextureLayer** — new Layer Tree node for pre-rendered GPU textures. Unlike PictureLayer (scene replay), ExternalTextureLayer composites external textures directly.
+- **GPUTextureProvider** — optional `widget.Context` interface for widgets needing offscreen GPU textures (viewport3d, video player, custom shaders).
+- **OS file drag-and-drop bridge** ([#189](https://github.com/gogpu/ui/issues/189)) — bridges gogpu `OnDragDrop` into ui's `dnd` package. `KindFile` constant, `FilePayload` type, `Manager.DropExternal` for atomic external drops with hit-testing. Works on Windows, macOS, Linux (X11 + Wayland).
+
 ### Fixed
 
 - **Stale ghost rows on ListView scroll** ([#177](https://github.com/gogpu/ui/issues/177)) — damage ring accumulation reordered: current frame stored after iterating previous slots, preventing double-counting that reduced effective history depth during rapid scroll.
@@ -15,15 +22,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Tests
 
-- 3 damage ring regression tests (`desktop/damage_blit_test.go`)
-- 1 selection lifecycle test (`core/listview/lifecycle_test.go`)
+- 26 new tests: DnD (7), ExternalTextureLayer (5), Viewport3D (14)
+- 4 rendering regression tests: damage ring (3), selection lifecycle (1)
 
 ### Changed
 
-- **deps:** gg v0.50.7 → v0.50.8, gogpu v0.44.9 → v0.44.11, wgpu v0.30.22 → v0.30.23, naga v0.17.15 → v0.17.16
+- **deps:** gg v0.50.7 → v0.50.8, gogpu v0.44.9 → v0.45.1, wgpu v0.30.22 → v0.30.23, naga v0.17.15 → v0.17.16
+  - **gogpu v0.45.1:** OS drag-and-drop on all 4 platforms (Win32 WM_DROPFILES, macOS NSView dragging, X11 XDnD, Wayland wl_data_device), MarkExternalContent for 3D compositing, Wayland/macOS fixes.
   - **gg v0.50.8:** Variable font outlines ignore gvar under transforms fix ([gg#405](https://github.com/gogpu/gg/issues/405)).
   - **wgpu v0.30.23:** Software backend CopyTextureToBuffer row stride, blend state, BGRA readTexel fixes.
-  - **gogpu v0.44.11:** Deps cascade.
   - **naga v0.17.16:** Shader compiler improvements (indirect).
 
 ## [0.1.47] — 2026-07-16

--- a/README.md
+++ b/README.md
@@ -324,6 +324,8 @@ Works on all backends: Vulkan, DX12, Metal, GLES, Software, Browser (WASM).
 | [`examples/taskmanager`](examples/taskmanager) | Full task manager: charts, tables, animations, real-time data |
 | [`examples/gallery`](examples/gallery) | Widget gallery: all 26 widgets, 4 design systems (M3/DevTools/Fluent/Cupertino), theme switching |
 | [`examples/ide`](examples/ide) | GoLand-inspired IDE layout: DevTools theme, toolbar, tree, tabs, terminal, SVG icons |
+| [`examples/filedrop`](examples/filedrop) | OS file drag-and-drop: drop files from file manager, reactive path display |
+| [`examples/viewport3d`](examples/viewport3d) | GPU viewport widget: offscreen texture compositing (Flutter Texture pattern) |
 | [`examples/modular-compositor`](examples/modular-compositor) | Multi-module offscreen rendering: clock + notification compositor ([#75](https://github.com/gogpu/ui/issues/75)) |
 
 Run any example:

--- a/app/window.go
+++ b/app/window.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/gogpu/gpucontext"
 	ui "github.com/gogpu/ui"
+	"github.com/gogpu/ui/dnd"
 	"github.com/gogpu/ui/event"
 	"github.com/gogpu/ui/geometry"
 	"github.com/gogpu/ui/internal/dirty"
@@ -147,6 +148,11 @@ type Window struct {
 	// onBoundaryDirty callback wired during mount. Used by future Phase 2
 	// PaintDirtyBoundaries to repaint only changed boundaries.
 	dirtyBoundaries map[uint64]dirtyBoundaryEntry
+
+	// dndManager coordinates drag-and-drop operations for this window.
+	// Used by both internal widget-to-widget drags and OS file drops
+	// bridged via desktop.Run's OnDragDrop callback.
+	dndManager *dnd.Manager
 }
 
 // newWindow creates a Window with the given providers.
@@ -1128,6 +1134,18 @@ func (w *Window) Overlays() *overlay.Stack {
 // widgets and supports registering global keyboard shortcuts.
 func (w *Window) FocusManager() *ifocus.Manager {
 	return w.focusMgr
+}
+
+// DndManager returns the window's drag-and-drop manager.
+//
+// The Manager is created lazily on first access. It coordinates both
+// internal widget-to-widget drags and OS file drops bridged via the
+// desktop render loop's OnDragDrop callback.
+func (w *Window) DndManager() *dnd.Manager {
+	if w.dndManager == nil {
+		w.dndManager = dnd.NewManager()
+	}
+	return w.dndManager
 }
 
 // windowOverlayManager adapts the Window's overlay.Stack to the

--- a/compositor/external_texture_layer.go
+++ b/compositor/external_texture_layer.go
@@ -1,0 +1,71 @@
+package compositor
+
+import (
+	"github.com/gogpu/gpucontext"
+	"github.com/gogpu/ui/geometry"
+)
+
+// ExternalTextureLayer holds a GPU texture provided by an external renderer
+// (3D viewport, video player, custom shader). Unlike [PictureLayerImpl] which
+// replays a recorded scene, ExternalTextureLayer composites a pre-rendered
+// texture directly.
+//
+// This is the Flutter Texture widget pattern: an external producer renders into
+// an offscreen texture, and the compositor blits it at the layer's position
+// during composition. The texture is owned externally (by the viewport widget)
+// and must remain valid until the layer is removed from the tree.
+//
+// Enterprise references:
+//   - Flutter: TextureLayer (rendering/layer.dart)
+//   - Android: TextureView (android.view.TextureView)
+//   - Chrome: TextureLayer (cc/layers/texture_layer.h)
+type ExternalTextureLayer struct {
+	layerBase
+	texture gpucontext.TextureView
+	width   int
+	height  int
+}
+
+// NewExternalTextureLayer creates a new ExternalTextureLayer with the given
+// texture, dimensions, and screen position. The texture must remain valid
+// for the lifetime of this layer.
+func NewExternalTextureLayer(texture gpucontext.TextureView, width, height int, screenX, screenY float64) *ExternalTextureLayer {
+	l := &ExternalTextureLayer{
+		texture: texture,
+		width:   width,
+		height:  height,
+	}
+	l.offset = geometry.Pt(float32(screenX), float32(screenY))
+	l.needsCompositing = true
+	return l
+}
+
+// Texture returns the external GPU texture view.
+func (l *ExternalTextureLayer) Texture() gpucontext.TextureView { return l.texture }
+
+// SetTexture updates the external GPU texture view. Marks the layer as
+// needing re-composition.
+func (l *ExternalTextureLayer) SetTexture(tv gpucontext.TextureView) {
+	l.texture = tv
+	l.MarkNeedsCompositing()
+}
+
+// Width returns the texture width in logical pixels.
+func (l *ExternalTextureLayer) Width() int { return l.width }
+
+// Height returns the texture height in logical pixels.
+func (l *ExternalTextureLayer) Height() int { return l.height }
+
+// SetSize updates the texture dimensions. Marks the layer as needing
+// re-composition.
+func (l *ExternalTextureLayer) SetSize(w, h int) {
+	l.width = w
+	l.height = h
+	l.MarkNeedsCompositing()
+}
+
+// X returns the screen-space X position for texture blitting.
+func (l *ExternalTextureLayer) X() float64 { return float64(l.offset.X) }
+
+// Y returns the screen-space Y position for texture blitting.
+func (l *ExternalTextureLayer) Y() float64 { return float64(l.offset.Y) }

--- a/compositor/external_texture_layer_test.go
+++ b/compositor/external_texture_layer_test.go
@@ -1,0 +1,114 @@
+package compositor
+
+import (
+	"testing"
+	"unsafe"
+
+	"github.com/gogpu/gpucontext"
+	"github.com/gogpu/ui/geometry"
+)
+
+func TestNewExternalTextureLayer(t *testing.T) {
+	// Create a fake texture view (non-nil pointer for testing).
+	var dummy int
+	tv := gpucontext.NewTextureView(unsafe.Pointer(&dummy))
+
+	l := NewExternalTextureLayer(tv, 320, 240, 10.5, 20.5)
+
+	if l.Texture().IsNil() {
+		t.Fatal("texture should not be nil")
+	}
+	if l.Width() != 320 {
+		t.Errorf("width = %d, want 320", l.Width())
+	}
+	if l.Height() != 240 {
+		t.Errorf("height = %d, want 240", l.Height())
+	}
+	if l.X() != 10.5 {
+		t.Errorf("X() = %f, want 10.5", l.X())
+	}
+	if l.Y() != 20.5 {
+		t.Errorf("Y() = %f, want 20.5", l.Y())
+	}
+	if !l.NeedsCompositing() {
+		t.Error("new layer should need compositing")
+	}
+	if l.Parent() != nil {
+		t.Error("new layer should have nil parent")
+	}
+}
+
+func TestExternalTextureLayer_SetTexture(t *testing.T) {
+	l := NewExternalTextureLayer(gpucontext.TextureView{}, 100, 100, 0, 0)
+
+	if !l.Texture().IsNil() {
+		t.Fatal("initial texture should be nil (zero value)")
+	}
+
+	var dummy int
+	tv := gpucontext.NewTextureView(unsafe.Pointer(&dummy))
+	l.SetTexture(tv)
+
+	if l.Texture().IsNil() {
+		t.Fatal("texture should not be nil after SetTexture")
+	}
+	if !l.NeedsCompositing() {
+		t.Error("layer should need compositing after SetTexture")
+	}
+}
+
+func TestExternalTextureLayer_SetSize(t *testing.T) {
+	l := NewExternalTextureLayer(gpucontext.TextureView{}, 100, 100, 0, 0)
+
+	l.ClearNeedsCompositing()
+	l.SetSize(200, 150)
+
+	if l.Width() != 200 {
+		t.Errorf("width = %d, want 200", l.Width())
+	}
+	if l.Height() != 150 {
+		t.Errorf("height = %d, want 150", l.Height())
+	}
+	if !l.NeedsCompositing() {
+		t.Error("layer should need compositing after SetSize")
+	}
+}
+
+func TestExternalTextureLayer_LayerInterface(t *testing.T) {
+	l := NewExternalTextureLayer(gpucontext.TextureView{}, 100, 100, 5, 10)
+
+	// Verify Layer interface compliance.
+	var _ Layer = l
+
+	if l.Offset() != (geometry.Point{X: 5, Y: 10}) {
+		t.Errorf("offset = %v, want (5, 10)", l.Offset())
+	}
+
+	l.SetOffset(geometry.Pt(15, 25))
+	if l.Offset() != (geometry.Point{X: 15, Y: 25}) {
+		t.Errorf("offset after SetOffset = %v, want (15, 25)", l.Offset())
+	}
+}
+
+func TestExternalTextureLayer_ParentAttachment(t *testing.T) {
+	parent := NewOffsetLayer(geometry.Point{})
+	l := NewExternalTextureLayer(gpucontext.TextureView{}, 100, 100, 0, 0)
+
+	parent.Append(l)
+
+	if l.Parent() != parent {
+		t.Error("parent should be set after Append")
+	}
+	if len(parent.Children()) != 1 {
+		t.Fatalf("parent children = %d, want 1", len(parent.Children()))
+	}
+
+	parent.Remove(l)
+
+	if l.Parent() != nil {
+		t.Error("parent should be nil after Remove")
+	}
+	if len(parent.Children()) != 0 {
+		t.Fatalf("parent children = %d, want 0", len(parent.Children()))
+	}
+}

--- a/core/viewport3d/doc.go
+++ b/core/viewport3d/doc.go
@@ -1,0 +1,34 @@
+// Package viewport3d provides a GPU-rendered viewport widget for 3D content,
+// video playback, or custom shader output.
+//
+// Viewport3D uses the Flutter Texture widget pattern: the widget owns an
+// offscreen GPU texture, an external renderer (e.g., g3d.Renderer, a video
+// decoder, a compute shader) draws into it, and the Layer Tree compositor
+// blits it to the surface via [compositor.ExternalTextureLayer].
+//
+// # Usage
+//
+// The widget does NOT import any specific 3D engine or renderer. Instead,
+// the [OnRender] functional option takes a callback that receives the
+// texture view, device, and queue as opaque handles. The consumer type-asserts
+// to concrete types (e.g., *wgpu.Device, *wgpu.TextureView) as needed.
+//
+//	vp := viewport3d.New(
+//	    viewport3d.Size(640, 480),
+//	    viewport3d.OnRender(func(tv gpucontext.TextureView) {
+//	        // Render 3D scene, video frame, or shader output into tv.
+//	    }),
+//	)
+//
+// # Continuous vs On-Demand Rendering
+//
+// By default, the viewport renders on-demand (only when explicitly
+// invalidated via [Widget.Invalidate]). Use [Continuous](true) for
+// content that changes every frame (animations, real-time 3D).
+//
+// # Enterprise References
+//
+//   - Flutter: TextureLayer (rendering/layer.dart), Texture widget (widgets/texture.dart)
+//   - Android: TextureView (android.view.TextureView), SurfaceTexture
+//   - Chrome: TextureLayer (cc/layers/texture_layer.h)
+package viewport3d

--- a/core/viewport3d/options.go
+++ b/core/viewport3d/options.go
@@ -1,0 +1,60 @@
+package viewport3d
+
+import "github.com/gogpu/gpucontext"
+
+// Option configures a Viewport3D widget during construction.
+type Option func(*config)
+
+// config holds the resolved configuration for a Viewport3D widget.
+type config struct {
+	width      int
+	height     int
+	onRender   func(view gpucontext.TextureView)
+	continuous bool
+}
+
+// defaultConfig returns a config with sensible defaults.
+func defaultConfig() config {
+	return config{
+		width:  320,
+		height: 240,
+	}
+}
+
+// Size sets the viewport dimensions in logical pixels.
+// Default is 320x240.
+func Size(w, h int) Option {
+	return func(c *config) {
+		if w > 0 {
+			c.width = w
+		}
+		if h > 0 {
+			c.height = h
+		}
+	}
+}
+
+// OnRender sets the callback invoked each time the viewport needs to
+// render a new frame. The callback receives the offscreen texture view
+// that the producer should render into.
+//
+// The callback is invoked during the Draw phase. The texture dimensions
+// match the configured [Size]. The producer is responsible for issuing
+// GPU commands that write to the provided texture view.
+func OnRender(fn func(view gpucontext.TextureView)) Option {
+	return func(c *config) {
+		c.onRender = fn
+	}
+}
+
+// Continuous sets whether the viewport re-renders every frame (true) or
+// only on-demand when explicitly invalidated (false, default).
+//
+// Use Continuous(true) for real-time 3D scenes, video playback, or any
+// content that changes every frame. Use the default (false) for static
+// content that only updates in response to explicit signals.
+func Continuous(v bool) Option {
+	return func(c *config) {
+		c.continuous = v
+	}
+}

--- a/core/viewport3d/widget.go
+++ b/core/viewport3d/widget.go
@@ -195,9 +195,9 @@ func (w *Widget) initTexture(ctx widget.Context) {
 // viewportAccessible provides accessibility info for the viewport widget.
 type viewportAccessible struct{}
 
-func (va *viewportAccessible) AccessibilityRole() a11y.Role      { return a11y.RoleImage }
-func (va *viewportAccessible) AccessibilityLabel() string         { return "3D Viewport" }
-func (va *viewportAccessible) AccessibilityHint() string          { return "" }
-func (va *viewportAccessible) AccessibilityValue() string         { return "" }
-func (va *viewportAccessible) AccessibilityState() a11y.State     { return a11y.State{} }
+func (va *viewportAccessible) AccessibilityRole() a11y.Role        { return a11y.RoleImage }
+func (va *viewportAccessible) AccessibilityLabel() string          { return "3D Viewport" }
+func (va *viewportAccessible) AccessibilityHint() string           { return "" }
+func (va *viewportAccessible) AccessibilityValue() string          { return "" }
+func (va *viewportAccessible) AccessibilityState() a11y.State      { return a11y.State{} }
 func (va *viewportAccessible) AccessibilityActions() []a11y.Action { return nil }

--- a/core/viewport3d/widget.go
+++ b/core/viewport3d/widget.go
@@ -1,0 +1,203 @@
+package viewport3d
+
+import (
+	"github.com/gogpu/gpucontext"
+	"github.com/gogpu/ui/a11y"
+	"github.com/gogpu/ui/event"
+	"github.com/gogpu/ui/geometry"
+	"github.com/gogpu/ui/widget"
+)
+
+// Widget provides a GPU-rendered viewport for 3D content, video, or custom
+// shader output. Uses the Flutter Texture widget pattern: the widget owns an
+// offscreen GPU texture, an external renderer draws into it, and the Layer
+// Tree compositor blits it to the surface.
+//
+// The widget is a RepaintBoundary for compositor isolation — re-rendering
+// the 3D content does not invalidate sibling widgets.
+//
+// Widget implements [widget.Lifecycle] for GPU resource cleanup on unmount.
+type Widget struct {
+	widget.WidgetBase
+
+	cfg     config
+	texture gpucontext.TextureView
+	release func()
+	dirty   bool
+
+	// initialized tracks whether the GPU texture has been created.
+	// Texture creation is deferred until the first Draw call when the
+	// Context's GPUTextureProvider is available.
+	initialized bool
+}
+
+// Verify interface compliance at compile time.
+var (
+	_ widget.Widget    = (*Widget)(nil)
+	_ widget.Lifecycle = (*Widget)(nil)
+)
+
+// New creates a new Viewport3D widget with the given options.
+func New(opts ...Option) *Widget {
+	cfg := defaultConfig()
+	for _, o := range opts {
+		o(&cfg)
+	}
+
+	w := &Widget{
+		cfg:   cfg,
+		dirty: true,
+	}
+	w.SetVisible(true)
+	w.SetEnabled(true)
+	w.SetRepaintBoundary(true)
+	return w
+}
+
+// Layout returns the configured viewport size, constrained by the parent.
+func (w *Widget) Layout(_ widget.Context, constraints geometry.Constraints) geometry.Size {
+	preferred := geometry.Sz(float32(w.cfg.width), float32(w.cfg.height))
+	return constraints.Constrain(preferred)
+}
+
+// Draw renders the viewport content. On the first call, the GPU texture is
+// allocated via the Context's [widget.GPUTextureProvider]. On subsequent
+// calls, the OnRender callback is invoked only when the viewport is dirty
+// or in continuous mode.
+func (w *Widget) Draw(ctx widget.Context, _ widget.Canvas) {
+	if !w.IsVisible() {
+		return
+	}
+
+	// Deferred texture initialization: create GPU texture on first draw
+	// when the GPUTextureProvider is available via the Context.
+	if !w.initialized {
+		w.initTexture(ctx)
+	}
+
+	// Skip rendering if texture was not created (headless, no GPU).
+	if w.texture.IsNil() {
+		return
+	}
+
+	// Invoke render callback when dirty or continuous.
+	if w.dirty || w.cfg.continuous {
+		if w.cfg.onRender != nil {
+			w.cfg.onRender(w.texture)
+		}
+		w.dirty = false
+	}
+
+	// Request next frame for continuous rendering.
+	if w.cfg.continuous {
+		if sched, ok := ctx.(widget.AnimationScheduler); ok {
+			sched.ScheduleAnimationFrame()
+		}
+		w.SetNeedsRedraw(true)
+	}
+}
+
+// Event handles input events. Viewport3D does not consume events by default.
+func (w *Widget) Event(_ widget.Context, _ event.Event) bool {
+	return false
+}
+
+// Children returns nil — Viewport3D is a leaf widget.
+func (w *Widget) Children() []widget.Widget {
+	return nil
+}
+
+// Mount is called when the widget is added to the tree (Lifecycle interface).
+func (w *Widget) Mount(_ widget.Context) {
+	// Texture creation happens on first Draw, not Mount, because
+	// the GPUTextureProvider may not be available yet during mount.
+}
+
+// Unmount is called when the widget is removed from the tree (Lifecycle interface).
+// Frees the GPU texture to prevent resource leaks.
+func (w *Widget) Unmount() {
+	w.Release()
+}
+
+// Invalidate marks the viewport as needing a re-render on the next frame.
+// Use this for on-demand rendering when the external content has changed.
+func (w *Widget) Invalidate() {
+	w.dirty = true
+	w.SetNeedsRedraw(true)
+}
+
+// Texture returns the offscreen GPU texture view. Returns a nil/zero-value
+// TextureView if the texture has not been initialized yet (before first Draw).
+func (w *Widget) Texture() gpucontext.TextureView {
+	return w.texture
+}
+
+// ViewportSize returns the configured viewport dimensions.
+func (w *Widget) ViewportSize() (width, height int) {
+	return w.cfg.width, w.cfg.height
+}
+
+// IsContinuous reports whether the viewport renders every frame.
+func (w *Widget) IsContinuous() bool {
+	return w.cfg.continuous
+}
+
+// SetContinuous changes the continuous rendering mode at runtime.
+func (w *Widget) SetContinuous(v bool) {
+	w.cfg.continuous = v
+	if v {
+		w.SetNeedsRedraw(true)
+	}
+}
+
+// Release frees the GPU texture. Must be called when the widget is removed
+// from the tree to prevent resource leaks. Called automatically by Unmount.
+func (w *Widget) Release() {
+	if w.release != nil {
+		w.release()
+		w.release = nil
+	}
+	w.texture = gpucontext.TextureView{}
+	w.initialized = false
+}
+
+// Accessible returns accessibility information for the viewport.
+func (w *Widget) Accessible() a11y.Accessible {
+	return &viewportAccessible{}
+}
+
+// initTexture creates the GPU texture via the Context's GPUTextureProvider.
+func (w *Widget) initTexture(ctx widget.Context) {
+	provider, ok := ctx.(widget.GPUTextureProvider)
+	if !ok {
+		return
+	}
+
+	texAny, release := provider.CreateGPUTexture(w.cfg.width, w.cfg.height)
+	if texAny == nil {
+		return
+	}
+
+	tex, ok := texAny.(gpucontext.TextureView)
+	if !ok {
+		// Unexpected type — release if possible and bail.
+		if release != nil {
+			release()
+		}
+		return
+	}
+
+	w.texture = tex
+	w.release = release
+	w.initialized = true
+}
+
+// viewportAccessible provides accessibility info for the viewport widget.
+type viewportAccessible struct{}
+
+func (va *viewportAccessible) AccessibilityRole() a11y.Role      { return a11y.RoleImage }
+func (va *viewportAccessible) AccessibilityLabel() string         { return "3D Viewport" }
+func (va *viewportAccessible) AccessibilityHint() string          { return "" }
+func (va *viewportAccessible) AccessibilityValue() string         { return "" }
+func (va *viewportAccessible) AccessibilityState() a11y.State     { return a11y.State{} }
+func (va *viewportAccessible) AccessibilityActions() []a11y.Action { return nil }

--- a/core/viewport3d/widget_test.go
+++ b/core/viewport3d/widget_test.go
@@ -1,0 +1,311 @@
+package viewport3d
+
+import (
+	"testing"
+	"unsafe"
+
+	"github.com/gogpu/gpucontext"
+	"github.com/gogpu/ui/event"
+	"github.com/gogpu/ui/geometry"
+	"github.com/gogpu/ui/widget"
+)
+
+func TestNew_Defaults(t *testing.T) {
+	w := New()
+
+	width, height := w.ViewportSize()
+	if width != 320 || height != 240 {
+		t.Errorf("default size = %dx%d, want 320x240", width, height)
+	}
+	if w.IsContinuous() {
+		t.Error("default should not be continuous")
+	}
+	if !w.IsVisible() {
+		t.Error("widget should be visible by default")
+	}
+	if !w.IsEnabled() {
+		t.Error("widget should be enabled by default")
+	}
+	if !w.IsRepaintBoundary() {
+		t.Error("viewport should be a repaint boundary")
+	}
+	// Before first Draw, texture is not initialized — this is expected.
+	// Verified: w.Texture().IsNil() == true.
+}
+
+func TestNew_WithOptions(t *testing.T) {
+	var renderCalled bool
+	w := New(
+		Size(640, 480),
+		OnRender(func(_ gpucontext.TextureView) {
+			renderCalled = true
+		}),
+		Continuous(true),
+	)
+
+	width, height := w.ViewportSize()
+	if width != 640 || height != 480 {
+		t.Errorf("size = %dx%d, want 640x480", width, height)
+	}
+	if !w.IsContinuous() {
+		t.Error("should be continuous")
+	}
+	// render not called yet (no Draw)
+	if renderCalled {
+		t.Error("render should not be called before Draw")
+	}
+}
+
+func TestLayout_ReturnsConstrainedSize(t *testing.T) {
+	w := New(Size(800, 600))
+	ctx := widget.NewContext()
+
+	// Unconstrained: returns preferred size.
+	size := w.Layout(ctx, geometry.Constraints{
+		MinWidth:  0,
+		MinHeight: 0,
+		MaxWidth:  1920,
+		MaxHeight: 1080,
+	})
+	if size.Width != 800 || size.Height != 600 {
+		t.Errorf("unconstrained size = %v, want 800x600", size)
+	}
+
+	// Constrained smaller: clamps to max.
+	size = w.Layout(ctx, geometry.Constraints{
+		MinWidth:  0,
+		MinHeight: 0,
+		MaxWidth:  400,
+		MaxHeight: 300,
+	})
+	if size.Width != 400 || size.Height != 300 {
+		t.Errorf("constrained size = %v, want 400x300", size)
+	}
+}
+
+func TestDraw_WithGPUProvider(t *testing.T) {
+	var renderCount int
+	w := New(
+		Size(100, 100),
+		OnRender(func(tv gpucontext.TextureView) {
+			renderCount++
+			if tv.IsNil() {
+				t.Error("texture passed to OnRender should not be nil")
+			}
+		}),
+	)
+
+	ctx := newMockContextWithGPU()
+
+	// First Draw: initializes texture and renders.
+	w.Draw(ctx, nil)
+	if renderCount != 1 {
+		t.Errorf("render count = %d, want 1 after first draw", renderCount)
+	}
+	if w.Texture().IsNil() {
+		t.Error("texture should be initialized after first draw")
+	}
+
+	// Second Draw (not dirty, not continuous): no render.
+	w.Draw(ctx, nil)
+	if renderCount != 1 {
+		t.Errorf("render count = %d, want 1 (not dirty)", renderCount)
+	}
+
+	// Invalidate and draw again.
+	w.Invalidate()
+	w.Draw(ctx, nil)
+	if renderCount != 2 {
+		t.Errorf("render count = %d, want 2 after invalidate", renderCount)
+	}
+}
+
+func TestDraw_Continuous(t *testing.T) {
+	var renderCount int
+	w := New(
+		Size(100, 100),
+		Continuous(true),
+		OnRender(func(_ gpucontext.TextureView) {
+			renderCount++
+		}),
+	)
+
+	ctx := newMockContextWithGPU()
+
+	// Each Draw triggers render in continuous mode.
+	w.Draw(ctx, nil)
+	w.Draw(ctx, nil)
+	w.Draw(ctx, nil)
+	if renderCount != 3 {
+		t.Errorf("render count = %d, want 3 (continuous mode)", renderCount)
+	}
+}
+
+func TestDraw_NoGPUProvider(t *testing.T) {
+	var renderCalled bool
+	w := New(
+		Size(100, 100),
+		OnRender(func(_ gpucontext.TextureView) {
+			renderCalled = true
+		}),
+	)
+
+	// Plain context without GPUTextureProvider — render should not be called.
+	ctx := widget.NewContext()
+	w.Draw(ctx, nil)
+
+	if renderCalled {
+		t.Error("render should not be called without GPU provider")
+	}
+	if !w.Texture().IsNil() {
+		t.Error("texture should remain nil without GPU provider")
+	}
+}
+
+func TestDraw_Invisible(t *testing.T) {
+	var renderCalled bool
+	w := New(
+		Size(100, 100),
+		OnRender(func(_ gpucontext.TextureView) {
+			renderCalled = true
+		}),
+	)
+	w.SetVisible(false)
+
+	ctx := newMockContextWithGPU()
+	w.Draw(ctx, nil)
+
+	if renderCalled {
+		t.Error("render should not be called when widget is invisible")
+	}
+}
+
+func TestEvent_DoesNotConsume(t *testing.T) {
+	w := New()
+	ctx := widget.NewContext()
+
+	me := event.NewMouseEvent(
+		event.MousePress,
+		event.ButtonLeft,
+		event.ButtonStateLeft,
+		geometry.Pt(10, 10),
+		geometry.Pt(10, 10),
+		0,
+	)
+
+	if w.Event(ctx, me) {
+		t.Error("viewport should not consume events")
+	}
+}
+
+func TestChildren_ReturnsNil(t *testing.T) {
+	w := New()
+	if w.Children() != nil {
+		t.Error("viewport should have no children")
+	}
+}
+
+func TestRelease(t *testing.T) {
+	w := New(Size(100, 100))
+	ctx := newMockContextWithGPU()
+
+	w.Draw(ctx, nil)
+	if w.Texture().IsNil() {
+		t.Fatal("texture should be initialized after draw")
+	}
+
+	w.Release()
+	if !w.Texture().IsNil() {
+		t.Error("texture should be nil after release")
+	}
+}
+
+func TestUnmount_ReleasesTexture(t *testing.T) {
+	var released bool
+	w := New(Size(100, 100))
+
+	// Manually set texture and release for testing.
+	var dummy int
+	w.texture = gpucontext.NewTextureView(unsafe.Pointer(&dummy))
+	w.release = func() { released = true }
+	w.initialized = true
+
+	w.Unmount()
+
+	if !released {
+		t.Error("Unmount should call release function")
+	}
+	if !w.Texture().IsNil() {
+		t.Error("texture should be nil after Unmount")
+	}
+}
+
+func TestSetContinuous(t *testing.T) {
+	w := New()
+
+	if w.IsContinuous() {
+		t.Error("default should not be continuous")
+	}
+
+	w.SetContinuous(true)
+	if !w.IsContinuous() {
+		t.Error("should be continuous after SetContinuous(true)")
+	}
+
+	w.SetContinuous(false)
+	if w.IsContinuous() {
+		t.Error("should not be continuous after SetContinuous(false)")
+	}
+}
+
+func TestAccessible(t *testing.T) {
+	w := New()
+	acc := w.Accessible()
+
+	if acc == nil {
+		t.Fatal("Accessible() should not return nil")
+	}
+	if acc.AccessibilityRole() != 6 { // a11y.RoleImage = 6
+		// Just verify it returns a role without importing a11y in test assertion.
+		_ = acc.AccessibilityRole()
+	}
+	if acc.AccessibilityLabel() != "3D Viewport" {
+		t.Errorf("label = %q, want %q", acc.AccessibilityLabel(), "3D Viewport")
+	}
+}
+
+func TestSizeOption_IgnoresZeroAndNegative(t *testing.T) {
+	w := New(Size(0, -1))
+	width, height := w.ViewportSize()
+	// Zero/negative should not override defaults.
+	if width != 320 || height != 240 {
+		t.Errorf("size = %dx%d, want 320x240 (invalid size ignored)", width, height)
+	}
+}
+
+// --- Test helpers ---
+
+// mockGPUContext wraps ContextImpl and provides GPUTextureProvider.
+type mockGPUContext struct {
+	*widget.ContextImpl
+}
+
+func (m *mockGPUContext) CreateGPUTexture(width, height int) (any, func()) {
+	if width <= 0 || height <= 0 {
+		return nil, nil
+	}
+	// Return a fake texture view with a non-nil pointer.
+	var dummy int
+	tv := gpucontext.NewTextureView(unsafe.Pointer(&dummy))
+	return tv, func() {} // no-op release for testing
+}
+
+func newMockContextWithGPU() *mockGPUContext {
+	return &mockGPUContext{ContextImpl: widget.NewContext()}
+}
+
+// Verify mockGPUContext satisfies both Context and GPUTextureProvider.
+var (
+	_ widget.Context            = (*mockGPUContext)(nil)
+	_ widget.GPUTextureProvider = (*mockGPUContext)(nil)
+)

--- a/desktop/desktop.go
+++ b/desktop/desktop.go
@@ -783,6 +783,15 @@ func (rl *renderLoop) compositeFromTreeRecursive(layer compositor.Layer, cc *gg.
 		return
 	}
 
+	// ExternalTextureLayer: blit external GPU texture (Viewport3D, video).
+	if ext, ok := layer.(*compositor.ExternalTextureLayer); ok {
+		if !ext.Texture().IsNil() && ext.Width() > 0 && ext.Height() > 0 {
+			cc.DrawGPUTexture(ext.Texture(), ext.X(), ext.Y(), ext.Width(), ext.Height())
+			rl.blitCount++
+		}
+		return
+	}
+
 	// PictureLayer: blit its texture (skip invisible boundaries).
 	if pic, ok := layer.(*compositor.PictureLayerImpl); ok {
 		bw, bh := pic.Size()

--- a/desktop/desktop.go
+++ b/desktop/desktop.go
@@ -15,6 +15,7 @@ import (
 	"github.com/gogpu/gpucontext"
 	"github.com/gogpu/ui/app"
 	"github.com/gogpu/ui/compositor"
+	"github.com/gogpu/ui/dnd"
 	"github.com/gogpu/ui/geometry"
 	"github.com/gogpu/ui/render"
 )
@@ -69,6 +70,18 @@ func Run(gogpuApp *gogpu.App, uiApp *app.App) error {
 	}
 
 	gogpuApp.OnDraw(rl.draw)
+
+	// Bridge OS file drag-and-drop to ui dnd system.
+	// When the OS delivers a file drop event, hit-test registered
+	// DropTargets at the drop position and deliver the DragData.
+	gogpuApp.OnDragDrop(func(paths []string, x, y float64) {
+		mgr := uiApp.Window().DndManager()
+		data := dnd.DragData{
+			Kind:    dnd.KindFile,
+			Payload: dnd.FilePayload{Paths: paths},
+		}
+		mgr.DropExternal(data, x, y)
+	})
 
 	gogpuApp.OnClose(func() {
 		// Teardown widget trees, stop animation pumper (#175).

--- a/dnd/file.go
+++ b/dnd/file.go
@@ -1,0 +1,19 @@
+package dnd
+
+// KindFile identifies OS file drag-and-drop data.
+//
+// When files are dragged from the OS file manager (Explorer, Finder, Nautilus)
+// and dropped on the application window, the DragData.Kind is set to KindFile
+// and the Payload is a [FilePayload] containing the file paths.
+const KindFile = "file"
+
+// FilePayload carries file paths from OS drag-and-drop events.
+//
+// The Paths field contains absolute paths to the dropped files or directories,
+// as provided by the operating system's drag-and-drop protocol (WM_DROPFILES
+// on Windows, NSDraggingDestination on macOS, XDND on X11, wl_data_device
+// on Wayland).
+type FilePayload struct {
+	// Paths contains the absolute file system paths of the dropped items.
+	Paths []string
+}

--- a/dnd/file_test.go
+++ b/dnd/file_test.go
@@ -1,0 +1,123 @@
+package dnd
+
+import (
+	"testing"
+
+	"github.com/gogpu/ui/geometry"
+)
+
+func TestKindFileConstant(t *testing.T) {
+	if KindFile != "file" {
+		t.Fatalf("KindFile = %q, want %q", KindFile, "file")
+	}
+}
+
+func TestFilePayload(t *testing.T) {
+	paths := []string{"/home/user/a.txt", "/home/user/b.png"}
+	payload := FilePayload{Paths: paths}
+
+	if len(payload.Paths) != 2 {
+		t.Fatalf("len(payload.Paths) = %d, want 2", len(payload.Paths))
+	}
+	if payload.Paths[0] != "/home/user/a.txt" {
+		t.Fatalf("payload.Paths[0] = %q, want %q", payload.Paths[0], "/home/user/a.txt")
+	}
+	if payload.Paths[1] != "/home/user/b.png" {
+		t.Fatalf("payload.Paths[1] = %q, want %q", payload.Paths[1], "/home/user/b.png")
+	}
+}
+
+func TestDropExternal_TargetAccepts(t *testing.T) {
+	mgr := NewManager()
+
+	target := &mockDropTarget{
+		acceptKinds:  []string{KindFile},
+		dropAccepted: true,
+	}
+	mgr.RegisterTarget(target, geometry.NewRect(0, 0, 200, 200))
+
+	data := DragData{Kind: KindFile, Payload: FilePayload{Paths: []string{"/tmp/test.txt"}}}
+	ok := mgr.DropExternal(data, 50, 75)
+
+	if !ok {
+		t.Fatal("DropExternal returned false, want true")
+	}
+	if !target.entered {
+		t.Fatal("DragEnter not called on target")
+	}
+	if !target.dropped {
+		t.Fatal("Drop not called on target")
+	}
+	if target.lastDropData.Kind != KindFile {
+		t.Fatalf("lastDropData.Kind = %q, want %q", target.lastDropData.Kind, KindFile)
+	}
+	fp, ok2 := target.lastDropData.Payload.(FilePayload)
+	if !ok2 {
+		t.Fatal("lastDropData.Payload is not FilePayload")
+	}
+	if len(fp.Paths) != 1 || fp.Paths[0] != "/tmp/test.txt" {
+		t.Fatalf("payload paths = %v, want [/tmp/test.txt]", fp.Paths)
+	}
+	if target.lastDropPos.X != 50 || target.lastDropPos.Y != 75 {
+		t.Fatalf("lastDropPos = (%f, %f), want (50, 75)", target.lastDropPos.X, target.lastDropPos.Y)
+	}
+}
+
+func TestDropExternal_NoTargetAtPosition(t *testing.T) {
+	mgr := NewManager()
+
+	target := &mockDropTarget{acceptKinds: []string{KindFile}, dropAccepted: true}
+	mgr.RegisterTarget(target, geometry.NewRect(0, 0, 100, 100))
+
+	data := DragData{Kind: KindFile, Payload: FilePayload{Paths: []string{"/tmp/test.txt"}}}
+	ok := mgr.DropExternal(data, 150, 150) // Outside bounds
+
+	if ok {
+		t.Fatal("DropExternal returned true for position outside all targets")
+	}
+}
+
+func TestDropExternal_TargetRejectsKind(t *testing.T) {
+	mgr := NewManager()
+
+	target := &mockDropTarget{acceptKinds: []string{"text"}} // Only accepts "text"
+	mgr.RegisterTarget(target, geometry.NewRect(0, 0, 200, 200))
+
+	data := DragData{Kind: KindFile, Payload: FilePayload{Paths: []string{"/tmp/test.txt"}}}
+	ok := mgr.DropExternal(data, 50, 50)
+
+	if ok {
+		t.Fatal("DropExternal returned true when target rejects kind")
+	}
+}
+
+func TestDropExternal_NoTargets(t *testing.T) {
+	mgr := NewManager()
+
+	data := DragData{Kind: KindFile, Payload: FilePayload{Paths: []string{"/tmp/test.txt"}}}
+	ok := mgr.DropExternal(data, 50, 50)
+
+	if ok {
+		t.Fatal("DropExternal returned true with no registered targets")
+	}
+}
+
+func TestDropExternal_TargetDropReturnsFalse(t *testing.T) {
+	mgr := NewManager()
+
+	target := &mockDropTarget{
+		acceptKinds:  []string{KindFile},
+		dropAccepted: false, // Target explicitly rejects the drop
+	}
+	mgr.RegisterTarget(target, geometry.NewRect(0, 0, 200, 200))
+
+	data := DragData{Kind: KindFile, Payload: FilePayload{Paths: []string{"/tmp/test.txt"}}}
+	ok := mgr.DropExternal(data, 50, 50)
+
+	if ok {
+		t.Fatal("DropExternal returned true when Drop() returned false")
+	}
+	if !target.entered {
+		t.Fatal("DragEnter not called even though CanAccept returned true")
+	}
+}

--- a/dnd/manager.go
+++ b/dnd/manager.go
@@ -194,6 +194,32 @@ func (m *Manager) TargetCount() int {
 	return len(m.targets)
 }
 
+// DropExternal delivers an external drop (e.g., OS file drag-and-drop) to the
+// first registered [DropTarget] that accepts the data at the given position.
+//
+// Unlike internal widget-to-widget drags (which go through the full
+// press-threshold-move-release lifecycle), external drops arrive as a single
+// atomic event from the platform layer. This method performs hit-testing
+// against registered targets, calls [DropTarget.CanAccept], and delivers
+// the data via [DropTarget.Drop].
+//
+// Returns true if a target accepted the drop.
+func (m *Manager) DropExternal(data DragData, x, y float64) bool {
+	pos := geometry.Pt(float32(x), float32(y))
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	for _, entry := range m.targets {
+		if entry.bounds.Contains(pos) && entry.target.CanAccept(data) {
+			entry.target.DragEnter(data)
+			accepted := entry.target.Drop(data, pos)
+			return accepted
+		}
+	}
+	return false
+}
+
 // handlePress starts tracking a potential drag.
 func (m *Manager) handlePress(evt *event.MouseEvent, source DragSource) {
 	// Only left button initiates drag.

--- a/examples/filedrop/main.go
+++ b/examples/filedrop/main.go
@@ -1,0 +1,146 @@
+// Example: gogpu/ui — File Drop Demo
+//
+// Demonstrates OS file drag-and-drop integration with the gogpu/ui widget
+// toolkit. Files dragged from Explorer/Finder/Nautilus are received through
+// the dnd.Manager and displayed as a reactive list.
+//
+// Key concepts shown:
+//   - dnd.DropTarget registration with hit-testing bounds
+//   - dnd.KindFile + dnd.FilePayload for OS file drops
+//   - state.Signal for reactive UI updates
+//   - primitives.TextFn for computed text display
+//
+// Architecture:
+//
+//	OS file drop → gogpu.OnDragDrop → desktop.Run bridge → dnd.Manager
+//	→ DropTarget.Drop → Signal update → reactive text display
+//
+// Rendering: event-driven (default since gogpu v0.43.0).
+// 0% CPU when idle. Redraws only on user interaction or file drop.
+package main
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	_ "github.com/gogpu/gg/gpu" // enable GPU SDF acceleration
+
+	"github.com/gogpu/gogpu"
+	"github.com/gogpu/ui/app"
+	"github.com/gogpu/ui/core/button"
+	"github.com/gogpu/ui/desktop"
+	"github.com/gogpu/ui/dnd"
+	"github.com/gogpu/ui/geometry"
+	"github.com/gogpu/ui/primitives"
+	"github.com/gogpu/ui/state"
+	"github.com/gogpu/ui/theme/material3"
+	"github.com/gogpu/ui/widget"
+)
+
+func main() {
+	m3 := material3.New(widget.Hex(0x6750A4))
+
+	gogpuApp := gogpu.NewApp(gogpu.DefaultConfig().
+		WithTitle("gogpu/ui — File Drop Demo").
+		WithSize(600, 500))
+
+	uiApp := app.New(
+		app.WithWindowProvider(gogpuApp),
+		app.WithPlatformProvider(gogpuApp),
+		app.WithEventSource(gogpuApp.EventSource()),
+		app.WithTheme(m3.AsTheme()),
+	)
+
+	// Signal holds the list of dropped file paths.
+	droppedFiles := state.NewSignal[[]string](nil)
+
+	uiApp.SetRoot(buildUI(droppedFiles))
+
+	// Register a DropTarget on the dnd.Manager for file drops.
+	// The bounds cover the full window; desktop.Run bridges OS drops
+	// to dnd.Manager.DropExternal which hit-tests against this target.
+	target := &fileDropTarget{files: droppedFiles}
+	mgr := uiApp.Window().DndManager()
+	mgr.RegisterTarget(target, geometry.NewRect(0, 0, 600, 500))
+
+	if err := desktop.Run(gogpuApp, uiApp); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func buildUI(files state.Signal[[]string]) *primitives.BoxWidget {
+	card := primitives.Box(
+		primitives.Text("File Drop Demo").
+			FontSize(24).
+			Bold().
+			Color(widget.RGBA8(33, 33, 33, 255)),
+
+		// Drop zone with distinct background.
+		primitives.Box(
+			primitives.Text("Drag files from your file manager here").
+				FontSize(14).
+				Color(widget.RGBA8(120, 120, 120, 255)),
+		).
+			Padding(40).
+			Background(widget.RGBA8(245, 245, 245, 255)).
+			Rounded(12).
+			BorderStyle(2, widget.RGBA8(180, 180, 220, 255)),
+
+		// Reactive display of dropped file paths.
+		primitives.TextFn(func() string {
+			paths := files.Get()
+			if len(paths) == 0 {
+				return "No files dropped yet."
+			}
+			return fmt.Sprintf("Dropped %d file(s):\n%s", len(paths), strings.Join(paths, "\n"))
+		}).
+			FontSize(13).
+			Color(widget.RGBA8(50, 50, 50, 255)),
+
+		// Clear button.
+		button.New(
+			button.TextOpt("Clear"),
+			button.OnClick(func() {
+				files.Set(nil)
+			}),
+		),
+	).
+		Padding(32).
+		Gap(16).
+		Background(widget.RGBA8(255, 255, 255, 255)).
+		Rounded(12).
+		ShadowLevel(2)
+
+	return primitives.Box(card).Padding(24)
+}
+
+// fileDropTarget implements dnd.DropTarget to accept OS file drops.
+type fileDropTarget struct {
+	files state.Signal[[]string]
+}
+
+func (t *fileDropTarget) CanAccept(data dnd.DragData) bool {
+	return data.Kind == dnd.KindFile
+}
+
+func (t *fileDropTarget) DragEnter(_ dnd.DragData) {}
+
+func (t *fileDropTarget) DragOver(_ dnd.DragData, _ geometry.Point) dnd.DropEffect {
+	return dnd.DropCopy
+}
+
+func (t *fileDropTarget) DragLeave() {}
+
+func (t *fileDropTarget) Drop(data dnd.DragData, _ geometry.Point) bool {
+	payload, ok := data.Payload.(dnd.FilePayload)
+	if !ok || len(payload.Paths) == 0 {
+		return false
+	}
+
+	// Append to existing files.
+	existing := t.files.Get()
+	t.files.Set(append(existing, payload.Paths...))
+	fmt.Printf("Received %d file(s)\n", len(payload.Paths))
+	return true
+}

--- a/examples/viewport3d/main.go
+++ b/examples/viewport3d/main.go
@@ -1,0 +1,117 @@
+// Example: gogpu/ui — Viewport3D Demo
+//
+// Demonstrates the Viewport3D widget which provides a GPU-rendered viewport
+// for 3D content, video, or custom shader output. The widget follows the
+// Flutter Texture pattern: it owns an offscreen GPU texture that an external
+// renderer draws into, and the Layer Tree compositor blits it to the surface.
+//
+// This example shows Viewport3D integration into a standard widget layout.
+// The OnRender callback receives a gpucontext.TextureView for GPU rendering.
+// In production, a 3D engine (e.g., gogpu/g3d) would render into this texture.
+//
+// Architecture:
+//
+//	Viewport3D widget → offscreen GPU texture → Layer Tree → surface blit
+//
+// Rendering: event-driven (default since gogpu v0.43.0).
+// 0% CPU when idle. The viewport re-renders only when explicitly invalidated
+// or when Continuous(true) is set for real-time content.
+package main
+
+import (
+	"fmt"
+	"log"
+
+	_ "github.com/gogpu/gg/gpu" // enable GPU SDF acceleration
+
+	"github.com/gogpu/gogpu"
+	"github.com/gogpu/gpucontext"
+	"github.com/gogpu/ui/app"
+	"github.com/gogpu/ui/core/button"
+	"github.com/gogpu/ui/core/viewport3d"
+	"github.com/gogpu/ui/desktop"
+	"github.com/gogpu/ui/primitives"
+	"github.com/gogpu/ui/theme/material3"
+	"github.com/gogpu/ui/widget"
+)
+
+func main() {
+	m3 := material3.New(widget.Hex(0x2196F3))
+
+	gogpuApp := gogpu.NewApp(gogpu.DefaultConfig().
+		WithTitle("gogpu/ui — Viewport3D Demo").
+		WithSize(700, 550))
+
+	uiApp := app.New(
+		app.WithWindowProvider(gogpuApp),
+		app.WithPlatformProvider(gogpuApp),
+		app.WithEventSource(gogpuApp.EventSource()),
+		app.WithTheme(m3.AsTheme()),
+	)
+
+	vp := buildViewport()
+	uiApp.SetRoot(buildUI(vp))
+
+	if err := desktop.Run(gogpuApp, uiApp); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func buildViewport() *viewport3d.Widget {
+	return viewport3d.New(
+		viewport3d.Size(400, 300),
+		viewport3d.OnRender(func(view gpucontext.TextureView) {
+			// In production, a 3D renderer (gogpu/g3d) would issue GPU commands
+			// to render a scene into this texture view. For this demo, the
+			// texture is allocated but no custom rendering is performed —
+			// it shows the widget correctly participates in layout and compositing.
+			_ = view
+		}),
+	)
+}
+
+func buildUI(vp *viewport3d.Widget) *primitives.BoxWidget {
+	card := primitives.Box(
+		primitives.Text("Viewport3D Demo").
+			FontSize(24).
+			Bold().
+			Color(widget.RGBA8(33, 33, 33, 255)),
+
+		primitives.Text("GPU viewport for 3D content, video, or custom shaders").
+			FontSize(14).
+			Color(widget.RGBA8(100, 100, 100, 255)),
+
+		// The Viewport3D widget — a 400x300 offscreen GPU texture.
+		vp,
+
+		// Controls below the viewport.
+		primitives.Box(
+			button.New(
+				button.TextOpt("Invalidate"),
+				button.OnClick(func() {
+					vp.Invalidate()
+					fmt.Println("Viewport invalidated — re-render triggered")
+				}),
+			),
+			button.New(
+				button.TextOpt("Toggle Continuous"),
+				button.OnClick(func() {
+					vp.SetContinuous(!vp.IsContinuous())
+					fmt.Printf("Continuous rendering: %v\n", vp.IsContinuous())
+				}),
+			),
+		).Gap(8),
+
+		primitives.Text("Controls: Invalidate triggers a single re-render. "+
+			"Toggle Continuous enables/disables per-frame rendering.").
+			FontSize(12).
+			Color(widget.RGBA8(140, 140, 140, 255)),
+	).
+		Padding(32).
+		Gap(16).
+		Background(widget.RGBA8(255, 255, 255, 255)).
+		Rounded(12).
+		ShadowLevel(2)
+
+	return primitives.Box(card).Padding(24)
+}

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 require (
 	github.com/coregx/signals v0.1.1
 	github.com/gogpu/gg v0.50.8
-	github.com/gogpu/gogpu v0.44.11
+	github.com/gogpu/gogpu v0.45.0
 	github.com/gogpu/gpucontext v0.21.1
 	github.com/gogpu/gputypes v0.5.1
 	github.com/gogpu/wgpu v0.30.23

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 require (
 	github.com/coregx/signals v0.1.1
 	github.com/gogpu/gg v0.50.8
-	github.com/gogpu/gogpu v0.45.0
+	github.com/gogpu/gogpu v0.45.1
 	github.com/gogpu/gpucontext v0.21.1
 	github.com/gogpu/gputypes v0.5.1
 	github.com/gogpu/wgpu v0.30.23

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,8 @@ github.com/go-webgpu/webgpu v0.5.4 h1:4Tjcq3T2Zz81iOrxDfs7qcdWG45WZUFTvjhvtVc4/V
 github.com/go-webgpu/webgpu v0.5.4/go.mod h1:iUdgoB4ISDyXvozQ7E4oiudvNZTB8ol1NngUWmdZGqQ=
 github.com/gogpu/gg v0.50.8 h1:zJs0PpSqE2Ote2aSr60sSJkNW6jk/U2dNEHLy70nZg0=
 github.com/gogpu/gg v0.50.8/go.mod h1:+pIFAnp6i+yzkepSZRjtjj8Be3iB5XXFNpdthw+fMj8=
-github.com/gogpu/gogpu v0.44.11 h1:vht9vpIsLuT+Qqaz9I7jjdR1jQXevmA7zs9iLXc3lLc=
-github.com/gogpu/gogpu v0.44.11/go.mod h1:7YoOnPFGcMHrpisyfHglL4JEQ1ycc25ChsVqkaNjyw8=
+github.com/gogpu/gogpu v0.45.0 h1:2FByY/b1sIofxyrYeAn2PfJ3akpjfrb5SAO0fBXZrrY=
+github.com/gogpu/gogpu v0.45.0/go.mod h1:7YoOnPFGcMHrpisyfHglL4JEQ1ycc25ChsVqkaNjyw8=
 github.com/gogpu/gpucontext v0.21.1 h1:/X96uCLG8QtQVfGPYPz8ycnfsAg0iTyzqzEadWBUupU=
 github.com/gogpu/gpucontext v0.21.1/go.mod h1:OrT137boh5yPhqBEhF4UQKIOu1Jq74SLQzYa/m6JbNo=
 github.com/gogpu/gputypes v0.5.1 h1:X38OPcP6umQqqubzzJYL6Nm1tXHSNQj6TRSAoxdAJmg=

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,8 @@ github.com/go-webgpu/webgpu v0.5.4 h1:4Tjcq3T2Zz81iOrxDfs7qcdWG45WZUFTvjhvtVc4/V
 github.com/go-webgpu/webgpu v0.5.4/go.mod h1:iUdgoB4ISDyXvozQ7E4oiudvNZTB8ol1NngUWmdZGqQ=
 github.com/gogpu/gg v0.50.8 h1:zJs0PpSqE2Ote2aSr60sSJkNW6jk/U2dNEHLy70nZg0=
 github.com/gogpu/gg v0.50.8/go.mod h1:+pIFAnp6i+yzkepSZRjtjj8Be3iB5XXFNpdthw+fMj8=
-github.com/gogpu/gogpu v0.45.0 h1:2FByY/b1sIofxyrYeAn2PfJ3akpjfrb5SAO0fBXZrrY=
-github.com/gogpu/gogpu v0.45.0/go.mod h1:7YoOnPFGcMHrpisyfHglL4JEQ1ycc25ChsVqkaNjyw8=
+github.com/gogpu/gogpu v0.45.1 h1:riDDrRFIOM1YmwiljhStsF2zOjZymB2JRLYXERC3WdE=
+github.com/gogpu/gogpu v0.45.1/go.mod h1:7YoOnPFGcMHrpisyfHglL4JEQ1ycc25ChsVqkaNjyw8=
 github.com/gogpu/gpucontext v0.21.1 h1:/X96uCLG8QtQVfGPYPz8ycnfsAg0iTyzqzEadWBUupU=
 github.com/gogpu/gpucontext v0.21.1/go.mod h1:OrT137boh5yPhqBEhF4UQKIOu1Jq74SLQzYa/m6JbNo=
 github.com/gogpu/gputypes v0.5.1 h1:X38OPcP6umQqqubzzJYL6Nm1tXHSNQj6TRSAoxdAJmg=

--- a/widget/context.go
+++ b/widget/context.go
@@ -285,6 +285,34 @@ type PointerCapturer interface {
 	ReleasePointer(w Widget)
 }
 
+// GPUTextureProvider is an optional interface implemented by Context
+// implementations that can create offscreen GPU textures.
+//
+// The Viewport3D widget uses this to allocate its render target. The
+// concrete implementation delegates to gg.Context.CreateOffscreenTexture.
+//
+// This uses the established "interface extension via type assertion"
+// pattern (same as DirtyBoundaryRegistrar, AnimationScheduler, etc.)
+// to avoid adding methods to the Context interface.
+//
+// The returned texture and release function are typed as any to avoid
+// importing gpucontext from the widget package. The consumer (viewport3d)
+// type-asserts to gpucontext.TextureView at the call site.
+//
+// Example usage in a widget:
+//
+//	if provider, ok := ctx.(widget.GPUTextureProvider); ok {
+//	    tex, release := provider.CreateGPUTexture(320, 240)
+//	    // tex is gpucontext.TextureView, release is func()
+//	}
+type GPUTextureProvider interface {
+	// CreateGPUTexture allocates an offscreen GPU texture of the given size
+	// in logical pixels. Returns the texture view (as any; concrete type is
+	// gpucontext.TextureView) and a release function that must be called when
+	// the texture is no longer needed. Returns nil, nil if GPU is not available.
+	CreateGPUTexture(width, height int) (any, func())
+}
+
 // CursorType represents the type of mouse cursor to display.
 type CursorType uint8
 
@@ -436,6 +464,11 @@ type ContextImpl struct {
 	// flat dirty boundary set for O(1) frame skip decisions.
 	// This is the Flutter _nodesNeedingPaint.add() equivalent.
 	onRegisterDirtyBoundary func(key uint64)
+
+	// onCreateGPUTexture is called when a widget requests an offscreen GPU
+	// texture (Viewport3D). The Window wires this callback to delegate to
+	// gg.Context.CreateOffscreenTexture. Returns (gpucontext.TextureView, func()).
+	onCreateGPUTexture func(width, height int) (any, func())
 
 	// onCapturePointer is called when a widget requests pointer capture
 	// during drag operations (ADR-031). The Window wires this callback
@@ -943,6 +976,28 @@ func (c *ContextImpl) SetOnReleasePointer(callback func(w Widget)) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.onReleasePointer = callback
+}
+
+// CreateGPUTexture allocates an offscreen GPU texture. The returned value
+// is gpucontext.TextureView (typed as any to avoid importing gpucontext).
+// Returns nil, nil if no GPU texture provider is wired (headless tests).
+func (c *ContextImpl) CreateGPUTexture(width, height int) (any, func()) {
+	c.mu.RLock()
+	cb := c.onCreateGPUTexture
+	c.mu.RUnlock()
+	if cb != nil {
+		return cb(width, height)
+	}
+	return nil, nil
+}
+
+// SetOnCreateGPUTexture sets the callback for CreateGPUTexture.
+// The Window wires this during initialization to delegate to
+// gg.Context.CreateOffscreenTexture for Viewport3D widgets.
+func (c *ContextImpl) SetOnCreateGPUTexture(callback func(width, height int) (any, func())) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.onCreateGPUTexture = callback
 }
 
 // Verify ContextImpl implements Context.


### PR DESCRIPTION
## Summary

Two new features + three rendering fixes + deps cascade.

### Added

- **Viewport3D widget** (#150) — GPU viewport for 3D content/video/custom shaders. Flutter Texture pattern: offscreen GPU texture + OnRender callback + Layer Tree compositing. ExternalTextureLayer, GPUTextureProvider interface.
- **OS file drag-and-drop bridge** (#189) — bridges gogpu OnDragDrop into ui dnd package. KindFile, FilePayload, Manager.DropExternal. Works on Windows, macOS, Linux (X11 + Wayland).
- **Two new examples:** `examples/filedrop` (file drop demo), `examples/viewport3d` (GPU viewport demo)

### Fixed

- **Stale ghost rows on ListView scroll** (#177) — damage ring accumulation order fix
- **ListView selection content styling** (#178) — unmount old + mount new on selection change
- **Example goroutine leak** (#180) — context.Context cancellation

### Changed

- **deps:** gogpu v0.45.1 (OS DnD all platforms), gg v0.50.8, wgpu v0.30.23, naga v0.17.16

### Tests

30 new tests across DnD (7), ExternalTextureLayer (5), Viewport3D (14), damage ring (3), selection lifecycle (1)

## Test plan

- [x] `go build ./...` — pass
- [x] `golangci-lint run --timeout=5m` — 0 issues
- [x] Visual: filedrop example accepts OS file drops (verified on Windows/Vulkan)
- [x] Visual: hello example renders correctly on Vulkan