### PR TITLE
fix(desktop): retain unchanged boundaries on resize

### DIFF
--- a/app/resize_dirty_test.go
+++ b/app/resize_dirty_test.go
@@ -1,0 +1,120 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/gogpu/ui/event"
+	"github.com/gogpu/ui/geometry"
+	"github.com/gogpu/ui/widget"
+)
+
+type fixedSizeResizeChild struct {
+	widget.WidgetBase
+	layoutCalls int
+}
+
+func newFixedSizeResizeChild() *fixedSizeResizeChild {
+	child := &fixedSizeResizeChild{}
+	child.SetVisible(true)
+	child.SetEnabled(true)
+	child.SetRepaintBoundary(true)
+	return child
+}
+
+func (c *fixedSizeResizeChild) Layout(_ widget.Context, _ geometry.Constraints) geometry.Size {
+	c.layoutCalls++
+	return geometry.Sz(50, 50)
+}
+
+func (c *fixedSizeResizeChild) Draw(_ widget.Context, _ widget.Canvas) {}
+
+func (c *fixedSizeResizeChild) Event(_ widget.Context, _ event.Event) bool { return false }
+
+type widthDependentResizeChild struct {
+	widget.WidgetBase
+	layoutCalls int
+}
+
+func newWidthDependentResizeChild() *widthDependentResizeChild {
+	child := &widthDependentResizeChild{}
+	child.SetVisible(true)
+	child.SetEnabled(true)
+	child.SetRepaintBoundary(true)
+	return child
+}
+
+func (c *widthDependentResizeChild) Layout(_ widget.Context, constraints geometry.Constraints) geometry.Size {
+	c.layoutCalls++
+	return constraints.Constrain(geometry.Sz(50, 50))
+}
+
+func (c *widthDependentResizeChild) Draw(_ widget.Context, _ widget.Canvas) {}
+
+func (c *widthDependentResizeChild) Event(_ widget.Context, _ event.Event) bool { return false }
+
+type selectiveResizeRoot struct {
+	widget.WidgetBase
+	fixedChild *fixedSizeResizeChild
+	widthChild *widthDependentResizeChild
+}
+
+func newSelectiveResizeRoot() *selectiveResizeRoot {
+	root := &selectiveResizeRoot{
+		fixedChild: newFixedSizeResizeChild(),
+		widthChild: newWidthDependentResizeChild(),
+	}
+	root.SetVisible(true)
+	root.SetEnabled(true)
+	root.AddChild(root.fixedChild)
+	root.AddChild(root.widthChild)
+	return root
+}
+
+func (r *selectiveResizeRoot) Layout(ctx widget.Context, constraints geometry.Constraints) geometry.Size {
+	size := constraints.Constrain(geometry.Sz(800, 600))
+	widget.LayoutChild(r.fixedChild, ctx, geometry.Tight(geometry.Sz(50, 50)))
+	widget.LayoutChild(r.widthChild, ctx, geometry.Tight(geometry.Sz(size.Width/2, 50)))
+	return size
+}
+
+func (r *selectiveResizeRoot) Draw(_ widget.Context, _ widget.Canvas) {}
+
+func (r *selectiveResizeRoot) Event(_ widget.Context, _ event.Event) bool { return false }
+
+func TestHandleResize_InvalidatesOnlyConstraintChangedBoundaries(t *testing.T) {
+	provider := &mockWindowProvider{width: 800, height: 600, scale: 1}
+	w := New(WithWindowProvider(provider)).Window()
+	t.Cleanup(w.Close)
+	root := newSelectiveResizeRoot()
+	w.SetRoot(root)
+	w.Frame()
+
+	// Model a completed paint: both boundaries and all widget redraw flags
+	// start clean before the resize event arrives.
+	widget.ClearRedrawInTree(root)
+	root.ClearSceneDirty()
+	root.fixedChild.ClearSceneDirty()
+	root.widthChild.ClearSceneDirty()
+	root.fixedChild.layoutCalls = 0
+	root.widthChild.layoutCalls = 0
+
+	provider.width, provider.height = 1024, 768
+	w.HandleResize(provider.width, provider.height)
+	w.Frame()
+
+	if root.fixedChild.layoutCalls != 0 {
+		t.Errorf("fixed-size child Layout called %d times, want 0 for unchanged constraints", root.fixedChild.layoutCalls)
+	}
+	if root.fixedChild.IsSceneDirty() {
+		t.Error("fixed-size child boundary became scene-dirty after unrelated window resize")
+	}
+	if root.widthChild.layoutCalls != 1 {
+		t.Errorf("width-dependent child Layout called %d times, want 1 for changed constraints", root.widthChild.layoutCalls)
+	}
+	if !root.widthChild.IsSceneDirty() {
+		t.Error("width-dependent child boundary remained clean after its constraints changed")
+	}
+	if !root.IsSceneDirty() {
+		t.Error("root boundary remained clean after its window constraints changed")
+	}
+}

--- a/app/resize_dirty_test.go
+++ b/app/resize_dirty_test.go
@@ -118,3 +118,38 @@ func TestHandleResize_InvalidatesOnlyConstraintChangedBoundaries(t *testing.T) {
 		t.Error("root boundary remained clean after its window constraints changed")
 	}
 }
+
+type unsuppressedResizeRoot struct {
+	widget.WidgetBase
+	invalidations int
+}
+
+// Deliberately shadow WidgetBase's suppressor with a different signature to
+// model third-party repaint-boundary implementations that cannot suppress a
+// dirty callback during an in-progress draw.
+func (*unsuppressedResizeRoot) SetSuppressDirtyCallback(int) {}
+
+func (r *unsuppressedResizeRoot) InvalidateScene() {
+	r.invalidations++
+	r.WidgetBase.InvalidateScene()
+}
+
+func (*unsuppressedResizeRoot) Layout(_ widget.Context, c geometry.Constraints) geometry.Size {
+	return c.Constrain(geometry.Sz(10, 10))
+}
+
+func (*unsuppressedResizeRoot) Draw(_ widget.Context, _ widget.Canvas) {}
+
+func (*unsuppressedResizeRoot) Event(_ widget.Context, _ event.Event) bool { return false }
+
+func TestInvalidateRootScene_WithoutDirtySuppressor(t *testing.T) {
+	root := &unsuppressedResizeRoot{}
+	root.SetRepaintBoundary(true)
+	w := &Window{root: root}
+
+	w.invalidateRootScene()
+
+	if root.invalidations != 1 {
+		t.Fatalf("root invalidations = %d, want 1", root.invalidations)
+	}
+}

--- a/app/window.go
+++ b/app/window.go
@@ -499,14 +499,13 @@ func (w *Window) HandleEvent(e event.Event) {
 // HandleResize processes a window resize.
 //
 // This updates the window size and marks layout as needing recalculation.
+// LayoutChild's constraint cache invalidates only widgets whose incoming
+// constraints changed; fixed-size subtrees remain clean across the resize.
 func (w *Window) HandleResize(width, height int) {
 	w.windowSize = geometry.Sz(float32(width), float32(height))
 	w.needsLayout = true
 	w.needsRedraw = true
 	w.needsFullRepaint = true
-	if w.root != nil {
-		widget.MarkRedrawInTree(w.root)
-	}
 }
 
 // HandleScaleChange applies a new display scale and invalidates retained
@@ -978,6 +977,13 @@ func (w *Window) DrawTo(canvas widget.Canvas) bool {
 		return false
 	}
 
+	// Root has no parent to invalidate its cached scene when callers render
+	// directly after a resize without an intervening Frame/layout pass. Keep
+	// this root-only: descendants rely on their own layout and paint dirtiness.
+	if w.needsRedraw || w.needsFullRepaint {
+		w.invalidateRootScene()
+	}
+
 	// Collect dirty regions (always — for RepaintBoundary Intersects fast path).
 	w.dirtyTracker.Reset()
 	w.dirtyCollector.Collect(w.root)
@@ -1004,6 +1010,28 @@ func (w *Window) DrawTo(canvas widget.Canvas) bool {
 	}
 
 	return drawn
+}
+
+// invalidateRootScene marks only the root RepaintBoundary dirty without
+// scheduling another frame while the current draw is already in progress.
+func (w *Window) invalidateRootScene() {
+	type sceneDirtier interface {
+		IsRepaintBoundary() bool
+		InvalidateScene()
+	}
+	sd, ok := w.root.(sceneDirtier)
+	if !ok || !sd.IsRepaintBoundary() {
+		return
+	}
+
+	type dirtySuppressor interface{ SetSuppressDirtyCallback(bool) }
+	if ds, ok := w.root.(dirtySuppressor); ok {
+		ds.SetSuppressDirtyCallback(true)
+		sd.InvalidateScene()
+		ds.SetSuppressDirtyCallback(false)
+		return
+	}
+	sd.InvalidateScene()
 }
 
 // drawHostManaged draws the full widget tree without clearing the canvas.

--- a/desktop/damage_blit_test.go
+++ b/desktop/damage_blit_test.go
@@ -225,7 +225,7 @@ func TestDamageBlitDecision_SpinnerOnly_DamageAware(t *testing.T) {
 }
 
 func TestDamageBlitDecision_FullRedrawNeeded_FullBlit(t *testing.T) {
-	// First frame or resize — always full blit.
+	// First frame or another explicit full redraw — always full blit.
 	rl := &renderLoop{fullRedrawNeeded: true, rootTextureChanged: false}
 	skipRootBlit := !rl.rootTextureChanged && !rl.fullRedrawNeeded
 

--- a/desktop/damage_blit_test.go
+++ b/desktop/damage_blit_test.go
@@ -199,7 +199,7 @@ func TestRootTextureChanged_TrackedCorrectly(t *testing.T) {
 func TestDamageBlitDecision_RootDirty_FullBlit(t *testing.T) {
 	// When root texture changed, should use full blit (not damage-aware).
 	rl := &renderLoop{rootTextureChanged: true}
-	skipRootBlit := !rl.rootTextureChanged && !rl.fullRedrawNeeded
+	skipRootBlit := !rl.requiresFullSurfaceRender()
 
 	if skipRootBlit {
 		t.Error("should NOT skip root blit when root texture changed")
@@ -213,7 +213,7 @@ func TestDamageBlitDecision_SpinnerOnly_DamageAware(t *testing.T) {
 		fullRedrawNeeded:   false,
 		frameDamageRects:   []image.Rectangle{image.Rect(100, 200, 148, 248)},
 	}
-	skipRootBlit := !rl.rootTextureChanged && !rl.fullRedrawNeeded
+	skipRootBlit := !rl.requiresFullSurfaceRender()
 	hasDamage := len(rl.frameDamageRects) > 0
 
 	if !skipRootBlit {
@@ -227,10 +227,10 @@ func TestDamageBlitDecision_SpinnerOnly_DamageAware(t *testing.T) {
 func TestDamageBlitDecision_FullRedrawNeeded_FullBlit(t *testing.T) {
 	// First frame or another explicit full redraw — always full blit.
 	rl := &renderLoop{fullRedrawNeeded: true, rootTextureChanged: false}
-	skipRootBlit := !rl.rootTextureChanged && !rl.fullRedrawNeeded
+	skipRootBlit := !rl.requiresFullSurfaceRender()
 
 	if skipRootBlit {
-		t.Error("should NOT skip root blit on first frame/resize")
+		t.Error("should NOT skip root blit on first frame/full redraw")
 	}
 }
 

--- a/desktop/desktop.go
+++ b/desktop/desktop.go
@@ -159,6 +159,29 @@ type boundaryTexEntry struct {
 	hasClip      bool          // whether clipRect is set
 }
 
+type surfaceResizer interface {
+	Resize(width, height int) error
+}
+
+func (rl *renderLoop) resizeSurface(resizer surfaceResizer, width, height int) bool {
+	if err := resizer.Resize(width, height); err != nil {
+		log.Printf("desktop: canvas.Resize: %v", err)
+		return false
+	}
+	rl.surfaceResizePending = true
+	return true
+}
+
+func (rl *renderLoop) finishSurfaceRender(err error) {
+	if err != nil {
+		log.Printf("desktop: canvas.Render: %v", err)
+		return
+	}
+	// A successful full render has populated the resized surface. Keep the
+	// flag on errors so the next platform redraw retries the frame.
+	rl.surfaceResizePending = false
+}
+
 // needsFrame reports whether the retained compositor has any work to present.
 // Kept as a policy seam so surface-only work cannot accidentally become
 // boundary texture invalidation.
@@ -199,11 +222,8 @@ func (rl *renderLoop) draw(dc *gogpu.Context) { //nolint:gocyclo,cyclop,gocognit
 
 	cw, ch := rl.canvas.Size()
 	if cw != w || ch != h {
-		if err := rl.canvas.Resize(w, h); err != nil {
-			log.Printf("desktop: canvas.Resize: %v", err)
-		} else {
+		if rl.resizeSurface(rl.canvas, w, h) {
 			cw, ch = w, h
-			rl.surfaceResizePending = true
 		}
 		// Boundary texture lifetime follows each boundary's physical size,
 		// not the swapchain size. ensureBoundaryTexture below selectively
@@ -521,13 +541,7 @@ func (rl *renderLoop) draw(dc *gogpu.Context) { //nolint:gocyclo,cyclop,gocognit
 		}
 	} else {
 		// Full blit path: root changed, surface resized, overlays present, or first frame.
-		if err := rl.canvas.Render(dc.RenderTarget()); err != nil {
-			log.Printf("desktop: canvas.Render: %v", err)
-		} else {
-			// A successful full render has populated the resized surface. Keep
-			// the flag on errors so the next platform redraw retries the frame.
-			rl.surfaceResizePending = false
-		}
+		rl.finishSurfaceRender(rl.canvas.Render(dc.RenderTarget()))
 		// Fill ALL ring buffer slots with fullWindow so every swapchain
 		// buffer (up to 4 on Linux Wayland) knows the entire screen
 		// changed. Without this, buffer N-1 from a previous frame has

--- a/desktop/desktop.go
+++ b/desktop/desktop.go
@@ -528,7 +528,7 @@ func (rl *renderLoop) draw(dc *gogpu.Context) { //nolint:gocyclo,cyclop,gocognit
 	if isDebugDamageEnabled() || isDebugDirtyEnabled() {
 		damageBlitEnabled = false
 	}
-	if damageBlitEnabled && skipRootBlit && !hasOverlays && len(rl.frameDamageRects) > 0 { //nolint:nestif // damage blit feature flag path selection
+	if damageBlitEnabled && skipRootBlit && !hasOverlays && len(rl.frameDamageRects) > 0 {
 		// ADR-030: Multi-rect damage-aware path.
 		// Accumulate damage across N swapchain buffers (ring buffer).
 		// Pass individual rects for per-draw dynamic scissor — zero pixel waste

--- a/desktop/desktop.go
+++ b/desktop/desktop.go
@@ -115,6 +115,10 @@ type renderLoop struct {
 	// Clean boundaries: texture reused. Dirty: re-rendered.
 	boundaryTextures map[uint64]*boundaryTexEntry
 	fullRedrawNeeded bool // First frame, before boundary textures exist
+	// A canvas resize clears the surface but does not invalidate retained
+	// boundary textures. Keep the surface work distinct from fullRedrawNeeded,
+	// which deliberately makes every boundary texture dirty.
+	surfaceResizePending bool
 
 	// Damage-aware blit (ADR-030): when only child boundaries changed
 	// (root clean), skip root DrawGPUTextureBase and use
@@ -155,6 +159,20 @@ type boundaryTexEntry struct {
 	hasClip      bool          // whether clipRect is set
 }
 
+// needsFrame reports whether the retained compositor has any work to present.
+// Kept as a policy seam so surface-only work cannot accidentally become
+// boundary texture invalidation.
+func (rl *renderLoop) needsFrame(win *app.Window) bool {
+	return rl.surfaceResizePending || rl.fullRedrawNeeded ||
+		win.NeedsRedraw() || win.HasDirtyBoundaries() || win.NeedsAnimationFrame()
+}
+
+// requiresFullSurfaceRender reports whether the swapchain must be fully
+// recomposed instead of preserving its previous contents with LoadOpLoad.
+func (rl *renderLoop) requiresFullSurfaceRender() bool {
+	return rl.surfaceResizePending || rl.rootTextureChanged || rl.fullRedrawNeeded
+}
+
 // draw is the OnDraw callback registered with gogpu.App.
 //
 // ADR-007 Phase 7: per-boundary GPU textures with damage-aware blit.
@@ -183,11 +201,15 @@ func (rl *renderLoop) draw(dc *gogpu.Context) { //nolint:gocyclo,cyclop,gocognit
 	if cw != w || ch != h {
 		if err := rl.canvas.Resize(w, h); err != nil {
 			log.Printf("desktop: canvas.Resize: %v", err)
+		} else {
+			cw, ch = w, h
+			rl.surfaceResizePending = true
 		}
-		cw, ch = w, h
 		// Boundary texture lifetime follows each boundary's physical size,
 		// not the swapchain size. ensureBoundaryTexture below selectively
-		// replaces only entries whose dimensions changed.
+		// replaces only entries whose dimensions changed. The separate
+		// surfaceResizePending flag still forces the cleared canvas to be
+		// recomposed and presented during platform live-resize ticks.
 	}
 
 	// A display-scale change can leave the logical size unchanged, so it does
@@ -204,6 +226,7 @@ func (rl *renderLoop) draw(dc *gogpu.Context) { //nolint:gocyclo,cyclop,gocognit
 	// No O(n) tree walk needed — the flat dirty set is authoritative.
 	//
 	// Work sources (all O(1)):
+	//   - surfaceResizePending: canvas changed size and needs recomposition
 	//   - fullRedrawNeeded: first frame, before boundary textures exist
 	//   - win.NeedsRedraw(): layout changed, ctx.Invalidate, signal dirty
 	//   - win.HasDirtyBoundaries(): upward propagation → RegisterDirtyBoundary
@@ -212,7 +235,7 @@ func (rl *renderLoop) draw(dc *gogpu.Context) { //nolint:gocyclo,cyclop,gocognit
 	// Flutter equivalent: _hasScheduledFrame || _nodesNeedingPaint.isNotEmpty
 	// Before Phase C: NeedsRedrawInTreeNonBoundary O(n) walked entire tree.
 	// After Phase C: HasDirtyBoundaries O(1) checks map length.
-	needsAnyWork := rl.fullRedrawNeeded || win.NeedsRedraw() || win.HasDirtyBoundaries() || win.NeedsAnimationFrame()
+	needsAnyWork := rl.needsFrame(win)
 	// Dirty widget overlay animation frames are handled by gogpu's
 	// drawDebugOverlays (self-sustaining render loop via RequestRedraw).
 	if isDebugDamageEnabled() && rl.canvas != nil && rl.canvas.NeedsAnimationFrame() {
@@ -229,9 +252,9 @@ func (rl *renderLoop) draw(dc *gogpu.Context) { //nolint:gocyclo,cyclop,gocognit
 	rl.blitCount = 0
 
 	if isDebugDamageEnabled() {
-		log.Printf("[FRAME] #%d needsRedraw=%v dirtyBoundaries=%d animFrame=%v fullRedraw=%v",
+		log.Printf("[FRAME] #%d needsRedraw=%v dirtyBoundaries=%d animFrame=%v fullRedraw=%v surfaceResize=%v",
 			rl.frameCounter, win.NeedsRedraw(), win.DirtyBoundaryCount(),
-			win.NeedsAnimationFrame(), rl.fullRedrawNeeded)
+			win.NeedsAnimationFrame(), rl.fullRedrawNeeded, rl.surfaceResizePending)
 	}
 
 	cc := rl.canvas.Context()
@@ -437,12 +460,13 @@ func (rl *renderLoop) draw(dc *gogpu.Context) { //nolint:gocyclo,cyclop,gocognit
 	// ADR-021 Phase 7: Pass damage rects to gg for partial present.
 	// Chain: ui → gg SetPresentDamage → gogpu SetDamageRects → wgpu PresentWithDamage → OS.
 	//
-	// When root texture changed (full repaint), send full-window damage to the
-	// OS compositor. Wayland compositors use wl_surface.damage_buffer as an
-	// optimization hint — without full damage on full repaint, vacated areas
-	// (e.g. collapsed content) may show stale pixels on the physical display
-	// because the compositor doesn't know those pixels changed.
-	if rl.rootTextureChanged || rl.fullRedrawNeeded {
+	// When the root texture changed or the canvas resized, send full-window
+	// damage to the OS compositor. Wayland compositors use
+	// wl_surface.damage_buffer as an optimization hint — without full damage
+	// on full repaint, vacated areas (e.g. collapsed content) may show stale
+	// pixels on the physical display because the compositor doesn't know those
+	// pixels changed.
+	if rl.requiresFullSurfaceRender() {
 		rl.canvas.SetPresentDamage([]image.Rectangle{
 			image.Rect(0, 0, cw, ch),
 		})
@@ -463,7 +487,7 @@ func (rl *renderLoop) draw(dc *gogpu.Context) { //nolint:gocyclo,cyclop,gocognit
 	// content preserved. Fallback to full Render when root changed or overlays present.
 	rl.canvas.MarkDirty()
 
-	skipRootBlit := !rl.rootTextureChanged && !rl.fullRedrawNeeded
+	skipRootBlit := !rl.requiresFullSurfaceRender()
 	hasOverlays := win.HasOverlays()
 
 	// Damage-aware blit: enabled by default (ADR-007 Phase 7, TASK-UI-OPT-003).
@@ -496,9 +520,13 @@ func (rl *renderLoop) draw(dc *gogpu.Context) { //nolint:gocyclo,cyclop,gocognit
 			log.Printf("desktop: RenderDirectWithDamageRects: %v", err)
 		}
 	} else {
-		// Full blit path: root changed, overlays present, or first frame.
+		// Full blit path: root changed, surface resized, overlays present, or first frame.
 		if err := rl.canvas.Render(dc.RenderTarget()); err != nil {
 			log.Printf("desktop: canvas.Render: %v", err)
+		} else {
+			// A successful full render has populated the resized surface. Keep
+			// the flag on errors so the next platform redraw retries the frame.
+			rl.surfaceResizePending = false
 		}
 		// Fill ALL ring buffer slots with fullWindow so every swapchain
 		// buffer (up to 4 on Linux Wayland) knows the entire screen

--- a/desktop/desktop.go
+++ b/desktop/desktop.go
@@ -114,7 +114,7 @@ type renderLoop struct {
 	// Each boundary rendered into its own offscreen texture.
 	// Clean boundaries: texture reused. Dirty: re-rendered.
 	boundaryTextures map[uint64]*boundaryTexEntry
-	fullRedrawNeeded bool // First frame, resize, theme change
+	fullRedrawNeeded bool // First frame, before boundary textures exist
 
 	// Damage-aware blit (ADR-030): when only child boundaries changed
 	// (root clean), skip root DrawGPUTextureBase and use
@@ -135,7 +135,7 @@ type renderLoop struct {
 
 	// Persistent layer tree (D5). Survives across frames; UpdateLayerTree
 	// reuses PictureLayerImpl/OffsetLayerImpl objects for unchanged boundaries.
-	// Nil on first frame or after releaseBoundaryTextures (resize, close).
+	// Nil on first frame or after releaseBoundaryTextures (close).
 	layerTree *compositor.OffsetLayerImpl
 
 	// Diagnostic counters (reset each frame, logged with GOGPU_DEBUG_DAMAGE=1).
@@ -185,8 +185,9 @@ func (rl *renderLoop) draw(dc *gogpu.Context) { //nolint:gocyclo,cyclop,gocognit
 			log.Printf("desktop: canvas.Resize: %v", err)
 		}
 		cw, ch = w, h
-		rl.releaseBoundaryTextures()
-		rl.fullRedrawNeeded = true
+		// Boundary texture lifetime follows each boundary's physical size,
+		// not the swapchain size. ensureBoundaryTexture below selectively
+		// replaces only entries whose dimensions changed.
 	}
 
 	// A display-scale change can leave the logical size unchanged, so it does
@@ -203,7 +204,7 @@ func (rl *renderLoop) draw(dc *gogpu.Context) { //nolint:gocyclo,cyclop,gocognit
 	// No O(n) tree walk needed — the flat dirty set is authoritative.
 	//
 	// Work sources (all O(1)):
-	//   - fullRedrawNeeded: resize, first frame, texture release
+	//   - fullRedrawNeeded: first frame, before boundary textures exist
 	//   - win.NeedsRedraw(): layout changed, ctx.Invalidate, signal dirty
 	//   - win.HasDirtyBoundaries(): upward propagation → RegisterDirtyBoundary
 	//   - win.NeedsAnimationFrame(): spinner ScheduleAnimationFrame
@@ -728,7 +729,6 @@ func (rl *renderLoop) ensureBoundaryTexture(key uint64, bw, bh int, cc *gg.Conte
 		tex, release := cc.CreateOffscreenTexture(pw, ph)
 		entry = &boundaryTexEntry{texture: tex, release: release, width: pw, height: ph}
 		rl.boundaryTextures[key] = entry
-		rl.fullRedrawNeeded = true
 	}
 	return entry
 }

--- a/desktop/resize_surface_e2e_test.go
+++ b/desktop/resize_surface_e2e_test.go
@@ -1,0 +1,134 @@
+//go:build !nogpu
+
+package desktop
+
+import (
+	"errors"
+	"reflect"
+	"sync"
+	"testing"
+	"unsafe"
+
+	"github.com/gogpu/gg/integration/ggcanvas"
+	"github.com/gogpu/gogpu"
+	"github.com/gogpu/gputypes"
+	"github.com/gogpu/ui/app"
+	"github.com/gogpu/ui/primitives"
+	"github.com/gogpu/wgpu"
+)
+
+// setPrivateTestField wires gogpu's public objects into a headless software
+// render target. gogpu does not currently expose a headless Context constructor.
+func setPrivateTestField(target any, name string, value any) {
+	v := reflect.ValueOf(target).Elem().FieldByName(name)
+	reflect.NewAt(v.Type(), unsafe.Pointer(v.UnsafeAddr())).Elem().Set(reflect.ValueOf(value))
+}
+
+// TestRenderLoop_SurfaceResizeRetainsBoundaryTextures exercises the actual draw
+// orchestration against wgpu's software backend. It verifies that a resized
+// surface is fully recomposed while an unchanged child boundary keeps its
+// retained texture entry.
+func TestRenderLoop_SurfaceResizeRetainsBoundaryTextures(t *testing.T) {
+	t.Setenv("GOGPU_DEBUG_DAMAGE", "overlay")
+	debugDamageOnce = sync.Once{}
+	t.Cleanup(func() {
+		debugDamageOnce = sync.Once{}
+		debugDamageEnabled = false
+	})
+
+	device, _, cleanup := createSoftwareDevice(t)
+	t.Cleanup(cleanup)
+
+	const surfaceSize = 100
+	texture, err := device.CreateTexture(&wgpu.TextureDescriptor{
+		Label: "resize-surface-e2e",
+		Size: wgpu.Extent3D{
+			Width: surfaceSize, Height: surfaceSize, DepthOrArrayLayers: 1,
+		},
+		MipLevelCount: 1,
+		SampleCount:   1,
+		Dimension:     wgpu.TextureDimension2D,
+		Format:        gputypes.TextureFormatRGBA8Unorm,
+		Usage:         wgpu.TextureUsageRenderAttachment,
+	})
+	if err != nil {
+		t.Fatalf("create surface texture: %v", err)
+	}
+	t.Cleanup(texture.Release)
+	view, err := device.CreateTextureView(texture, nil)
+	if err != nil {
+		t.Fatalf("create surface view: %v", err)
+	}
+	t.Cleanup(view.Release)
+
+	renderer := &gogpu.Renderer{}
+	target := &gogpu.RenderTarget{}
+	setPrivateTestField(renderer, "device", device)
+	setPrivateTestField(renderer, "surfaceFormat", gputypes.TextureFormatRGBA8Unorm)
+	setPrivateTestField(renderer, "primary", target)
+	setPrivateTestField(target, "renderer", renderer)
+	setPrivateTestField(target, "format", gputypes.TextureFormatRGBA8Unorm)
+	setPrivateTestField(target, "width", uint32(surfaceSize))
+	setPrivateTestField(target, "height", uint32(surfaceSize))
+	setPrivateTestField(target, "currentView", view)
+	setPrivateTestField(target, "frameStarted", true)
+
+	drawContext := &gogpu.Context{}
+	setPrivateTestField(drawContext, "renderer", renderer)
+	setPrivateTestField(drawContext, "scaleFactor", 1.0)
+
+	gogpuApp := gogpu.NewApp(gogpu.DefaultConfig().WithSize(surfaceSize, surfaceSize))
+	setPrivateTestField(gogpuApp, "renderer", renderer)
+	uiApp := app.New(
+		app.WithWindowProvider(gogpuApp),
+		app.WithPlatformProvider(gogpuApp),
+	)
+	uiApp.SetRoot(primitives.Box(
+		primitives.NewRepaintBoundary(primitives.Box().Width(20).Height(20)),
+	).Width(surfaceSize).Height(surfaceSize))
+
+	canvas, err := ggcanvas.New(gogpuApp.GPUContextProvider(), 80, 80)
+	if err != nil {
+		t.Fatalf("create initial canvas: %v", err)
+	}
+	t.Cleanup(func() { _ = canvas.Close() })
+
+	rl := &renderLoop{
+		gogpuApp: gogpuApp,
+		uiApp:    uiApp,
+		canvas:   canvas,
+	}
+	rl.draw(drawContext)
+
+	if rl.surfaceResizePending {
+		t.Error("successful full render left surface resize pending")
+	}
+	if gotW, gotH := canvas.Size(); gotW != surfaceSize || gotH != surfaceSize {
+		t.Fatalf("canvas size = %dx%d, want %dx%d", gotW, gotH, surfaceSize, surfaceSize)
+	}
+	if len(rl.boundaryTextures) == 0 {
+		t.Fatal("full recomposition did not populate the retained boundary cache")
+	}
+
+}
+
+type failingSurfaceResizer struct{ err error }
+
+func (r failingSurfaceResizer) Resize(_, _ int) error { return r.err }
+
+func TestRenderLoop_SurfaceFailuresRemainPending(t *testing.T) {
+	wantErr := errors.New("injected surface failure")
+	rl := &renderLoop{}
+	if rl.resizeSurface(failingSurfaceResizer{err: wantErr}, 120, 80) {
+		t.Fatal("failed resize reported success")
+	}
+	if rl.surfaceResizePending {
+		t.Error("failed resize marked an unresized surface pending")
+	}
+
+	rl.surfaceResizePending = true
+	rl.finishSurfaceRender(wantErr)
+	if !rl.surfaceResizePending {
+		t.Error("failed render cleared the pending resize retry")
+	}
+}

--- a/desktop/resize_surface_e2e_test.go
+++ b/desktop/resize_surface_e2e_test.go
@@ -109,7 +109,6 @@ func TestRenderLoop_SurfaceResizeRetainsBoundaryTextures(t *testing.T) {
 	if len(rl.boundaryTextures) == 0 {
 		t.Fatal("full recomposition did not populate the retained boundary cache")
 	}
-
 }
 
 type failingSurfaceResizer struct{ err error }

--- a/desktop/resize_texture_test.go
+++ b/desktop/resize_texture_test.go
@@ -1,0 +1,81 @@
+package desktop
+
+import (
+	"testing"
+
+	"github.com/gogpu/gg"
+	"github.com/gogpu/ui/compositor"
+)
+
+func TestEnsureBoundaryTexture_DoesNotDirtyCleanSibling(t *testing.T) {
+	ctx := gg.NewContext(800, 600)
+	t.Cleanup(func() {
+		if err := ctx.Close(); err != nil {
+			t.Errorf("close context: %v", err)
+		}
+	})
+	rl := &renderLoop{
+		boundaryTextures: map[uint64]*boundaryTexEntry{
+			2: {width: 50, height: 50, sceneVersion: 3},
+		},
+	}
+
+	// Allocating the resized root texture must invalidate only that entry,
+	// not every boundary consulted later in the same tree walk.
+	rootEntry := rl.ensureBoundaryTexture(1, 800, 600, ctx)
+	if rl.fullRedrawNeeded {
+		t.Fatal("allocating one boundary texture forced a full-tree redraw")
+	}
+
+	rootPic := compositor.NewPictureLayer()
+	rootPic.SetSceneVersion(1)
+	rootPic.ClearDirty()
+	if rl.isBoundaryClean(rootEntry, rootPic, dummyScene()) {
+		t.Error("fresh root texture was considered clean before its first render")
+	}
+
+	siblingPic := compositor.NewPictureLayer()
+	siblingPic.SetSceneVersion(3)
+	siblingPic.ClearDirty()
+	if !rl.isBoundaryClean(rl.boundaryTextures[2], siblingPic, dummyScene()) {
+		t.Error("unchanged sibling texture became dirty when another boundary was allocated")
+	}
+}
+
+func TestEnsureBoundaryTexture_ReleasesOnlySizeChangedEntry(t *testing.T) {
+	ctx := gg.NewContext(800, 600)
+	t.Cleanup(func() {
+		if err := ctx.Close(); err != nil {
+			t.Errorf("close context: %v", err)
+		}
+	})
+	releases := 0
+	existing := &boundaryTexEntry{
+		width:   50,
+		height:  50,
+		release: func() { releases++ },
+	}
+	rl := &renderLoop{
+		boundaryTextures: map[uint64]*boundaryTexEntry{
+			1: existing,
+			2: {width: 25, height: 25, release: func() { releases++ }},
+		},
+	}
+
+	if got := rl.ensureBoundaryTexture(1, 50, 50, ctx); got != existing {
+		t.Error("same-size boundary replaced its retained texture entry")
+	}
+	if releases != 0 {
+		t.Fatalf("same-size boundary released %d textures, want 0", releases)
+	}
+
+	if got := rl.ensureBoundaryTexture(1, 75, 50, ctx); got == existing {
+		t.Error("size-changed boundary retained its stale texture entry")
+	}
+	if releases != 1 {
+		t.Fatalf("size change released %d textures, want only the changed entry", releases)
+	}
+	if rl.boundaryTextures[2] == nil {
+		t.Error("unrelated boundary texture entry was discarded")
+	}
+}

--- a/desktop/resize_texture_test.go
+++ b/desktop/resize_texture_test.go
@@ -4,8 +4,35 @@ import (
 	"testing"
 
 	"github.com/gogpu/gg"
+	"github.com/gogpu/ui/app"
 	"github.com/gogpu/ui/compositor"
 )
+
+func TestSurfaceResizePending_ForcesFullSurfaceFrameWithoutDirtyingBoundaries(t *testing.T) {
+	win := app.New().Window()
+	win.ClearAfterPaint()
+	win.ClearDirtyBoundaries()
+	win.ClearAnimationFrame()
+	if win.NeedsRedraw() || win.HasDirtyBoundaries() || win.NeedsAnimationFrame() {
+		t.Fatal("test window is not clean")
+	}
+
+	rl := &renderLoop{surfaceResizePending: true}
+	if !rl.needsFrame(win) {
+		t.Error("a clean window skipped the frame required by a canvas resize")
+	}
+	if !rl.requiresFullSurfaceRender() {
+		t.Error("a canvas resize did not require full surface composition")
+	}
+
+	entry := &boundaryTexEntry{sceneVersion: 3}
+	pic := compositor.NewPictureLayer()
+	pic.SetSceneVersion(3)
+	pic.ClearDirty()
+	if !rl.isBoundaryClean(entry, pic, dummyScene()) {
+		t.Error("surface-only resize invalidated an unchanged boundary texture")
+	}
+}
 
 func TestEnsureBoundaryTexture_DoesNotDirtyCleanSibling(t *testing.T) {
 	ctx := gg.NewContext(800, 600)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -905,7 +905,7 @@ Key functions:
 - `HasDirtyBoundaries()` -- O(1) flat dirty set check for frame skip
 - `recordBoundary(w, ctx)` -- records scene with DrawChild skip for child boundaries
 - `widget.ClearRedrawInTree(w)` -- clears all flags recursively
-- `widget.MarkRedrawInTree(w)` -- marks all widgets dirty (used by resize, theme change)
+- `widget.MarkRedrawInTree(w)` -- marks all widgets dirty (used by root replacement or theme changes)
 - `widget.NeedsRedrawInTree(w)` -- checks if any descendant needs redraw
 
 ### Canvas Implementation

--- a/docs/RENDER-PIPELINE.md
+++ b/docs/RENDER-PIPELINE.md
@@ -79,6 +79,8 @@ Recursively walks the widget tree (`paintBoundaryWithDepth`). Each dirty+visible
 
 **DrawChild skip pattern:** During recording, child boundaries are SKIPPED — they have their own GPU textures. The parent scene contains only non-boundary children (text, backgrounds, dividers).
 
+**Draw invariant:** A widget's drawing must be a function of its bounds and widget state. Window size belongs in layout constraints or an explicit signal, not a direct read from `Draw`; resize invalidates only boundaries whose layout or state actually changed.
+
 ### Step 5: Paint Overlay Boundaries
 
 ```
@@ -212,7 +214,7 @@ GOGPU_DAMAGE_BLIT=0 go run ./examples/gallery/
 | Spinner animating | 48×48 scissor blit at 30fps |
 | Spinner scrolled offscreen | 0% — boundary culled |
 | Dropdown open | Overlay boundary + scrim |
-| Window resize | Full redraw (all boundaries) |
+| Window resize | Root plus size-changed/reflowed boundaries; fixed-size boundary textures retained |
 
 ## Enterprise References
 

--- a/widget/redraw.go
+++ b/widget/redraw.go
@@ -112,9 +112,9 @@ func ClearRedrawInTree(w Widget) {
 // MarkRedrawInTree sets the needsRedraw flag on all widgets in the
 // subtree rooted at w.
 //
-// This is used when a full redraw is required, such as after SetRoot,
-// theme changes, or window resize. It ensures the next draw pass will
-// render all widgets.
+// This is used when every widget's visual state may have changed, such as
+// after SetRoot or a theme change. It ensures the next draw pass will render
+// all widgets.
 func MarkRedrawInTree(w Widget) {
 	if w == nil {
 		return


### PR DESCRIPTION
## Summary

- stop marking the entire widget tree dirty on every window resize
- retain repaint-boundary textures and the persistent layer tree when their own sizes remain unchanged
- keep a separate surface-resize work signal so clean macOS live-resize ticks still fully compose and present
- invalidate only the root scene for direct post-resize rendering while normal constraint changes dirty affected descendants
- add deterministic regressions for fixed-size cache reuse, constraint-driven invalidation, and selective texture replacement

## Why

Window resizing currently dirties every repaint boundary and releases every cached boundary texture, even when most boundaries keep the same dimensions. Allocating or resizing one boundary texture also contaminates the frame-global full-redraw flag. Together these behaviors defeat retained rendering and cause avoidable GPU allocation churn during live resize.

This change makes texture lifetime follow each boundary's physical size. Layout's existing constraint cache remains responsible for dirtying descendants whose constraints genuinely change, while unchanged fixed-size subtrees reuse their recorded scene and texture.

Canvas resize remains a distinct surface-only work reason. It admits an otherwise-clean live-resize frame and forces full-surface composition/damage without feeding root or child scene dirtiness, then clears only after a successful full render.

## Verification

- `go test ./... -count=1`
- `go test -race ./app ./desktop ./widget`
- focused resize regressions repeated 20 times
- `go build ./...`
- `go vet ./...`
- `git diff --check`

The broad repository race run still reports the pre-existing animation-pumper test race in `mockWindowProvider.RequestRedraw`; all other packages and the changed paths pass. Live Metal/RSS validation was not available in this environment.

This is intentionally separate from #172, which handles cross-display device-scale changes and may require a small rebase after either PR merges.

Fixes #176

### Local CI and Codecov preflight

- rebased onto current `main` (`273cc1e`) and the prior conflict resolved while preserving the upstream pluggable debug-overlay path
- `go test ./... -count=1` with a full coverage profile: pass
- focused resize/render tests and desktop race suite: pass; the broad app race remains blocked only by the pre-existing `TestWindow_AnimPumper_StartsOnInvalidation` mock race noted above
- `go build ./...`, `go vet ./...`, `gofmt`, and diff checks: pass
- local Codecov-equivalent changed-production coverage: **39/39 statements (100%)** (`app/window.go` 13/13, `desktop/desktop.go` 26/26); overall coverage 87.0%

Upstream CI run approval is still external to this branch: GitHub marked the fork workflow `action_required` with zero jobs (run `31435378503`). A `gogpu` maintainer must approve the workflow before Actions and the configured Codecov upload/bot can run.

## Review follow-up (2026-08-12)

Removed the obsolete `//nolint:nestif` suppression and the stray blank line, then rebased onto current `main`.
