### PR TITLE
focus: let a focused widget claim Tab

### DIFF
--- a/internal/focus/focus_test.go
+++ b/internal/focus/focus_test.go
@@ -127,3 +127,34 @@ func TestDrawFocusRing_Constants(t *testing.T) {
 		t.Errorf("DefaultFocusRingStrokeWidth = %v, want 2.0", DefaultFocusRingStrokeWidth)
 	}
 }
+
+// grabberWidget claims Tab the way a terminal does.
+type grabberWidget struct {
+	mockWidget
+	grab bool
+}
+
+func (g *grabberWidget) GrabsKey(k event.Key) bool { return g.grab && k == event.KeyTab }
+
+// A focused widget that claims Tab must receive it. The manager consumes Tab
+// for traversal before the widget tree is reached, so without this escape
+// hatch a terminal can never see shell completion.
+func TestTabReachesAKeyGrabber(t *testing.T) {
+	g := &grabberWidget{grab: true}
+	g.focusable = true
+	g.SetVisible(true)
+	g.SetEnabled(true)
+	m := New(g)
+	m.Focus(g)
+
+	tab := &event.KeyEvent{Key: event.KeyTab, KeyType: event.KeyPress}
+	if m.HandleKeyEvent(tab) {
+		t.Error("manager consumed Tab even though the focused widget claimed it")
+	}
+
+	// Not claiming it leaves traversal exactly as it was.
+	g.grab = false
+	if !m.HandleKeyEvent(tab) {
+		t.Error("manager stopped handling Tab for traversal")
+	}
+}

--- a/internal/focus/manager.go
+++ b/internal/focus/manager.go
@@ -160,8 +160,14 @@ func (m *Manager) HandleKeyEvent(e *event.KeyEvent) bool {
 		return true
 	}
 
-	// Tab navigation on press and repeat.
+	// Tab navigation on press and repeat — unless the focused widget claims
+	// the key. A terminal needs raw Tab for shell completion; without this
+	// escape hatch the manager consumes every Tab before the widget tree is
+	// reached, whether or not there is anywhere to traverse to.
 	if e.Key == event.KeyTab {
+		if g, ok := m.focused.(widget.KeyGrabber); ok && g.GrabsKey(e.Key) {
+			return false
+		}
 		return m.handleTab(e)
 	}
 

--- a/widget/focusable.go
+++ b/widget/focusable.go
@@ -1,5 +1,7 @@
 package widget
 
+import "github.com/gogpu/ui/event"
+
 // Focusable is implemented by widgets that can receive keyboard focus.
 //
 // Widgets that support keyboard interaction (text inputs, buttons, etc.)
@@ -34,4 +36,27 @@ type Focusable interface {
 
 	// IsFocused reports whether this widget currently has keyboard focus.
 	IsFocused() bool
+}
+
+// KeyGrabber is implemented by focused widgets that need a key the framework
+// otherwise reserves for itself. Today that is Tab and Shift+Tab, which the
+// focus manager consumes for traversal before the widget tree sees them.
+//
+// A terminal emulator is the canonical case: Tab is shell completion, and a
+// terminal that eats it is broken. Code editors (indent) and game or 3D views
+// (raw input) have the same need. Other toolkits expose the same escape
+// hatch — Qt via focusNextPrevChild, the web via preventDefault on Tab.
+//
+// Only the FOCUSED widget is asked, and only for keys the manager was about to
+// consume, so implementing this cannot break traversal elsewhere.
+//
+// Example:
+//
+//	func (t *Terminal) GrabsKey(k event.Key) bool {
+//	    return k == event.KeyTab // forward to the shell, don't traverse
+//	}
+type KeyGrabber interface {
+	// GrabsKey reports whether this widget wants key k delivered to it
+	// instead of being handled by the framework.
+	GrabsKey(k event.Key) bool
 }


### PR DESCRIPTION
The focus manager consumes Tab and Shift+Tab for traversal before the widget tree is reached, and `handleTab` returns `true` unconditionally — whether or not there is anywhere to traverse to. A widget that needs Tab itself can therefore never see it.

That makes it impossible to embed a terminal emulator: shell completion is bound to Tab, and the key never arrives. Same for a code editor with indent-on-Tab, or any grid that wants Tab to move a cell.

### What this adds

`widget.KeyGrabber`, a single optional method:

```go
type KeyGrabber interface {
    GrabsKey(k event.Key) bool
}
```

Before consuming a key it reserved, the manager asks the **focused** widget whether it wants it, and steps aside if the answer is yes.

- Only the focused widget is consulted, so nothing else in the tree changes behaviour.
- Only for keys the manager was already going to consume.
- Widgets that do not implement it are unaffected — traversal works exactly as before.

### Prior art

Qt exposes the same escape hatch through `focusNextPrevChild`; the web does it with `preventDefault` on Tab. Both put the decision on the focused widget rather than on the traversal code.

### Tests

`TestTabReachesAKeyGrabber` covers both directions: a focused widget that claims Tab receives it, and the same widget with the claim withdrawn leaves traversal exactly as it was.
