### PR TITLE
fix(registry): canonicalize widget metadata names

### DIFF
--- a/registry/widget.go
+++ b/registry/widget.go
@@ -166,9 +166,7 @@ func (r *WidgetRegistry) Register(name string, factory WidgetFactory, info ...Wi
 	if len(info) > 0 {
 		widgetInfo := info[0]
 		// Ensure the name in info matches the registration name
-		if widgetInfo.Name == "" {
-			widgetInfo.Name = name
-		}
+		widgetInfo.Name = name
 		r.info[name] = widgetInfo
 	} else {
 		// Create minimal info

--- a/registry/widget_test.go
+++ b/registry/widget_test.go
@@ -221,26 +221,53 @@ func TestRegisterDuplicate(t *testing.T) {
 	}
 }
 
-// TestRegisterInfoNameInheritance tests that info.Name inherits registration name.
-func TestRegisterInfoNameInheritance(t *testing.T) {
-	r := newTestRegistry()
-
-	// Register with empty Name in info
-	err := r.Register("my-widget", mockWidgetFactory, WidgetInfo{
-		Description: "Test widget",
-		Category:    CategoryInput,
-	})
-	if err != nil {
-		t.Fatalf("Register() error = %v", err)
+// TestRegisterInfoNameCanonicalization tests that metadata always uses the
+// registration name as its canonical identity.
+func TestRegisterInfoNameCanonicalization(t *testing.T) {
+	tests := []struct {
+		name string
+		info WidgetInfo
+	}{
+		{
+			name: "empty info name",
+			info: WidgetInfo{
+				Description: "Test widget",
+				Category:    CategoryInput,
+			},
+		},
+		{
+			name: "matching info name",
+			info: WidgetInfo{
+				Name:        "my-widget",
+				Description: "Test widget",
+				Category:    CategoryInput,
+			},
+		},
+		{
+			name: "mismatched info name",
+			info: WidgetInfo{
+				Name:        "other-widget",
+				Description: "Test widget",
+				Category:    CategoryInput,
+			},
+		},
 	}
 
-	// Verify info.Name is set to registration name
-	info, ok := r.Info("my-widget")
-	if !ok {
-		t.Fatal("Info() returned false")
-	}
-	if info.Name != "my-widget" {
-		t.Errorf("info.Name = %q, want %q", info.Name, "my-widget")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := newTestRegistry()
+			if err := r.Register("my-widget", mockWidgetFactory, tt.info); err != nil {
+				t.Fatalf("Register() error = %v", err)
+			}
+
+			info, ok := r.Info("my-widget")
+			if !ok {
+				t.Fatal("Info() returned false")
+			}
+			if info.Name != "my-widget" {
+				t.Errorf("info.Name = %q, want %q", info.Name, "my-widget")
+			}
+		})
 	}
 }
 
@@ -560,8 +587,8 @@ func TestClear(t *testing.T) {
 func TestAllInfo(t *testing.T) {
 	r := newTestRegistry()
 
-	_ = r.Register("beta", mockWidgetFactory, WidgetInfo{Name: "beta", Description: "Beta widget"})
-	_ = r.Register("alpha", mockWidgetFactory, WidgetInfo{Name: "alpha", Description: "Alpha widget"})
+	_ = r.Register("beta", mockWidgetFactory, WidgetInfo{Name: "aardvark", Description: "Beta widget"})
+	_ = r.Register("alpha", mockWidgetFactory, WidgetInfo{Name: "zeta", Description: "Alpha widget"})
 
 	infos := r.AllInfo()
 	if len(infos) != 2 {


### PR DESCRIPTION
## Summary

- make the explicit registration key authoritative for `WidgetInfo.Name`
- canonicalize empty, matching, and mismatched metadata consistently
- keep `Info` and `AllInfo` identities and sorting aligned with registry keys
- add regression coverage for canonicalization and ordering

## Why

`Register(name, factory, info)` documents `name` as the widget's unique registration identifier, but it only copied that value into `WidgetInfo.Name` when the metadata field was empty. A caller could register key `"button"` with `WidgetInfo{Name: "other"}`, causing `Info("button")` and `AllInfo()` to report and sort under the wrong identity.

The plugin registry already follows the same policy by unconditionally deriving stored identity fields from the registration call.

## Verification

- baseline preserves a mismatched supplied metadata name
- empty, matching, and mismatched names now all resolve to the registration key
- `AllInfo` sorts by canonical registration names
- no repository caller depends on mismatched supplied names
- `go test ./registry`
- `go test -race ./registry`
- `go test ./...`
- `go build ./...`
- `CGO_ENABLED=0 go test ./...`
- `go vet ./...`
- `gofmt` and `git diff --check`

The full race suite still reports the pre-existing animation-pumper test-mock race; the changed registry package is race-clean.


### Local CI and Codecov preflight

- rebased onto current `main` (`273cc1e`)
- `go test ./... -count=1`: pass
- `go test -race ./registry -count=1`: pass; the repository-wide race suite remains blocked only by the pre-existing animation-pumper test-mock race noted above
- `go build ./...`, `go vet ./...`, `gofmt`, and diff checks: pass
- local Codecov-equivalent changed-production coverage: **3/3 statements (100%)**; overall coverage 86.3%

Upstream CI run approval is still external to this branch: GitHub marked the fork workflow `action_required` with zero jobs. A `gogpu` maintainer must approve the workflow before Actions and the configured Codecov upload/bot can run.
