### PR TITLE
fix(desktop): damage rect rounding + debug overlay scale (#195)

### DIFF
--- a/desktop/damage_scissor_units_test.go
+++ b/desktop/damage_scissor_units_test.go
@@ -1,0 +1,99 @@
+package desktop
+
+import (
+	"image"
+	"math"
+	"testing"
+)
+
+// TestPhysicalDamageRect_FloorCeilAtFractionalScale pins that the GPU-scissor
+// damage rect rounds identically to gg's own Context.trackDamage -- Floor on
+// the min corner, Ceil on the max corner -- rather than truncating the min
+// corner and round-half-up-ing the SIZE, which is a different function and can
+// under-cover by one physical pixel at fractional device scales.
+//
+// Under LoadOpLoad that missing pixel keeps the previous frame's content, a
+// real stale seam -- not merely a debug-visualization glitch, since this feeds
+// the GPU scissor, not the debug overlay.
+//
+// Chosen numbers discriminate the two formulas: logical origin (11,5), size
+// 20x10, scale 1.5.
+//
+//	Floor/Ceil (gg, correct):               [Floor(16.5),Floor(7.5)]..[Ceil(46.5),Ceil(22.5)] = (16,7)-(47,23)
+//	truncate+round-half-up-size (pre-fix):  (16,7)-(16+int(30.5),7+int(15.5)) = (16,7)-(46,22)
+//
+// Integer scales are unaffected -- both formulas agree when scale is whole,
+// which is why the Retina (2x) hardware session that found the debug-overlay
+// findings never surfaced this.
+//
+// (Finding 2 in issue #195.)
+func TestPhysicalDamageRect_FloorCeilAtFractionalScale(t *testing.T) {
+	tests := []struct {
+		name  string
+		rx    int     // logical origin X (math.Round of float32 ScreenOrigin.X)
+		ry    int     // logical origin Y
+		bw    int     // logical boundary width
+		bh    int     // logical boundary height
+		scale float64 // device scale factor
+		want  image.Rectangle
+	}{
+		// 1x: non-discriminating (both formulas agree). Guards against
+		// over-correcting.
+		{
+			name: "1x identity",
+			rx:   11, ry: 5, bw: 20, bh: 10,
+			scale: 1.0,
+			want:  image.Rect(11, 5, 31, 15),
+		},
+		// 2x: non-discriminating (integer scale, both agree).
+		{
+			name: "2x retina",
+			rx:   11, ry: 5, bw: 20, bh: 10,
+			scale: 2.0,
+			want:  image.Rect(22, 10, 62, 30),
+		},
+		// 1.5x: DISCRIMINATING. Pre-fix gives (16,7)-(46,22). Post-fix
+		// gives (16,7)-(47,23). The Max corner differs by 1px on each axis.
+		{
+			name: "1.5x fractional - discriminating",
+			rx:   11, ry: 5, bw: 20, bh: 10,
+			scale: 1.5,
+			want:  image.Rect(16, 7, 47, 23),
+		},
+		// 1.25x: another fractional scale common on Windows.
+		{
+			name: "1.25x Windows",
+			rx:   10, ry: 10, bw: 100, bh: 50,
+			scale: 1.25,
+			want: image.Rect(
+				int(math.Floor(10*1.25)),
+				int(math.Floor(10*1.25)),
+				int(math.Ceil(110*1.25)),
+				int(math.Ceil(60*1.25)),
+			),
+		},
+		// 1.75x: discriminating fractional scale.
+		{
+			name: "1.75x fractional",
+			rx:   7, ry: 3, bw: 30, bh: 20,
+			scale: 1.75,
+			want: image.Rect(
+				int(math.Floor(7*1.75)),
+				int(math.Floor(3*1.75)),
+				int(math.Ceil(37*1.75)),
+				int(math.Ceil(23*1.75)),
+			),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := physicalDamageRect(tt.rx, tt.ry, tt.bw, tt.bh, tt.scale)
+			if got != tt.want {
+				t.Errorf("physicalDamageRect(%d, %d, %d, %d, %g) = %v, want %v"+
+					"\n  (a Max.X/Max.Y one pixel short means the truncate+round-half-up-size formula is back)",
+					tt.rx, tt.ry, tt.bw, tt.bh, tt.scale, got, tt.want)
+			}
+		})
+	}
+}

--- a/desktop/debug_dirty.go
+++ b/desktop/debug_dirty.go
@@ -56,7 +56,23 @@ func (o *dirtyOverlay) update(regions []geometry.Rect) {
 	}
 }
 
-func (o *dirtyOverlay) draw(cc *gg.Context, scale float64) {
+// draw renders the cyan flash-and-fade overlay.
+//
+// f.rect is LOGICAL (user-space): it originates from Window.DirtyRegions ->
+// WidgetBase.ScreenBounds, i.e. layout coordinates. gg's Fill/Stroke apply the
+// device-scale matrix themselves (Context.deviceSpacePath), so the rect must NOT
+// be pre-multiplied by DeviceScale here -- doing so scales the overlay by
+// deviceScale twice (4x on a 2x display). Same units the sibling
+// SetPresentDamage call site uses.
+//
+// (Finding 3 in issue #195.)
+func (o *dirtyOverlay) draw(cc *gg.Context) {
+	// Overlay rects are screen-space: ignore any leftover user transform, and
+	// do not leak our color/line width into the caller's paint state.
+	cc.Push()
+	cc.Identity()
+	defer cc.Pop()
+
 	now := time.Now()
 	for _, f := range o.flashes {
 		age := now.Sub(f.time)
@@ -65,10 +81,10 @@ func (o *dirtyOverlay) draw(cc *gg.Context, scale float64) {
 		}
 		fade := 1.0 - float64(age)/float64(dirtyFlashDuration)
 
-		x := float64(f.rect.Min.X) * scale
-		y := float64(f.rect.Min.Y) * scale
-		w := float64(f.rect.Max.X-f.rect.Min.X) * scale
-		h := float64(f.rect.Max.Y-f.rect.Min.Y) * scale
+		x := float64(f.rect.Min.X)
+		y := float64(f.rect.Min.Y)
+		w := float64(f.rect.Max.X - f.rect.Min.X)
+		h := float64(f.rect.Max.Y - f.rect.Min.Y)
 		if w <= 0 || h <= 0 {
 			continue
 		}
@@ -77,10 +93,16 @@ func (o *dirtyOverlay) draw(cc *gg.Context, scale float64) {
 		cc.DrawRectangle(x, y, w, h)
 		_ = cc.Fill()
 
-		cc.SetRGBA(0, 0.7, 0.9, 0.7*fade)
-		cc.SetLineWidth(2)
-		cc.DrawRectangle(x+1, y+1, w-2, h-2)
-		_ = cc.Stroke()
+		// Border is inset 1px from the fill on each side. At logical scale a
+		// dirty region as small as 1-2px wide is ordinary (a caret, a thin
+		// divider) -- guard against the inset going negative, which would draw
+		// an inverted, offset border box.
+		if w > 2 && h > 2 {
+			cc.SetRGBA(0, 0.7, 0.9, 0.7*fade)
+			cc.SetLineWidth(2)
+			cc.DrawRectangle(x+1, y+1, w-2, h-2)
+			_ = cc.Stroke()
+		}
 	}
 }
 

--- a/desktop/debug_dirty_test.go
+++ b/desktop/debug_dirty_test.go
@@ -1,0 +1,160 @@
+package desktop
+
+import (
+	"image"
+	"testing"
+
+	"github.com/gogpu/gg"
+	"github.com/gogpu/ui/geometry"
+)
+
+// dirtyOverlay.draw must NOT pre-multiply its rect by DeviceScale.
+// Window.DirtyRegions returns LOGICAL (layout-space) rects, and gg's
+// Fill/Stroke apply the device matrix themselves (Context.deviceSpacePath).
+// Pre-multiplying scaled the overlay by deviceScale TWICE -- 4x on a 2x
+// display, 9x on 3x.
+//
+// The overlay is env-gated in production (GOGPU_DEBUG_DIRTY=1, sync.Once), so
+// this drives update/draw directly and bypasses the gate entirely.
+//
+// (Finding 3 in issue #195.)
+func TestDirtyOverlay_DrawsAtOneDeviceScale(t *testing.T) {
+	tests := []struct {
+		name    string
+		logical int // logical canvas size (square)
+		scale   float64
+		region  geometry.Rect
+		want    image.Rectangle // expected drawn-pixel bbox, PHYSICAL
+	}{
+		// 1x: physical == logical. Non-discriminating (the bug is invisible at
+		// scale 1 by construction) but guards against over-correcting.
+		{"1x identity", 100, 1.0,
+			geometry.NewRect(10, 10, 20, 20), image.Rect(10, 10, 30, 30)},
+		// 2x: pre-fix this drew at (40,40)-(120,120).
+		{"2x retina", 100, 2.0,
+			geometry.NewRect(10, 10, 20, 20), image.Rect(20, 20, 60, 60)},
+		// 3x: pre-fix this drew at (90,90)-(270,270).
+		{"3x", 100, 3.0,
+			geometry.NewRect(10, 10, 20, 20), image.Rect(30, 30, 90, 90)},
+		// Off-origin, to catch a translation-only regression.
+		{"2x off-origin", 200, 2.0,
+			geometry.NewRect(50, 30, 40, 20), image.Rect(100, 60, 180, 100)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cc := gg.NewContextWithScale(tt.logical, tt.logical, tt.scale)
+			// Pin the CPU analytic rasterizer for deterministic, readable-back
+			// pixels. The desktop test binary may register gg's GPU accelerator
+			// via blank imports, so force CPU path explicitly.
+			cc.SetRasterizerMode(gg.RasterizerAnalytic)
+
+			var o dirtyOverlay
+			o.update([]geometry.Rect{tt.region})
+			if len(o.flashes) != 1 {
+				t.Fatalf("update produced %d flashes, want 1", len(o.flashes))
+			}
+			o.draw(cc)
+
+			img, ok := cc.Image().(*image.RGBA)
+			if !ok {
+				t.Fatalf("cc.Image() is %T, want *image.RGBA", cc.Image())
+			}
+			got := alphaBBoxDirty(img, 16)
+			if !rectWithinDirty(got, tt.want, 1) {
+				t.Errorf("drawn bbox = %v, want %v (+/-1px)\n"+
+					"a bbox at ~%dx the expected offset/size means the rect was "+
+					"scaled by deviceScale twice",
+					got, tt.want, int(tt.scale))
+			}
+		})
+	}
+}
+
+// TestDirtyOverlay_DoesNotLeakPaintState pins the Push/Identity/Pop wrapper:
+// the overlay must not leave its color or line width on the caller's context.
+func TestDirtyOverlay_DoesNotLeakPaintState(t *testing.T) {
+	cc := gg.NewContextWithScale(100, 100, 2.0)
+	cc.SetRasterizerMode(gg.RasterizerAnalytic)
+	cc.SetRGBA(1, 0, 0, 1)
+	cc.SetLineWidth(7)
+
+	var o dirtyOverlay
+	o.update([]geometry.Rect{geometry.NewRect(10, 10, 20, 20)})
+	o.draw(cc)
+
+	// Stroke a rect well clear of the overlay and check it came out red, not
+	// cyan -- i.e. the caller's paint survived.
+	cc.DrawRectangle(70, 70, 20, 20)
+	if err := cc.Stroke(); err != nil {
+		t.Fatalf("Stroke: %v", err)
+	}
+	img, ok := cc.Image().(*image.RGBA)
+	if !ok {
+		t.Fatalf("cc.Image() is %T, want *image.RGBA", cc.Image())
+	}
+	px := img.RGBAAt(140, 150) // on the left edge of the stroked rect, physical
+	if px.R < 128 || px.B > 64 {
+		t.Errorf("post-overlay stroke color = %+v, want red-dominant "+
+			"(overlay leaked SetRGBA into the caller's paint)", px)
+	}
+}
+
+// TestDirtyOverlay_DegenerateRectNoInvertedBorder pins the w>2&&h>2 border
+// guard: at logical scale a dirty region as small as 1-2px wide is ordinary.
+// Before the guard, the border's 1px inset (w-2/h-2) went negative for such
+// rects, drawing an inverted, offset border box.
+func TestDirtyOverlay_DegenerateRectNoInvertedBorder(t *testing.T) {
+	cc := gg.NewContextWithScale(100, 100, 3.0)
+	cc.SetRasterizerMode(gg.RasterizerAnalytic)
+
+	var o dirtyOverlay
+	// Logical 1x1 rect -> physical 3x3 fill at (30,30)-(33,33).
+	o.update([]geometry.Rect{geometry.NewRect(10, 10, 1, 1)})
+	o.draw(cc)
+
+	img, ok := cc.Image().(*image.RGBA)
+	if !ok {
+		t.Fatalf("cc.Image() is %T, want *image.RGBA", cc.Image())
+	}
+	got := alphaBBoxDirty(img, 16)
+	want := image.Rect(30, 30, 33, 33) // fill only -- border guard suppresses the stroke
+	if !rectWithinDirty(got, want, 1) {
+		t.Errorf("drawn bbox = %v, want %v (+/-1px) -- a bbox extending outside "+
+			"or offset from the fill means the border's w-2/h-2 inset went "+
+			"negative", got, want)
+	}
+}
+
+// alphaBBoxDirty returns the bounding box of all pixels whose alpha is >=
+// minAlpha. Returns the zero rectangle when nothing was drawn.
+func alphaBBoxDirty(img *image.RGBA, minAlpha uint8) image.Rectangle {
+	b := img.Bounds()
+	var out image.Rectangle
+	first := true
+	for y := b.Min.Y; y < b.Max.Y; y++ {
+		for x := b.Min.X; x < b.Max.X; x++ {
+			if img.RGBAAt(x, y).A < minAlpha {
+				continue
+			}
+			p := image.Rect(x, y, x+1, y+1)
+			if first {
+				out, first = p, false
+			} else {
+				out = out.Union(p)
+			}
+		}
+	}
+	return out
+}
+
+func rectWithinDirty(got, want image.Rectangle, tol int) bool {
+	d := func(a, b int) int {
+		if a > b {
+			return a - b
+		}
+		return b - a
+	}
+	return d(got.Min.X, want.Min.X) <= tol && d(got.Min.Y, want.Min.Y) <= tol &&
+		d(got.Max.X, want.Max.X) <= tol && d(got.Max.Y, want.Max.Y) <= tol
+}

--- a/desktop/desktop.go
+++ b/desktop/desktop.go
@@ -421,7 +421,7 @@ func (rl *renderLoop) draw(dc *gogpu.Context) { //nolint:gocyclo,cyclop,gocognit
 	if isDebugDirtyEnabled() {
 		rl.debugOverlay.update(win.DirtyRegions())
 		cc.SetDamageTracking(false)
-		rl.debugOverlay.draw(cc, rl.canvas.DeviceScale())
+		rl.debugOverlay.draw(cc)
 		cc.SetDamageTracking(true)
 		if rl.debugOverlay.needsAnimationFrame() {
 			if isDebugDamageEnabled() {
@@ -684,6 +684,28 @@ func scaleToPhysical(w, h int, scale float64) (int, int) {
 	return int(float64(w)*scale + 0.5), int(float64(h)*scale + 0.5)
 }
 
+// physicalDamageRect converts a logical damage rect (origin rx,ry + size bw,bh)
+// to physical pixels for the GPU scissor, matching gg's own Context.trackDamage
+// rounding: Floor on the min corner, Ceil on the max corner, independently.
+//
+// This ensures the scissor rect fully covers the damaged region at any device
+// scale. The previous formula (truncate min + round-half-up size) can
+// under-cover by one physical pixel at fractional scales (1.25x, 1.5x, 1.75x).
+// Integer scales (1x, 2x, 3x) are unaffected -- both formulas agree.
+//
+// A scale <= 0 is treated as 1.0 (headless / non-HiDPI).
+func physicalDamageRect(rx, ry, bw, bh int, scale float64) image.Rectangle {
+	if scale <= 0 {
+		scale = 1.0
+	}
+	return image.Rect(
+		int(math.Floor(float64(rx)*scale)),
+		int(math.Floor(float64(ry)*scale)),
+		int(math.Ceil(float64(rx+bw)*scale)),
+		int(math.Ceil(float64(ry+bh)*scale)),
+	)
+}
+
 // ensureBoundaryTexture allocates or resizes the offscreen texture for a boundary.
 //
 // HiDPI: bw/bh are LOGICAL widget bounds, but an offscreen texture is a GPU
@@ -772,14 +794,19 @@ func (rl *renderLoop) trackBoundaryDamage(pic *compositor.PictureLayerImpl, bw, 
 	rl.boundaryDamageLogical = append(rl.boundaryDamageLogical, image.Rect(
 		rx, ry, rx+bw, ry+bh,
 	))
-	// Physical coords for GPU scissor.
+	// Physical coords for GPU scissor. Match gg's own trackDamage rounding
+	// (Floor on the min corner, Ceil on the max corner) exactly -- truncating
+	// the min corner while round-half-up-ing the SIZE is a different function,
+	// and at fractional device scales it can under-cover by one physical pixel.
+	// E.g. scale=1.5, rx=11, bw=20: Floor/Ceil gives [16,47) but
+	// truncate+rounded-size gives [16,46) -- the right edge lands one physical
+	// pixel short of gg's own damage rect, leaving a stale LoadOpLoad seam.
+	// Integer scales are unaffected -- both formulas agree when scale is whole.
+	// (Finding 2 in issue #195.)
 	scale := float64(rl.canvas.DeviceScale())
-	rl.frameDamageRects = append(rl.frameDamageRects, image.Rect(
-		int(float64(rx)*scale),
-		int(float64(ry)*scale),
-		int(float64(rx)*scale)+int(float64(bw)*scale+0.5),
-		int(float64(ry)*scale)+int(float64(bh)*scale+0.5),
-	))
+	rl.frameDamageRects = append(rl.frameDamageRects,
+		physicalDamageRect(rx, ry, bw, bh, scale),
+	)
 }
 
 // compositeTexturesFromTree walks the Layer Tree and blits all boundary textures


### PR DESCRIPTION
## Summary

Fixes findings 2 and 3 from #195 (damage rects: logical vs physical pixel mismatches).

### Finding 2 (production): scissor rounding
`trackBoundaryDamage` used truncate+round-half-up-size formula. At fractional scales (1.25x, 1.5x, 1.75x), this under-covers by 1 physical pixel — stale LoadOpLoad seam. Fix: `math.Floor`/`math.Ceil` rounding via extracted `physicalDamageRect` helper.

### Finding 3 (debug overlay): deviceScale²
`debug_dirty.go` pre-multiplied by scale before `Fill`/`Stroke` which applies `deviceMatrix` again = double scale. Fix: removed manual pre-multiplication, added Push/Identity/Pop state isolation.

### Tests
- 5 `physicalDamageRect` tests (1x, 2x, 1.5x discriminating, 1.25x, 1.75x)
- 7 debug overlay pixel tests (headless gg.Context, analytic rasterizer)

Findings 1, 4, 5 from #195 are gg-side — tracked separately.

## Test plan
- [x] `go build ./...` — pass
- [x] `go test ./... -count=1` — 0 failures
- [x] `golangci-lint run --timeout=5m` — 0 issues