### PR TITLE
fix(app): keep pointer events within window bounds

### DIFF
--- a/app/app_test.go
+++ b/app/app_test.go
@@ -139,6 +139,18 @@ func (m *mockEventSource) OnPointer(fn func(gpucontext.PointerEvent)) {
 	m.onPointer = fn
 }
 
+// mockScrollEventSource exercises the detailed, position-carrying scroll
+// path. Keep it separate from mockEventSource because the bridge registers
+// either OnScrollEvent or OnScroll, never both.
+type mockScrollEventSource struct {
+	mockEventSource
+	onScrollEvent func(gpucontext.ScrollEvent)
+}
+
+func (m *mockScrollEventSource) OnScrollEvent(fn func(gpucontext.ScrollEvent)) {
+	m.onScrollEvent = fn
+}
+
 // --- App tests ---
 
 func TestNewApp_Headless(t *testing.T) {

--- a/app/event_bridge.go
+++ b/app/event_bridge.go
@@ -6,6 +6,68 @@ import (
 	"github.com/gogpu/ui/geometry"
 )
 
+// eventBridgeState is shared by the platform callbacks installed by
+// attachEventBridge. EventSource callbacks run on the UI thread, so the state
+// does not need synchronization.
+type eventBridgeState struct {
+	pressedButtons  event.ButtonState
+	lastMousePos    geometry.Point
+	cursorInside    bool
+	leaveDispatched bool
+	mods            event.Modifiers
+}
+
+// pointInWindow reports whether pos is inside the window's logical content
+// bounds. A size can be unavailable briefly during window creation; preserve
+// event delivery until the first real size arrives in that case.
+func pointInWindow(w *Window, pos geometry.Point) bool {
+	size := w.WindowSize()
+	if size.IsEmpty() {
+		return true
+	}
+	return geometry.FromPointSize(geometry.Point{}, size).Contains(pos)
+}
+
+// handleBridgeMouseMove rejects ordinary mouse movement outside the window.
+// A held button bypasses the gate so pointer capture and drag tracking keep
+// receiving moves after the pointer crosses the window edge.
+func handleBridgeMouseMove(w *Window, state *eventBridgeState, x, y float64) {
+	pos := geometry.Pt(float32(x), float32(y))
+	inside := pointInWindow(w, pos)
+	if !inside && state.pressedButtons == 0 {
+		if state.cursorInside {
+			// Some platforms keep sending moves in a narrow area outside the
+			// window without first sending PointerLeave. Synthesize one leave
+			// on the transition so widget hover and cursor state are cleared.
+			state.cursorInside = false
+			state.leaveDispatched = true
+			w.HandleEvent(event.NewMouseEvent(
+				event.MouseLeave,
+				event.ButtonNone,
+				state.pressedButtons,
+				pos,
+				pos,
+				state.mods,
+			))
+		}
+		return
+	}
+
+	state.cursorInside = inside
+	if inside {
+		state.leaveDispatched = false
+	}
+	state.lastMousePos = pos
+	w.HandleEvent(event.NewMouseEvent(
+		event.MouseMove,
+		event.ButtonNone,
+		state.pressedButtons,
+		pos,
+		pos, // global position same as local for root dispatch
+		state.mods,
+	))
+}
+
 // attachEventBridge registers event callbacks on the EventSource that
 // translate platform events into ui/event types and dispatch them to
 // the Window.
@@ -13,49 +75,33 @@ import (
 // This function is called once during App creation when an EventSource
 // is provided. The callbacks are invoked on the main thread by the host
 // application's event loop.
+//
+// Window-bound checks belong here: Window.HandleEvent also serves the public
+// App.HandleEvent API and uitest, whose caller-supplied coordinates must remain
+// available for synthetic input.
 func attachEventBridge(es gpucontext.EventSource, w *Window) {
-	// Track which mouse buttons are currently pressed so that MouseMove
-	// events carry accurate ButtonState. Without this, widgets that rely
-	// on drag state (e.g., scrollbar thumb dragging) cannot detect a
-	// "lost" MouseRelease (e.g., released outside widget bounds).
-	var pressedButtons event.ButtonState
-
-	// Track last known mouse position so WheelEvents carry correct position
-	// (the platform's OnScroll callback doesn't provide mouse coordinates).
-	var lastMousePos geometry.Point
-
-	// Track the keyboard modifiers so mouse and wheel events can carry them.
-	// The platform's mouse callbacks report only a button and a position, so
-	// without this every MouseEvent is built with ModNone and ⌥click, ⇧click,
-	// ⌃click and shift-extend-selection are simply not expressible — an app
-	// either does without them or reimplements this tracking itself.
-	var mods event.Modifiers
+	state := &eventBridgeState{}
 
 	es.OnMouseMove(func(x, y float64) {
-		pos := geometry.Pt(float32(x), float32(y))
-		lastMousePos = pos
-		e := event.NewMouseEvent(
-			event.MouseMove,
-			event.ButtonNone,
-			pressedButtons,
-			pos,
-			pos, // global position same as local for root dispatch
-			mods,
-		)
-		w.HandleEvent(e)
+		handleBridgeMouseMove(w, state, x, y)
 	})
 
 	es.OnMousePress(func(button gpucontext.MouseButton, x, y float64) {
 		pos := geometry.Pt(float32(x), float32(y))
 		btn := translateMouseButton(button)
-		pressedButtons |= buttonToState(btn)
+		state.pressedButtons |= buttonToState(btn)
+		state.cursorInside = pointInWindow(w, pos)
+		if state.cursorInside {
+			state.leaveDispatched = false
+		}
+		state.lastMousePos = pos
 		e := event.NewMouseEvent(
 			event.MousePress,
 			btn,
-			pressedButtons,
+			state.pressedButtons,
 			pos,
 			pos,
-			mods,
+			state.mods,
 		)
 		w.HandleEvent(e)
 	})
@@ -63,14 +109,19 @@ func attachEventBridge(es gpucontext.EventSource, w *Window) {
 	es.OnMouseRelease(func(button gpucontext.MouseButton, x, y float64) {
 		pos := geometry.Pt(float32(x), float32(y))
 		btn := translateMouseButton(button)
-		pressedButtons &^= buttonToState(btn)
+		state.pressedButtons &^= buttonToState(btn)
+		state.cursorInside = pointInWindow(w, pos)
+		if state.cursorInside {
+			state.leaveDispatched = false
+		}
+		state.lastMousePos = pos
 		e := event.NewMouseEvent(
 			event.MouseRelease,
 			btn,
-			pressedButtons,
+			state.pressedButtons,
 			pos,
 			pos,
-			mods,
+			state.mods,
 		)
 		w.HandleEvent(e)
 	})
@@ -82,7 +133,7 @@ func attachEventBridge(es gpucontext.EventSource, w *Window) {
 		// alone reports no Shift. Fold the key itself in, or holding a modifier
 		// and clicking — with no other key in between, which is the whole
 		// gesture — would leave the state empty.
-		mods = uiMods | modifierForKey(uiKey)
+		state.mods = uiMods | modifierForKey(uiKey)
 		// Rune=0: character input is delivered separately via OnTextInput.
 		// KeyPress only carries the key code for navigation (arrows, Tab,
 		// Backspace, etc.) and modifier detection (Ctrl+C, etc.).
@@ -99,7 +150,7 @@ func attachEventBridge(es gpucontext.EventSource, w *Window) {
 		uiKey := translateKey(key)
 		uiMods := translateModifiers(platMods)
 		// Releasing a modifier clears it: the reported state still contains it.
-		mods = uiMods &^ modifierForKey(uiKey)
+		state.mods = uiMods &^ modifierForKey(uiKey)
 		e := event.NewKeyEvent(
 			event.KeyRelease,
 			uiKey,
@@ -121,16 +172,7 @@ func attachEventBridge(es gpucontext.EventSource, w *Window) {
 		}
 	})
 
-	es.OnScroll(func(dx, dy float64) {
-		delta := geometry.Pt(float32(dx), float32(dy))
-		e := event.NewWheelEvent(
-			delta,
-			lastMousePos,
-			lastMousePos,
-			mods,
-		)
-		w.HandleEvent(e)
-	})
+	attachScrollBridge(es, w, state)
 
 	es.OnResize(func(width, height int) {
 		w.HandleResize(width, height)
@@ -140,12 +182,68 @@ func attachEventBridge(es gpucontext.EventSource, w *Window) {
 		// A modifier believed to be held after the window lost focus would turn
 		// the next ordinary click into a modified one: the release happened
 		// somewhere else and this window never saw it.
-		mods = event.ModNone
+		state.mods = event.ModNone
+		if !focused {
+			// Focus loss does not guarantee matching mouse releases or a
+			// PointerLeave. Reset bridge ownership at this boundary; otherwise
+			// stale buttons would bypass the outside-window gate indefinitely.
+			state.pressedButtons = 0
+			state.cursorInside = false
+		}
 		w.HandleFocusChange(focused)
 	})
 
 	// Wire W3C Pointer Events for Enter/Leave (cursor/hover support).
-	attachPointerBridge(es, w, &pressedButtons, &lastMousePos)
+	attachPointerBridge(es, w, state)
+}
+
+// attachScrollBridge prefers ScrollEventSource because it reports the pointer
+// position for each wheel event. The basic EventSource callback has no
+// position, so it falls back to the last pointer position and cursor state.
+func attachScrollBridge(es gpucontext.EventSource, w *Window, state *eventBridgeState) {
+	if scrollSource, ok := es.(gpucontext.ScrollEventSource); ok {
+		scrollSource.OnScrollEvent(func(scroll gpucontext.ScrollEvent) {
+			pos := geometry.Pt(float32(scroll.X), float32(scroll.Y))
+			inside := pointInWindow(w, pos)
+			zeroWithoutPosition := pos.IsZero() &&
+				(!state.cursorInside || !state.lastMousePos.IsZero())
+			if !inside || zeroWithoutPosition {
+				// A few EventSource implementations historically reported wheel
+				// positions in the wrong coordinate space, or as (0,0). Treat the
+				// position as untrusted unless the independently tracked cursor
+				// state (or an active drag) confirms that the event belongs here.
+				if !state.cursorInside && state.pressedButtons == 0 {
+					return
+				}
+				pos = state.lastMousePos
+			}
+
+			delta := geometry.Pt(float32(scroll.DeltaX), float32(scroll.DeltaY))
+			w.HandleEvent(event.NewWheelEvent(
+				delta,
+				pos,
+				pos,
+				translateModifiers(scroll.Modifiers),
+			))
+		})
+		// gogpu dispatches a detailed scroll event to both its detailed and
+		// legacy callbacks. Register exactly one to avoid duplicate wheels.
+		return
+	}
+
+	es.OnScroll(func(dx, dy float64) {
+		if !state.cursorInside && state.pressedButtons == 0 {
+			return
+		}
+
+		delta := geometry.Pt(float32(dx), float32(dy))
+		w.HandleEvent(event.NewWheelEvent(
+			delta,
+			state.lastMousePos,
+			state.lastMousePos,
+			state.mods,
+		))
+	})
 }
 
 // attachPointerBridge wires W3C PointerEventSource for Enter/Leave events.
@@ -155,28 +253,31 @@ func attachEventBridge(es gpucontext.EventSource, w *Window) {
 // hover state when the mouse exits the window entirely.
 //
 // PointerMove/Down/Up are already handled by the legacy OnMouseMove,
-// OnMousePress, and OnMouseRelease callbacks, so only Enter and Leave
-// are handled here to avoid duplicate event dispatch.
-func attachPointerBridge(
-	es gpucontext.EventSource,
-	w *Window,
-	pressedButtons *event.ButtonState,
-	lastMousePos *geometry.Point,
-) {
+// OnMousePress, and OnMouseRelease callbacks. Enter, Leave, and Cancel are
+// handled here because the legacy EventSource has no equivalent callbacks.
+func attachPointerBridge(es gpucontext.EventSource, w *Window, state *eventBridgeState) {
 	pes, ok := es.(gpucontext.PointerEventSource)
 	if !ok {
 		return
 	}
 
 	pes.OnPointer(func(ev gpucontext.PointerEvent) {
+		// Legacy mouse state and cursor hover must not be changed by an
+		// independent touch or pen pointer.
+		if ev.PointerType != gpucontext.PointerTypeMouse {
+			return
+		}
+
 		switch ev.Type {
 		case gpucontext.PointerEnter:
 			pos := geometry.Pt(float32(ev.X), float32(ev.Y))
-			*lastMousePos = pos
+			state.cursorInside = true
+			state.leaveDispatched = false
+			state.lastMousePos = pos
 			e := event.NewMouseEvent(
 				event.MouseEnter,
 				event.ButtonNone,
-				*pressedButtons,
+				state.pressedButtons,
 				pos, pos,
 				translateModifiers(ev.Modifiers),
 			)
@@ -184,14 +285,27 @@ func attachPointerBridge(
 
 		case gpucontext.PointerLeave:
 			pos := geometry.Pt(float32(ev.X), float32(ev.Y))
+			state.cursorInside = false
+			if state.leaveDispatched {
+				return
+			}
+			state.leaveDispatched = true
 			e := event.NewMouseEvent(
 				event.MouseLeave,
 				event.ButtonNone,
-				*pressedButtons,
+				state.pressedButtons,
 				pos, pos,
 				translateModifiers(ev.Modifiers),
 			)
 			w.HandleEvent(e)
+
+		case gpucontext.PointerCancel:
+			// The platform has ended the gesture without guaranteeing legacy
+			// mouse-release callbacks. Drop bridge and window capture state, then
+			// fail closed until a new pointer event establishes cursor state.
+			state.pressedButtons = 0
+			state.cursorInside = false
+			w.cancelPointerState()
 		}
 	})
 }

--- a/app/event_bridge_test.go
+++ b/app/event_bridge_test.go
@@ -9,6 +9,19 @@ import (
 	"github.com/gogpu/ui/widget"
 )
 
+func newBoundedEventBridgeRoot(es gpucontext.EventSource) *mockWidget {
+	wp := &mockWindowProvider{width: 400, height: 300, scale: 1}
+	a := New(WithWindowProvider(wp), WithEventSource(es))
+	root := newMockWidget()
+	a.SetRoot(root)
+	return root
+}
+
+func resetEventBridgeRoot(root *mockWidget) {
+	root.eventCalled = false
+	root.lastEvent = nil
+}
+
 func TestEventBridge_MouseMove(t *testing.T) {
 	es := &mockEventSource{}
 	a := New(WithEventSource(es))
@@ -30,6 +43,79 @@ func TestEventBridge_MouseMove(t *testing.T) {
 	}
 	if me.Position.X != 100.0 || me.Position.Y != 200.0 {
 		t.Errorf("position = %v, want (100, 200)", me.Position)
+	}
+}
+
+func TestEventBridge_MouseMoveOutsideWindow(t *testing.T) {
+	es := &mockEventSource{}
+	root := newBoundedEventBridgeRoot(es)
+
+	es.onMouseMove(450, 100)
+
+	if root.eventCalled {
+		t.Errorf("outside move dispatched %T, want no event", root.lastEvent)
+	}
+}
+
+func TestEventBridge_MouseMoveOutsideSynthesizesOneLeave(t *testing.T) {
+	es := &mockEventSource{}
+	root := newBoundedEventBridgeRoot(es)
+
+	es.onMouseMove(100, 100)
+	resetEventBridgeRoot(root)
+	es.onMouseMove(450, 100)
+
+	leave, ok := root.lastEvent.(*event.MouseEvent)
+	if !ok || leave.MouseType != event.MouseLeave {
+		t.Fatalf("inside-to-outside event = %T %#v, want MouseLeave", root.lastEvent, root.lastEvent)
+	}
+
+	resetEventBridgeRoot(root)
+	es.onMouseMove(460, 100)
+	if root.eventCalled {
+		t.Errorf("second outside move dispatched %T, want no event", root.lastEvent)
+	}
+
+	// A platform PointerLeave arriving after the synthetic transition is
+	// the same exit and must not dispatch a duplicate leave.
+	es.onPointer(gpucontext.PointerEvent{
+		Type:        gpucontext.PointerLeave,
+		PointerType: gpucontext.PointerTypeMouse,
+		X:           460,
+		Y:           100,
+	})
+	if root.eventCalled {
+		t.Errorf("PointerLeave after synthetic leave dispatched %T, want no event", root.lastEvent)
+	}
+}
+
+func TestEventBridge_DragOutsidePreservesCaptureEvents(t *testing.T) {
+	es := &mockEventSource{}
+	root := newBoundedEventBridgeRoot(es)
+
+	es.onMousePress(gpucontext.MouseButtonLeft, 100, 100)
+	resetEventBridgeRoot(root)
+	es.onMouseMove(450, 100)
+
+	move, ok := root.lastEvent.(*event.MouseEvent)
+	if !ok || move.MouseType != event.MouseMove {
+		t.Fatalf("drag move event = %T %#v, want MouseMove", root.lastEvent, root.lastEvent)
+	}
+	if !move.Buttons.IsLeftPressed() {
+		t.Error("drag move outside window lost the pressed-button state")
+	}
+
+	resetEventBridgeRoot(root)
+	es.onMouseRelease(gpucontext.MouseButtonLeft, 450, 100)
+	release, ok := root.lastEvent.(*event.MouseEvent)
+	if !ok || release.MouseType != event.MouseRelease {
+		t.Fatalf("outside release event = %T %#v, want MouseRelease", root.lastEvent, root.lastEvent)
+	}
+
+	resetEventBridgeRoot(root)
+	es.onMouseMove(460, 100)
+	if root.eventCalled {
+		t.Errorf("post-release outside move dispatched %T, want no event", root.lastEvent)
 	}
 }
 
@@ -140,6 +226,10 @@ func TestEventBridge_Scroll(t *testing.T) {
 	root := newMockWidget()
 	a.SetRoot(root)
 
+	// The basic EventSource scroll callback has no position. Establish the
+	// pointer as in-bounds before scrolling.
+	es.onMouseMove(100, 100)
+	resetEventBridgeRoot(root)
 	es.onScroll(0.0, -3.0)
 
 	if !root.eventCalled {
@@ -154,6 +244,310 @@ func TestEventBridge_Scroll(t *testing.T) {
 	}
 	if we.Delta.Y != -3.0 {
 		t.Errorf("delta Y = %v, want -3", we.Delta.Y)
+	}
+}
+
+func TestEventBridge_ScrollOutsideWindow_Fallback(t *testing.T) {
+	es := &mockEventSource{}
+	root := newBoundedEventBridgeRoot(es)
+
+	es.onMouseMove(100, 100)
+	es.onMouseMove(450, 100)
+	resetEventBridgeRoot(root)
+	es.onScroll(0, -3)
+
+	if root.eventCalled {
+		t.Errorf("outside scroll dispatched %T, want no event", root.lastEvent)
+	}
+
+	es.onMouseMove(100, 100)
+	resetEventBridgeRoot(root)
+	es.onScroll(0, -3)
+	if _, ok := root.lastEvent.(*event.WheelEvent); !ok {
+		t.Fatalf("scroll after re-entry = %T, want WheelEvent", root.lastEvent)
+	}
+}
+
+func TestEventBridge_DetailedScrollUsesEventPositionAndBounds(t *testing.T) {
+	es := &mockScrollEventSource{}
+	root := newBoundedEventBridgeRoot(es)
+
+	if es.onScrollEvent == nil {
+		t.Fatal("OnScrollEvent callback was not registered")
+	}
+	if es.onScroll != nil {
+		t.Fatal("legacy OnScroll callback registered with detailed source; wheels would dispatch twice")
+	}
+
+	es.onScrollEvent(gpucontext.ScrollEvent{
+		X: 120, Y: 130,
+		DeltaX: 2, DeltaY: -4,
+		Modifiers: gpucontext.ModShift,
+	})
+	wheel, ok := root.lastEvent.(*event.WheelEvent)
+	if !ok {
+		t.Fatalf("detailed scroll event = %T, want WheelEvent", root.lastEvent)
+	}
+	if wheel.Position != geometry.Pt(120, 130) {
+		t.Errorf("wheel position = %v, want (120, 130)", wheel.Position)
+	}
+	if wheel.Delta != geometry.Pt(2, -4) {
+		t.Errorf("wheel delta = %v, want (2, -4)", wheel.Delta)
+	}
+	if !wheel.Modifiers().IsShift() {
+		t.Error("detailed wheel lost its Shift modifier")
+	}
+
+	// All available signals now agree the cursor is outside.
+	es.onMouseMove(100, 100)
+	es.onMouseMove(450, 130)
+	resetEventBridgeRoot(root)
+	es.onScrollEvent(gpucontext.ScrollEvent{X: 450, Y: 130, DeltaY: -4})
+	if root.eventCalled {
+		t.Errorf("outside detailed scroll dispatched %T, want no event", root.lastEvent)
+	}
+}
+
+func TestEventBridge_DetailedScrollFallsBackForUntrustedPosition(t *testing.T) {
+	es := &mockScrollEventSource{}
+	root := newBoundedEventBridgeRoot(es)
+
+	// Keep a trusted pointer position. Contract-violating backends have
+	// historically reported physical (therefore out-of-bounds) coordinates
+	// or no position at all; neither should discard an otherwise valid wheel.
+	es.onMouseMove(100, 100)
+	resetEventBridgeRoot(root)
+
+	es.onScrollEvent(gpucontext.ScrollEvent{X: 1000, Y: 700, DeltaY: -2})
+	wheel, ok := root.lastEvent.(*event.WheelEvent)
+	if !ok {
+		t.Fatalf("out-of-bounds reported position event = %T, want WheelEvent", root.lastEvent)
+	}
+	if wheel.Position != geometry.Pt(100, 100) {
+		t.Errorf("fallback position = %v, want last trusted position (100, 100)", wheel.Position)
+	}
+
+	resetEventBridgeRoot(root)
+	es.onScrollEvent(gpucontext.ScrollEvent{DeltaY: -2})
+	wheel, ok = root.lastEvent.(*event.WheelEvent)
+	if !ok {
+		t.Fatalf("zero reported position event = %T, want WheelEvent", root.lastEvent)
+	}
+	if wheel.Position != geometry.Pt(100, 100) {
+		t.Errorf("zero-position fallback = %v, want last trusted position (100, 100)", wheel.Position)
+	}
+
+	// The same ambiguous zero must not revive a stale in-window position
+	// after an independently observed exit (including momentum scroll).
+	es.onMouseMove(450, 100)
+	resetEventBridgeRoot(root)
+	es.onScrollEvent(gpucontext.ScrollEvent{DeltaY: -2, IsMomentum: true})
+	if root.eventCalled {
+		t.Errorf("zero-position momentum after exit dispatched %T, want no event", root.lastEvent)
+	}
+}
+
+func TestEventBridge_DetailedZeroPositionRequiresInsideState(t *testing.T) {
+	es := &mockScrollEventSource{}
+	root := newBoundedEventBridgeRoot(es)
+
+	// (0,0) is a real in-window corner, so keep it when PointerEnter has
+	// independently established that the cursor is there.
+	es.onPointer(gpucontext.PointerEvent{Type: gpucontext.PointerEnter})
+	resetEventBridgeRoot(root)
+	es.onScrollEvent(gpucontext.ScrollEvent{DeltaY: -2})
+	wheel, ok := root.lastEvent.(*event.WheelEvent)
+	if !ok {
+		t.Fatalf("trusted origin scroll = %T, want WheelEvent", root.lastEvent)
+	}
+	if !wheel.Position.IsZero() {
+		t.Errorf("trusted origin position = %v, want (0,0)", wheel.Position)
+	}
+
+	// Once the cursor leaves, the same all-zero event is an untrusted
+	// no-position report and must not revive scrolling outside the window.
+	es.onPointer(gpucontext.PointerEvent{Type: gpucontext.PointerLeave})
+	resetEventBridgeRoot(root)
+	es.onScrollEvent(gpucontext.ScrollEvent{DeltaY: -2})
+	if root.eventCalled {
+		t.Errorf("zero-position scroll after leave dispatched %T, want no event", root.lastEvent)
+	}
+}
+
+func TestEventBridge_DetailedScrollDuringDragOutside(t *testing.T) {
+	es := &mockScrollEventSource{}
+	root := newBoundedEventBridgeRoot(es)
+
+	es.onMousePress(gpucontext.MouseButtonLeft, 100, 100)
+	resetEventBridgeRoot(root)
+	es.onScrollEvent(gpucontext.ScrollEvent{X: 450, Y: 100, DeltaY: -2})
+
+	if _, ok := root.lastEvent.(*event.WheelEvent); !ok {
+		t.Fatalf("drag scroll event = %T, want WheelEvent", root.lastEvent)
+	}
+}
+
+func TestEventBridge_FocusLossInvalidatesFallbackScrollPosition(t *testing.T) {
+	es := &mockEventSource{}
+	root := newBoundedEventBridgeRoot(es)
+
+	es.onMouseMove(100, 100)
+	es.onFocus(false)
+	resetEventBridgeRoot(root)
+	es.onScroll(0, -2)
+
+	if root.eventCalled {
+		t.Errorf("scroll after focus loss dispatched %T, want no event", root.lastEvent)
+	}
+}
+
+func TestEventBridge_FocusLossCancelsHeldButtons(t *testing.T) {
+	es := &mockScrollEventSource{}
+	root := newBoundedEventBridgeRoot(es)
+
+	// The release may occur while another window has focus, so no matching
+	// OnMouseRelease callback is guaranteed.
+	es.onMousePress(gpucontext.MouseButtonLeft, 100, 100)
+	es.onFocus(false)
+	resetEventBridgeRoot(root)
+
+	es.onMouseMove(450, 100)
+	if root.eventCalled {
+		t.Errorf("outside move after focus loss dispatched %T, want no event", root.lastEvent)
+	}
+
+	es.onScrollEvent(gpucontext.ScrollEvent{X: 450, Y: 100, DeltaY: -2})
+	if root.eventCalled {
+		t.Errorf("outside scroll after focus loss dispatched %T, want no event", root.lastEvent)
+	}
+
+	// A new gesture starts from a clean button state rather than inheriting
+	// the lost left-button release.
+	es.onMousePress(gpucontext.MouseButtonRight, 100, 100)
+	press, ok := root.lastEvent.(*event.MouseEvent)
+	if !ok {
+		t.Fatalf("new press event = %T, want MouseEvent", root.lastEvent)
+	}
+	if press.Buttons != event.ButtonStateRight {
+		t.Errorf("new press buttons = %v, want right only", press.Buttons)
+	}
+}
+
+func TestEventBridge_PointerCancelCancelsHeldButtonsAndCapture(t *testing.T) {
+	es := &mockScrollEventSource{}
+	wp := &mockWindowProvider{width: 400, height: 300, scale: 1}
+	a := New(WithWindowProvider(wp), WithEventSource(es))
+	root := newMockWidget()
+	a.SetRoot(root)
+	w := a.Window()
+
+	es.onMousePress(gpucontext.MouseButtonLeft, 100, 100)
+	w.ctx.CapturePointer(root)
+	if w.capturedWidget != root {
+		t.Fatal("precondition: root should hold pointer capture")
+	}
+
+	es.onPointer(gpucontext.PointerEvent{Type: gpucontext.PointerCancel})
+	if w.capturedWidget != nil {
+		t.Error("capturedWidget should be nil after PointerCancel")
+	}
+	if w.mouseButtonsHeld != 0 {
+		t.Errorf("mouseButtonsHeld = %v after PointerCancel, want none", w.mouseButtonsHeld)
+	}
+	release, ok := root.lastEvent.(*event.MouseEvent)
+	if !ok || release.MouseType != event.MouseRelease || release.Buttons != 0 {
+		t.Fatalf("captured widget cancellation event = %T %#v, want final MouseRelease", root.lastEvent, root.lastEvent)
+	}
+
+	resetEventBridgeRoot(root)
+	es.onMouseMove(450, 100)
+	if root.eventCalled {
+		t.Errorf("outside move after PointerCancel dispatched %T, want no event", root.lastEvent)
+	}
+	es.onScrollEvent(gpucontext.ScrollEvent{X: 450, Y: 100, DeltaY: -2})
+	if root.eventCalled {
+		t.Errorf("outside scroll after PointerCancel dispatched %T, want no event", root.lastEvent)
+	}
+}
+
+func TestEventBridge_NonMousePointerEventsPreserveMouseState(t *testing.T) {
+	es := &mockEventSource{}
+	wp := &mockWindowProvider{width: 400, height: 300, scale: 1}
+	a := New(WithWindowProvider(wp), WithEventSource(es))
+	root := newMockWidget()
+	a.SetRoot(root)
+	w := a.Window()
+
+	for _, pointerType := range []gpucontext.PointerType{
+		gpucontext.PointerTypeTouch,
+		gpucontext.PointerTypePen,
+	} {
+		resetEventBridgeRoot(root)
+		es.onPointer(gpucontext.PointerEvent{
+			Type:        gpucontext.PointerEnter,
+			PointerType: pointerType,
+			PointerID:   2,
+		})
+		if root.eventCalled {
+			t.Errorf("%v PointerEnter dispatched %T, want no event", pointerType, root.lastEvent)
+		}
+		es.onScroll(0, -2)
+		if root.eventCalled {
+			t.Errorf("%v PointerEnter armed mouse scroll fallback", pointerType)
+		}
+	}
+
+	es.onMouseMove(100, 100)
+	resetEventBridgeRoot(root)
+	for _, pointerType := range []gpucontext.PointerType{
+		gpucontext.PointerTypeTouch,
+		gpucontext.PointerTypePen,
+	} {
+		es.onPointer(gpucontext.PointerEvent{
+			Type:        gpucontext.PointerLeave,
+			PointerType: pointerType,
+			PointerID:   2,
+		})
+	}
+	if root.eventCalled {
+		t.Errorf("non-mouse enter/leave dispatched %T, want no event", root.lastEvent)
+	}
+
+	// The touch/pen leaves must not invalidate the independently tracked
+	// in-window mouse position.
+	es.onScroll(0, -2)
+	if _, ok := root.lastEvent.(*event.WheelEvent); !ok {
+		t.Fatalf("mouse scroll after non-mouse leave = %T, want WheelEvent", root.lastEvent)
+	}
+
+	es.onMousePress(gpucontext.MouseButtonLeft, 100, 100)
+	w.ctx.CapturePointer(root)
+	for _, pointerType := range []gpucontext.PointerType{
+		gpucontext.PointerTypeTouch,
+		gpucontext.PointerTypePen,
+	} {
+		es.onPointer(gpucontext.PointerEvent{
+			Type:        gpucontext.PointerCancel,
+			PointerType: pointerType,
+			PointerID:   2,
+		})
+	}
+
+	if w.capturedWidget != root {
+		t.Error("touch PointerCancel cleared unrelated mouse capture")
+	}
+	if w.mouseButtonsHeld != event.ButtonStateLeft {
+		t.Errorf("mouseButtonsHeld = %v after touch PointerCancel, want left", w.mouseButtonsHeld)
+	}
+
+	resetEventBridgeRoot(root)
+	es.onMouseMove(450, 100)
+	move, ok := root.lastEvent.(*event.MouseEvent)
+	if !ok || move.MouseType != event.MouseMove {
+		t.Fatalf("mouse drag after touch PointerCancel = %T, want MouseMove", root.lastEvent)
+	}
+	if !move.Buttons.IsLeftPressed() {
+		t.Error("mouse drag lost left-button state after touch PointerCancel")
 	}
 }
 
@@ -534,6 +928,8 @@ var (
 	_ gpucontext.PlatformProvider   = (*mockPlatformProvider)(nil)
 	_ gpucontext.EventSource        = (*mockEventSource)(nil)
 	_ gpucontext.PointerEventSource = (*mockEventSource)(nil)
+	_ gpucontext.EventSource        = (*mockScrollEventSource)(nil)
+	_ gpucontext.ScrollEventSource  = (*mockScrollEventSource)(nil)
 	_ widget.Canvas                 = (*mockCanvas)(nil)
 	_ widget.Widget                 = (*mockWidget)(nil)
 	_ widget.Widget                 = (*cursorSettingWidget)(nil)

--- a/app/event_bridge_test.go
+++ b/app/event_bridge_test.go
@@ -46,6 +46,14 @@ func TestEventBridge_MouseMove(t *testing.T) {
 	}
 }
 
+func TestPointInWindow_AllowsEventsBeforeSizeIsKnown(t *testing.T) {
+	var w Window
+
+	if !pointInWindow(&w, geometry.Pt(10_000, 10_000)) {
+		t.Fatal("pointInWindow rejected an event before the window size was known")
+	}
+}
+
 func TestEventBridge_MouseMoveOutsideWindow(t *testing.T) {
 	es := &mockEventSource{}
 	root := newBoundedEventBridgeRoot(es)

--- a/app/window.go
+++ b/app/window.go
@@ -132,7 +132,7 @@ type Window struct {
 	// reset during drag operations (Frame.ResetCursor skipped while dragging).
 	mouseButtonsHeld event.ButtonState
 
-	// windowSize tracks the last known window size in physical pixels.
+	// windowSize tracks the last known window size in logical pixels.
 	windowSize geometry.Size
 
 	// frameCallback, if set, is called after each frame with statistics.
@@ -422,6 +422,19 @@ func (w *Window) HandleEvent(e event.Event) {
 	// Update context time for event processing.
 	w.ctx.SetNow(time.Now())
 
+	// Track button ownership before any dispatch path can return early (for
+	// example, when an overlay consumes a press and captures the pointer).
+	if me, ok := e.(*event.MouseEvent); ok {
+		previousButtons := w.mouseButtonsHeld
+		w.mouseButtonsHeld = me.Buttons
+		if me.MouseType == event.MousePress && previousButtons == 0 {
+			// A press can be the first positional event delivered after focus or
+			// window creation. Establish its target so cancellation can clear a
+			// pressed control even when no preceding MouseMove was observed.
+			w.updateHover(me.Position, me.Buttons, me.Modifiers())
+		}
+	}
+
 	// Overlays get priority.
 	if w.overlays.HandleEvent(w.ctx, e) {
 		return
@@ -450,8 +463,6 @@ func (w *Window) HandleEvent(e event.Event) {
 			if me.MouseType == event.MouseRelease && me.Buttons == 0 {
 				w.capturedWidget = nil
 			}
-			// Track mouse button state even during capture.
-			w.mouseButtonsHeld = me.Buttons
 			if consumed {
 				return
 			}
@@ -472,11 +483,6 @@ func (w *Window) HandleEvent(e event.Event) {
 			// The window-level leave event still propagates to the root below.
 			w.clearHover(me.Buttons, me.Modifiers())
 		}
-	}
-
-	// Track mouse button state for drag cursor protection.
-	if me, ok := e.(*event.MouseEvent); ok {
-		w.mouseButtonsHeld = me.Buttons
 	}
 
 	// Dispatch event to root widget.
@@ -551,6 +557,10 @@ func invalidateScenesInTree(w widget.Widget) {
 
 // HandleFocusChange processes a window focus change.
 func (w *Window) HandleFocusChange(focused bool) {
+	if !focused {
+		w.cancelPointerState()
+	}
+
 	if w.root == nil {
 		return
 	}
@@ -570,6 +580,66 @@ func (w *Window) HandleFocusChange(focused bool) {
 	w.needsRedraw = true
 	if w.wp != nil {
 		w.wp.RequestRedraw()
+	}
+}
+
+// cancelPointerState ends Window-owned capture and held-button tracking when a
+// matching release may never arrive, such as after focus loss or a platform
+// PointerCancel. Captured widgets receive releases at an outside-window point
+// first so they can clear internal drag state without activating a control.
+func (w *Window) cancelPointerState() {
+	// Window's zero value is valid for public no-op handlers such as
+	// HandleFocusChange. Pointer callbacks also share this cleanup path, so
+	// keep it safe before newWindow has installed a widget context.
+	if w.ctx == nil {
+		w.capturedWidget = nil
+		w.mouseButtonsHeld = 0
+		w.hoveredWidget = nil
+		return
+	}
+
+	if captured := w.capturedWidget; captured != nil && w.mouseButtonsHeld != 0 {
+		remaining := w.mouseButtonsHeld
+		outside := geometry.Pt(-1, -1)
+		if bounded, ok := captured.(interface{ Bounds() geometry.Rect }); ok {
+			bounds := bounded.Bounds()
+			outside = geometry.Pt(bounds.Min.X-1, bounds.Min.Y-1)
+		}
+		for _, heldButton := range [...]struct {
+			button event.Button
+			state  event.ButtonState
+		}{
+			{event.ButtonLeft, event.ButtonStateLeft},
+			{event.ButtonRight, event.ButtonStateRight},
+			{event.ButtonMiddle, event.ButtonStateMiddle},
+			{event.ButtonX1, event.ButtonStateX1},
+			{event.ButtonX2, event.ButtonStateX2},
+		} {
+			if !remaining.Has(heldButton.state) {
+				continue
+			}
+			remaining &^= heldButton.state
+			_ = captured.Event(w.ctx, event.NewMouseEvent(
+				event.MouseRelease,
+				heldButton.button,
+				remaining,
+				outside,
+				outside,
+				event.ModNone,
+			))
+		}
+	}
+
+	// A widget may explicitly release itself while handling the synthetic
+	// event. Clear any capture that remains afterward.
+	if captured := w.capturedWidget; captured != nil {
+		w.ctx.ReleasePointer(captured)
+	}
+	w.mouseButtonsHeld = 0
+	w.clearHover(0, event.ModNone)
+	w.ctx.ResetCursor()
+	if w.pp != nil {
+		w.syncCursor()
 	}
 }
 

--- a/app/window.go
+++ b/app/window.go
@@ -422,18 +422,7 @@ func (w *Window) HandleEvent(e event.Event) {
 	// Update context time for event processing.
 	w.ctx.SetNow(time.Now())
 
-	// Track button ownership before any dispatch path can return early (for
-	// example, when an overlay consumes a press and captures the pointer).
-	if me, ok := e.(*event.MouseEvent); ok {
-		previousButtons := w.mouseButtonsHeld
-		w.mouseButtonsHeld = me.Buttons
-		if me.MouseType == event.MousePress && previousButtons == 0 {
-			// A press can be the first positional event delivered after focus or
-			// window creation. Establish its target so cancellation can clear a
-			// pressed control even when no preceding MouseMove was observed.
-			w.updateHover(me.Position, me.Buttons, me.Modifiers())
-		}
-	}
+	w.trackMouseButtonOwnership(e)
 
 	// Overlays get priority.
 	if w.overlays.HandleEvent(w.ctx, e) {
@@ -499,6 +488,25 @@ func (w *Window) HandleEvent(e event.Event) {
 	// Tab navigation starts from the correct position.
 	if me, ok := e.(*event.MouseEvent); ok && me.MouseType == event.MousePress {
 		w.syncContextFocusToManager()
+	}
+}
+
+// trackMouseButtonOwnership records button state before any dispatch path can
+// return early, such as when an overlay consumes a press and captures the
+// pointer.
+func (w *Window) trackMouseButtonOwnership(e event.Event) {
+	me, ok := e.(*event.MouseEvent)
+	if !ok {
+		return
+	}
+
+	previousButtons := w.mouseButtonsHeld
+	w.mouseButtonsHeld = me.Buttons
+	if me.MouseType == event.MousePress && previousButtons == 0 {
+		// A press can be the first positional event delivered after focus or
+		// window creation. Establish its target so cancellation can clear a
+		// pressed control even when no preceding MouseMove was observed.
+		w.updateHover(me.Position, me.Buttons, me.Modifiers())
 	}
 }
 

--- a/app/window_test.go
+++ b/app/window_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 
 	"github.com/gogpu/gpucontext"
+	"github.com/gogpu/ui/core/button"
+	"github.com/gogpu/ui/core/slider"
 	"github.com/gogpu/ui/event"
 	"github.com/gogpu/ui/geometry"
 	"github.com/gogpu/ui/state"
@@ -206,6 +208,16 @@ func TestWindow_HandleFocusChange_NoRoot(t *testing.T) {
 	a := New()
 	w := a.Window()
 	// Should not panic.
+	w.HandleFocusChange(true)
+}
+
+func TestWindow_HandleFocusChange_ZeroValue(t *testing.T) {
+	var w Window
+
+	// Both paths are public no-ops until a root and context are installed.
+	// In particular, focus loss must not dereference the nil context while
+	// trying to clear pointer state.
+	w.HandleFocusChange(false)
 	w.HandleFocusChange(true)
 }
 
@@ -1917,6 +1929,111 @@ func TestWindow_PointerCapture_AutoRelease(t *testing.T) {
 		if ev.MouseType == event.MouseMove {
 			t.Error("move event should not be delivered to widget after capture release")
 		}
+	}
+}
+
+func TestWindow_PointerCapture_ReleasesOnFocusLoss(t *testing.T) {
+	a := New()
+	w := a.Window()
+
+	cw := newCaptureWidget(geometry.NewRect(10, 10, 110, 50))
+	root := newHoverContainer(cw)
+	w.SetRoot(root)
+	w.ctx.CapturePointer(cw)
+	w.mouseButtonsHeld = event.ButtonStateLeft
+
+	w.HandleFocusChange(false)
+
+	if w.capturedWidget != nil {
+		t.Error("capturedWidget should be nil after focus loss")
+	}
+	if w.mouseButtonsHeld != 0 {
+		t.Errorf("mouseButtonsHeld = %v after focus loss, want none", w.mouseButtonsHeld)
+	}
+	if len(cw.events) == 0 {
+		t.Fatal("captured widget did not receive a cancellation release")
+	}
+	release := cw.events[len(cw.events)-1]
+	if release.MouseType != event.MouseRelease || release.Buttons != 0 {
+		t.Errorf("cancellation event = %#v, want final MouseRelease", release)
+	}
+
+	// Direct delivery outside the widget must not survive the cancellation.
+	cw.events = nil
+	w.HandleEvent(event.NewMouseEvent(
+		event.MouseMove,
+		event.ButtonNone,
+		0,
+		geometry.Pt(300, 300),
+		geometry.Pt(300, 300),
+		event.ModNone,
+	))
+	if len(cw.events) != 0 {
+		t.Errorf("outside move reached formerly captured widget after focus loss: %d events", len(cw.events))
+	}
+}
+
+func TestWindow_FocusLossCancelsSliderDrag(t *testing.T) {
+	value := state.NewSignal[float32](50)
+	s := slider.New(
+		slider.Min(0),
+		slider.Max(100),
+		slider.ValueSignal(value),
+	)
+	s.SetBounds(geometry.NewRect(0, 0, 200, 30))
+
+	a := New()
+	w := a.Window()
+	w.SetRoot(s)
+	w.HandleEvent(event.NewMouseEvent(
+		event.MousePress,
+		event.ButtonLeft,
+		event.ButtonStateLeft,
+		geometry.Pt(100, 15),
+		geometry.Pt(100, 15),
+		event.ModNone,
+	))
+	if w.capturedWidget != s {
+		t.Fatal("precondition: slider should hold pointer capture")
+	}
+
+	w.HandleFocusChange(false)
+	valueAfterCancel := value.Get()
+	consumed := s.Event(w.ctx, event.NewMouseEvent(
+		event.MouseMove,
+		event.ButtonNone,
+		0,
+		geometry.Pt(180, 15),
+		geometry.Pt(180, 15),
+		event.ModNone,
+	))
+	if consumed {
+		t.Error("slider consumed buttonless move after focus-loss cancellation")
+	}
+	if value.Get() != valueAfterCancel {
+		t.Errorf("slider value changed after canceled drag: got %v, want %v", value.Get(), valueAfterCancel)
+	}
+}
+
+func TestWindow_FocusLossClearsPressedButtonWithoutClick(t *testing.T) {
+	clicked := false
+	btn := button.New(button.OnClick(func() { clicked = true }))
+	btn.SetBounds(geometry.NewRect(0, 0, 100, 40))
+
+	a := New()
+	w := a.Window()
+	w.SetRoot(btn)
+	pos := geometry.Pt(50, 20)
+	w.HandleEvent(event.NewMouseEvent(
+		event.MousePress, event.ButtonLeft, event.ButtonStateLeft, pos, pos, event.ModNone,
+	))
+
+	w.HandleFocusChange(false)
+	w.HandleEvent(event.NewMouseEvent(
+		event.MouseRelease, event.ButtonLeft, 0, pos, pos, event.ModNone,
+	))
+	if clicked {
+		t.Error("button clicked after its pressed gesture was canceled by focus loss")
 	}
 }
 

--- a/app/window_test.go
+++ b/app/window_test.go
@@ -221,6 +221,17 @@ func TestWindow_HandleFocusChange_ZeroValue(t *testing.T) {
 	w.HandleFocusChange(true)
 }
 
+func TestWindow_FocusLossResetsPlatformCursorWithoutRoot(t *testing.T) {
+	pp := &mockPlatformProvider{lastCursor: gpucontext.CursorPointer}
+	w := New(WithPlatformProvider(pp)).Window()
+
+	w.HandleFocusChange(false)
+
+	if pp.lastCursor != gpucontext.CursorDefault {
+		t.Errorf("platform cursor = %v, want default after focus loss", pp.lastCursor)
+	}
+}
+
 func TestWindow_ScaleFromProvider(t *testing.T) {
 	wp := &mockWindowProvider{width: 800, height: 600, scale: 2.0}
 	a := New(WithWindowProvider(wp))

--- a/core/listview/event.go
+++ b/core/listview/event.go
@@ -44,9 +44,14 @@ func handleContentMouseEvent(lv *Widget, ctx widget.Context, e *event.MouseEvent
 func handleContentMouseMove(lv *Widget, _ widget.Context, e *event.MouseEvent) bool {
 	// Position is already in content space — ScrollView applies the inverse
 	// of its Draw transform before dispatching to content children.
+	contentX := e.Position.X
 	contentY := e.Position.Y
 
-	idx := lv.heights.findIndexAtOffset(contentY)
+	idx := noHoveredIndex
+	rowWidth, hasRowWidth := contentRowWidth(lv)
+	if contentX >= 0 && (!hasRowWidth || contentX <= rowWidth) {
+		idx = lv.heights.findIndexAtOffset(contentY)
+	}
 	itemCount := lv.cfg.ResolvedItemCount()
 	if idx < 0 || idx >= itemCount {
 		idx = noHoveredIndex
@@ -74,7 +79,12 @@ func handleContentMousePress(lv *Widget, ctx widget.Context, e *event.MouseEvent
 
 	// Position is already in content space — ScrollView applies the inverse
 	// of its Draw transform before dispatching to content children.
+	contentX := e.Position.X
 	contentY := e.Position.Y
+	rowWidth, hasRowWidth := contentRowWidth(lv)
+	if contentX < 0 || (hasRowWidth && contentX > rowWidth) {
+		return false
+	}
 
 	idx := lv.heights.findIndexAtOffset(contentY)
 	itemCount := lv.cfg.ResolvedItemCount()
@@ -96,6 +106,16 @@ func handleContentMousePress(lv *Widget, ctx widget.Context, e *event.MouseEvent
 	ctx.RequestFocus(lv)
 
 	return true
+}
+
+// contentRowWidth reports the horizontal hit band used to paint list rows.
+// Before layout establishes viewport geometry, only the always-invalid
+// negative X range can be rejected safely.
+func contentRowWidth(lv *Widget) (float32, bool) {
+	if lv.scroll == nil || lv.viewportWidth <= 0 {
+		return 0, false
+	}
+	return lv.viewportWidth - lv.scroll.ScrollbarInset(), true
 }
 
 // handleListKeyEvent processes keyboard events for list-level navigation.

--- a/core/listview/internal_test.go
+++ b/core/listview/internal_test.go
@@ -1707,6 +1707,81 @@ func TestListView_HoverChangesVisibleOnRedraw(t *testing.T) {
 	}
 }
 
+func TestContentMouseMoveRejectsOutsideRowWidth(t *testing.T) {
+	lv := New(ItemCount(10), FixedItemHeight(20))
+	ctx := widget.NewContext()
+	lv.Layout(ctx, geometry.Tight(geometry.Sz(100, 100)))
+	rowWidth, ok := contentRowWidth(lv)
+	if !ok {
+		t.Fatal("row width unavailable after layout")
+	}
+
+	tests := []struct {
+		name string
+		x    float32
+		want int
+	}{
+		{name: "negative", x: -1, want: noHoveredIndex},
+		{name: "left edge", x: 0, want: 1},
+		{name: "right edge", x: rowWidth, want: 1},
+		{name: "past right edge", x: rowWidth + 1, want: noHoveredIndex},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lv.hoveredIndex = noHoveredIndex
+			handleContentMouseMove(lv, ctx, &event.MouseEvent{
+				MouseType: event.MouseMove,
+				Position:  geometry.Pt(tt.x, 25),
+			})
+			if lv.hoveredIndex != tt.want {
+				t.Errorf("hoveredIndex = %d, want %d", lv.hoveredIndex, tt.want)
+			}
+		})
+	}
+}
+
+func TestContentMousePressRejectsOutsideRowWidth(t *testing.T) {
+	clicked := make([]int, 0, 2)
+	lv := New(
+		ItemCount(10),
+		FixedItemHeight(20),
+		OnItemClick(func(index int) { clicked = append(clicked, index) }),
+	)
+	ctx := widget.NewContext()
+	lv.Layout(ctx, geometry.Tight(geometry.Sz(100, 100)))
+	rowWidth, ok := contentRowWidth(lv)
+	if !ok {
+		t.Fatal("row width unavailable after layout")
+	}
+
+	tests := []struct {
+		name         string
+		x            float32
+		wantConsumed bool
+		wantClicks   int
+	}{
+		{name: "negative", x: -1, wantClicks: 0},
+		{name: "left edge", x: 0, wantConsumed: true, wantClicks: 1},
+		{name: "right edge", x: rowWidth, wantConsumed: true, wantClicks: 2},
+		{name: "past right edge", x: rowWidth + 1, wantClicks: 2},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			consumed := handleContentMousePress(lv, ctx, &event.MouseEvent{
+				MouseType: event.MousePress,
+				Button:    event.ButtonLeft,
+				Position:  geometry.Pt(tt.x, 25),
+			})
+			if consumed != tt.wantConsumed {
+				t.Errorf("consumed = %v, want %v", consumed, tt.wantConsumed)
+			}
+			if len(clicked) != tt.wantClicks {
+				t.Errorf("click count = %d, want %d", len(clicked), tt.wantClicks)
+			}
+		})
+	}
+}
+
 // TestListView_WheelEventDispatch verifies that mouse wheel events reach
 // the ScrollView inside ListView and trigger scroll + redraw.
 func TestListView_WheelEventDispatch(t *testing.T) {


### PR DESCRIPTION
## Summary

- gate ordinary mouse moves and legacy/detailed wheel events to the window's logical bounds while retaining held-button capture outside the window
- use detailed scroll coordinates/modifiers where available, preserve platform compatibility fallbacks, and deduplicate leave/callback delivery
- reset mouse-only capture, pressed, hover, and cursor state on focus loss or pointer cancellation without letting touch/pen mutate legacy mouse state
- enforce ListView's drawable content X band, excluding the scrollbar inset
- add regressions for bounds, HiDPI coordinates, capture/cancellation, zero-value windows, and ListView edges

## Why

Pointer events can arrive after the cursor leaves a native window. Passing ordinary moves and wheel events through caused stale hover/selection/scroll behavior, while simply dropping every outside event would break legitimate captured drags. The bridge now distinguishes those cases at the shared boundary and cleans up incomplete pointer sequences when focus is lost.

## Verification

- `go test ./... -count=1`
- `CGO_ENABLED=0 go build ./...`
- `go build ./...`
- `go vet ./app/... ./event/... ./core/listview/...`
- focused event/ListView tests repeated 20×
- focused race tests
- `gofmt` and `git diff --check`

A pre-existing test-only race in `TestWindow_AnimPumper_StartsOnInvalidation` still prevents a clean full `go test -race ./...`; the changed focused packages expose no new race.

Fixes #179


### Local CI and Codecov preflight

- rebased onto current `main` (`273cc1e`)
- `go test ./... -count=1`: pass
- focused changed-package race suite: pass; the repository-wide race suite remains blocked only by the pre-existing `TestWindow_AnimPumper_StartsOnInvalidation` mock race noted above
- `go build ./...`, `go vet ./...`, `gofmt`, and diff checks: pass
- local Codecov-equivalent changed-production coverage: **137/137 statements (100%)** (`app/event_bridge.go` 92/92, `app/window.go` 31/31, `core/listview/event.go` 14/14); overall coverage 86.4%

Upstream CI run approval is still external to this branch: GitHub marked the fork workflow `action_required` with zero jobs. A `gogpu` maintainer must approve the workflow before Actions and the configured Codecov upload/bot can run.

## Review follow-up (2026-08-12)

Extracted mouse-button ownership tracking into the private `trackMouseButtonOwnership` helper, reducing `HandleEvent` below the configured cyclomatic-complexity limit without changing event ordering.
