### PR TITLE
chore: bump version to v0.1.53

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.1.52] — 2026-08-11
+## [0.1.53] — 2026-08-11
 
 ### Added
 


### PR DESCRIPTION
Version bump: v0.1.52 tag already taken. CHANGELOG section renamed to v0.1.53.