### PR TITLE
fix(desktop): resync device scale after display changes

### DIFF
--- a/app/scale_change_test.go
+++ b/app/scale_change_test.go
@@ -1,0 +1,89 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/gogpu/ui/geometry"
+	"github.com/gogpu/ui/primitives"
+	"github.com/gogpu/ui/widget"
+)
+
+func TestHandleScaleChangeInvalidatesEveryBoundary(t *testing.T) {
+	a := New()
+	w := a.Window()
+
+	root := &testContainer{}
+	root.SetVisible(true)
+	root.SetBounds(geometry.NewRect(0, 0, 800, 600))
+	child := &testLeaf{}
+	child.SetVisible(true)
+	child.SetRepaintBoundary(true)
+	child.SetBounds(geometry.NewRect(10, 10, 58, 58))
+	child.SetParent(root)
+	legacyBoundary := primitives.NewRepaintBoundary(&testLeaf{})
+	legacyBoundary.ClearBoundaryDirty()
+	legacyBoundary.SetParent(root)
+	root.kids = []widget.Widget{child, legacyBoundary}
+	w.SetRoot(root)
+
+	overlayContent := &testLeaf{}
+	overlayContent.SetVisible(true)
+	overlayContent.SetBounds(geometry.NewRect(100, 100, 148, 148))
+	mgr := &windowOverlayManager{window: w}
+	mgr.PushOverlay(overlayContent, nil)
+
+	boundaries := []*testLeaf{child, overlayContent}
+	root.SetCachedScene(widget.NewSceneCache())
+	root.ClearSceneDirty()
+	for _, boundary := range boundaries {
+		boundary.SetCachedScene(widget.NewSceneCache())
+		boundary.ClearSceneDirty()
+	}
+	widget.ClearRedrawInTree(root)
+	widget.ClearRedrawInTree(overlayContent)
+	w.ClearAfterPaint()
+
+	// A continuously animating boundary can already need redraw while its
+	// retained scene is clean. A tree-wide MarkRedrawInTree call skips scene
+	// invalidation in this state because SetNeedsRedraw has an O(1) guard.
+	child.SetNeedsRedraw(true)
+	child.ClearSceneDirty()
+	if !child.NeedsRedraw() || child.IsSceneDirty() {
+		t.Fatal("test setup: child must need redraw while its retained scene is clean")
+	}
+
+	w.HandleScaleChange(2)
+
+	if got := w.Context().Scale(); got != 2 {
+		t.Errorf("context scale = %v, want 2", got)
+	}
+	if !root.IsSceneDirty() {
+		t.Error("root retained scene should be invalidated")
+	}
+	if !child.IsSceneDirty() {
+		t.Error("already-redraw-dirty child retained scene should be invalidated")
+	}
+	if !overlayContent.IsSceneDirty() {
+		t.Error("overlay retained scene should be invalidated")
+	}
+	if !legacyBoundary.IsBoundaryDirty() {
+		t.Error("legacy RepaintBoundary scene should be invalidated")
+	}
+	if !w.NeedsRedraw() {
+		t.Error("window should need redraw")
+	}
+	if !w.needsFullRepaint {
+		t.Error("scale change should force a full repaint")
+	}
+}
+
+func TestHandleScaleChangeWithoutWidgets(t *testing.T) {
+	w := New().Window()
+	w.HandleScaleChange(1.5)
+	if got := w.Context().Scale(); got != 1.5 {
+		t.Errorf("context scale = %v, want 1.5", got)
+	}
+	if !w.NeedsRedraw() {
+		t.Error("window should need redraw")
+	}
+}

--- a/app/scale_change_test.go
+++ b/app/scale_change_test.go
@@ -87,3 +87,17 @@ func TestHandleScaleChangeWithoutWidgets(t *testing.T) {
 		t.Error("window should need redraw")
 	}
 }
+
+func TestHandleScaleChangeRejectsNonPositiveScale(t *testing.T) {
+	w := New().Window()
+	initialScale := w.Context().Scale()
+	for _, scale := range []float64{0, -1} {
+		w.HandleScaleChange(scale)
+		if got := w.Context().Scale(); got != initialScale {
+			t.Errorf("context scale after %v = %v, want %v", scale, got, initialScale)
+		}
+		if w.NeedsRedraw() {
+			t.Errorf("invalid scale %v should not request redraw", scale)
+		}
+	}
+}

--- a/app/window.go
+++ b/app/window.go
@@ -509,6 +509,46 @@ func (w *Window) HandleResize(width, height int) {
 	}
 }
 
+// HandleScaleChange applies a new display scale and invalidates retained
+// rendering created at the previous scale. Logical layout is unchanged, but
+// cached scenes may contain scale-specific raster content such as SVG paths.
+func (w *Window) HandleScaleChange(scale float64) {
+	if scale <= 0 {
+		return
+	}
+
+	w.ctx.SetScale(float32(scale))
+	invalidateScenesInTree(w.root)
+	for _, overlayContent := range w.OverlayContentWidgets() {
+		invalidateScenesInTree(overlayContent)
+	}
+	w.needsRedraw = true
+	w.needsFullRepaint = true
+}
+
+func invalidateScenesInTree(w widget.Widget) {
+	if w == nil {
+		return
+	}
+
+	type boundaryInvalidator interface {
+		IsRepaintBoundary() bool
+		InvalidateScene()
+	}
+	if boundary, ok := w.(boundaryInvalidator); ok && boundary.IsRepaintBoundary() {
+		boundary.InvalidateScene()
+	}
+	// Legacy RepaintBoundary widgets own a separate retained scene. A widget
+	// can implement both boundary mechanisms, so invalidate them independently.
+	if boundary, ok := w.(widget.RepaintBoundaryMarker); ok {
+		boundary.MarkBoundaryDirty()
+	}
+
+	for _, child := range w.Children() {
+		invalidateScenesInTree(child)
+	}
+}
+
 // HandleFocusChange processes a window focus change.
 func (w *Window) HandleFocusChange(focused bool) {
 	if w.root == nil {

--- a/desktop/desktop.go
+++ b/desktop/desktop.go
@@ -189,6 +189,11 @@ func (rl *renderLoop) draw(dc *gogpu.Context) { //nolint:gocyclo,cyclop,gocognit
 		rl.fullRedrawNeeded = true
 	}
 
+	// A display-scale change can leave the logical size unchanged, so it does
+	// not pass through the resize branch above. Synchronize from this frame's
+	// snapshot before the idle gate and before allocating boundary textures.
+	rl.syncDeviceScale(dc.ScaleFactor())
+
 	win := rl.uiApp.Window()
 
 	// ADR-028 Phase C: O(1) frame skip using flat dirty boundary list.
@@ -960,6 +965,20 @@ func collectLiveKeys(layer compositor.Layer, keys map[uint64]bool) {
 			collectLiveKeys(child, keys)
 		}
 	}
+}
+
+// syncDeviceScale resets every cache whose contents or allocation depends on
+// device pixels. It returns true when a new scale was applied.
+func (rl *renderLoop) syncDeviceScale(scale float64) bool {
+	if scale <= 0 || rl.canvas.DeviceScale() == scale {
+		return false
+	}
+
+	rl.canvas.SetDeviceScale(scale)
+	rl.releaseBoundaryTextures()
+	rl.uiApp.Window().HandleScaleChange(scale)
+	rl.fullRedrawNeeded = true
+	return true
 }
 
 // releaseBoundaryTextures frees all offscreen GPU textures.

--- a/desktop/device_scale_sync_test.go
+++ b/desktop/device_scale_sync_test.go
@@ -1,0 +1,140 @@
+package desktop
+
+import (
+	"testing"
+
+	"github.com/gogpu/gg/integration/ggcanvas"
+	"github.com/gogpu/gpucontext"
+	"github.com/gogpu/gputypes"
+	"github.com/gogpu/ui/app"
+	"github.com/gogpu/ui/compositor"
+	"github.com/gogpu/ui/event"
+	"github.com/gogpu/ui/geometry"
+	"github.com/gogpu/ui/widget"
+)
+
+type scaleSyncDeviceProvider struct{}
+
+func (scaleSyncDeviceProvider) Device() gpucontext.Device { return gpucontext.Device{} }
+func (scaleSyncDeviceProvider) Queue() gpucontext.Queue   { return gpucontext.Queue{} }
+func (scaleSyncDeviceProvider) SurfaceFormat() gputypes.TextureFormat {
+	return gputypes.TextureFormatUndefined
+}
+func (scaleSyncDeviceProvider) Adapter() gpucontext.Adapter         { return gpucontext.Adapter{} }
+func (scaleSyncDeviceProvider) AdapterInfo() gpucontext.AdapterInfo { return gpucontext.AdapterInfo{} }
+
+type scaleSyncBoundary struct {
+	widget.WidgetBase
+}
+
+func (w *scaleSyncBoundary) Layout(_ widget.Context, cs geometry.Constraints) geometry.Size {
+	return cs.Constrain(geometry.Sz(50, 50))
+}
+func (w *scaleSyncBoundary) Draw(_ widget.Context, _ widget.Canvas)     {}
+func (w *scaleSyncBoundary) Event(_ widget.Context, _ event.Event) bool { return false }
+
+func newScaleSyncRenderLoop(t *testing.T, scale float64, released *int) (*renderLoop, *scaleSyncBoundary) {
+	t.Helper()
+	canvas, err := ggcanvas.NewWithScale(scaleSyncDeviceProvider{}, 64, 64, scale)
+	if err != nil {
+		t.Fatalf("ggcanvas.NewWithScale: %v", err)
+	}
+	t.Cleanup(func() { _ = canvas.Close() })
+
+	uiApp := app.New()
+	root := &scaleSyncBoundary{}
+	root.SetVisible(true)
+	uiApp.Window().SetRoot(root)
+	uiApp.Window().Context().SetScale(float32(scale))
+	root.SetCachedScene(widget.NewSceneCache())
+	root.ClearSceneDirty()
+	widget.ClearRedrawInTree(root)
+	uiApp.Window().ClearAfterPaint()
+
+	rl := &renderLoop{
+		uiApp:            uiApp,
+		canvas:           canvas,
+		layerTree:        compositor.NewOffsetLayer(geometry.Point{}),
+		boundaryTextures: make(map[uint64]*boundaryTexEntry),
+	}
+	for key := uint64(1); key <= 3; key++ {
+		rl.boundaryTextures[key] = &boundaryTexEntry{
+			release: func() { (*released)++ },
+			width:   48,
+			height:  48,
+		}
+	}
+	return rl, root
+}
+
+func TestSyncDeviceScaleFlip(t *testing.T) {
+	released := 0
+	rl, root := newScaleSyncRenderLoop(t, 1, &released)
+
+	if !rl.syncDeviceScale(2) {
+		t.Fatal("syncDeviceScale should report a scale change")
+	}
+	if got := rl.canvas.DeviceScale(); got != 2 {
+		t.Errorf("canvas device scale = %v, want 2", got)
+	}
+	if got := rl.uiApp.Window().Context().Scale(); got != 2 {
+		t.Errorf("widget context scale = %v, want 2", got)
+	}
+	if released != 3 {
+		t.Errorf("released %d boundary textures, want 3", released)
+	}
+	if rl.boundaryTextures != nil {
+		t.Error("boundary texture cache should be reset")
+	}
+	if rl.layerTree != nil {
+		t.Error("layer tree should be reset")
+	}
+	if !rl.fullRedrawNeeded {
+		t.Error("scale change should force a full redraw")
+	}
+	if !root.IsSceneDirty() {
+		t.Error("retained scenes should be invalidated at the new scale")
+	}
+}
+
+func TestSyncDeviceScaleNoOps(t *testing.T) {
+	for _, scale := range []float64{2, 0, -1} {
+		t.Run(testScaleName(scale), func(t *testing.T) {
+			released := 0
+			rl, root := newScaleSyncRenderLoop(t, 2, &released)
+
+			if rl.syncDeviceScale(scale) {
+				t.Fatalf("syncDeviceScale(%v) should report no change", scale)
+			}
+			if got := rl.canvas.DeviceScale(); got != 2 {
+				t.Errorf("canvas device scale = %v, want 2", got)
+			}
+			if got := rl.uiApp.Window().Context().Scale(); got != 2 {
+				t.Errorf("widget context scale = %v, want 2", got)
+			}
+			if released != 0 {
+				t.Errorf("released %d boundary textures, want 0", released)
+			}
+			if rl.boundaryTextures == nil || rl.layerTree == nil {
+				t.Error("render caches should remain intact")
+			}
+			if rl.fullRedrawNeeded {
+				t.Error("no-op should not force a full redraw")
+			}
+			if root.IsSceneDirty() {
+				t.Error("no-op should not invalidate retained scenes")
+			}
+		})
+	}
+}
+
+func testScaleName(scale float64) string {
+	switch scale {
+	case 0:
+		return "zero"
+	case -1:
+		return "negative"
+	default:
+		return "unchanged"
+	}
+}

--- a/desktop/device_scale_sync_test.go
+++ b/desktop/device_scale_sync_test.go
@@ -1,9 +1,12 @@
 package desktop
 
 import (
+	"reflect"
 	"testing"
+	"unsafe"
 
 	"github.com/gogpu/gg/integration/ggcanvas"
+	"github.com/gogpu/gogpu"
 	"github.com/gogpu/gpucontext"
 	"github.com/gogpu/gputypes"
 	"github.com/gogpu/ui/app"
@@ -126,6 +129,49 @@ func TestSyncDeviceScaleNoOps(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestDrawRunsScaleSyncBeforeIdleGate exercises the render-loop seam around
+// the scale synchronization call without requiring a live platform surface.
+// The synthetic context supplies only the dimensions queried before the idle
+// gate; equal scales keep the frame idle so no GPU commands are submitted.
+func TestDrawRunsScaleSyncBeforeIdleGate(t *testing.T) {
+	released := 0
+	rl, _ := newScaleSyncRenderLoop(t, 1, &released)
+	rl.uiApp.Window().SetRoot(nil)
+	rl.uiApp.Window().Frame()
+	rl.uiApp.Window().ClearAfterPaint()
+	rl.fullRedrawNeeded = false
+
+	rl.draw(syntheticContext(64, 64, 1))
+
+	if got := rl.canvas.DeviceScale(); got != 1 {
+		t.Errorf("canvas device scale = %v, want 1", got)
+	}
+	if released != 0 {
+		t.Errorf("idle draw released %d boundary textures, want 0", released)
+	}
+}
+
+// syntheticContext creates the minimal gogpu.Context needed to drive the
+// render-loop preflight. gogpu intentionally exposes Context only during a
+// live frame, so this test sets its private renderer dimensions explicitly and
+// never reaches GPU operations after the idle gate.
+func syntheticContext(width, height int, scale float64) *gogpu.Context {
+	target := &gogpu.RenderTarget{}
+	setPrivateField(target, "width", uint32(width))
+	setPrivateField(target, "height", uint32(height))
+	renderer := &gogpu.Renderer{}
+	setPrivateField(renderer, "primary", target)
+	ctx := &gogpu.Context{}
+	setPrivateField(ctx, "renderer", renderer)
+	setPrivateField(ctx, "scaleFactor", scale)
+	return ctx
+}
+
+func setPrivateField(target any, name string, value any) {
+	field := reflect.ValueOf(target).Elem().FieldByName(name)
+	reflect.NewAt(field.Type(), unsafe.Pointer(field.UnsafeAddr())).Elem().Set(reflect.ValueOf(value))
 }
 
 func testScaleName(scale float64) string {


### PR DESCRIPTION
## Summary

- synchronize the UI canvas device scale from the current gogpu frame before the idle-render gate
- invalidate scale-dependent retained scenes, repaint boundaries, overlays, textures, and layer state when the scale changes
- add focused regressions for scale-only display transitions in both the app and desktop layers

## Why

A window moving between displays with different scale factors can retain its logical size. In that case the resize path does not run, and `RenderDirectWithDamageRects` bypasses ggcanvas's later provider-scale check. The old device scale, boundary textures, and retained scene content can therefore survive the transition.

The new frame-level synchronization updates scale-dependent state before deciding that a frame is idle, ensuring the scale-change redraw produces correctly rasterized content.

## Verification

- `go test ./... -count=1`
- `go build ./...`
- `CGO_ENABLED=0 go build ./...`
- focused app/desktop scale tests, including repeated and shuffled runs
- focused race tests
- `go vet ./...`
- `git diff --check`

The broad `go test -race ./app ./desktop` run still reports the repository's pre-existing `mockWindowProvider.RequestRedraw` race in `TestWindow_AnimPumper_StartsOnInvalidation`; the changed desktop tests pass under `-race`.

Fixes #172

### Local CI and Codecov preflight

- rebased onto current `main` (`273cc1e`)
- `go test ./... -count=1` with an atomic coverage profile: pass
- focused changed-behavior race suites: pass; the broad app/desktop race remains blocked only by the pre-existing `TestWindow_AnimPumper_StartsOnInvalidation` mock race noted above
- `go build ./...`, `go vet ./...`, `gofmt`, and diff checks: pass
- local Codecov-equivalent changed-production coverage: **30/30 statements (100%)** (`app/window.go` 21/21, `desktop/desktop.go` 9/9); overall coverage 86.4%

Upstream CI run approval is still external to this branch: GitHub marked the fork workflow `action_required` with zero jobs (run `31434862113`). A `gogpu` maintainer must approve the workflow before Actions and the configured Codecov upload/bot can run.

