### PR TITLE
fix(gesture): GestureHitTest scoped hit-test + deps cascade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,12 +16,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- All 20+ interactive widgets implement `gesture.GestureAware` — button, checkbox, radio, textfield, dropdown, slider, dialog, scrollview, tabview, listview, gridview, collapsible, popover, splitview, treeview, datatable, toolbar, menu, docking, chip, stripe, titlebar.
+- All 20+ interactive widgets implement `gesture.GestureAware` with `GestureHitTest(pos)` — container widgets (Collapsible, TabView, Docking) scope recognizers to their interactive region (header, tab strip, zone tabs). Leaf widgets (Button, Checkbox, TextField, etc.) always return recognizers.
+- ScrollView removed from `GestureAware` — scrollbar drag handled by Event() handler with proper thumb hit-testing. Container widgets must not compete with child recognizers.
 - Event bridge: unified pointer pipeline (ADR-049 Phase 3) — pointer events flow through gesture arena before widget dispatch.
 - **deps:** gg v0.52.2 → v0.52.3, gogpu v0.52.1 → v0.53.0, gpucontext v0.27.0 → v0.28.0, wgpu v0.31.2 → v0.31.4
 
 ### Fixed
 
+- **fix(gesture): GestureHitTest scoped hit-test** — container widgets (Collapsible, TabView, Docking) no longer consume child widget clicks. `GestureRecognizers()` replaced by `GestureHitTest(pos geometry.Point)` which receives widget-local coordinates and returns recognizers only for the interactive region.
 - **fix(desktop): retain unchanged boundaries on resize** ([#176](https://github.com/gogpu/ui/issues/176), @besmpl) — unchanged boundaries preserved during window resize.
 - **fix(app): keep pointer events within window bounds** ([#179](https://github.com/gogpu/ui/issues/179), @besmpl) — pointer coordinates clamped to window dimensions.
 

--- a/app/window.go
+++ b/app/window.go
@@ -1412,6 +1412,10 @@ func (w *Window) GestureArena() *gesture.Arena {
 // gesture hit-testing collects ALL matching widgets on the path (not just
 // the deepest one), because parent and child may both have recognizers
 // that compete in the arena.
+//
+// Each GestureAware widget receives the pointer position in widget-local
+// coordinates, allowing container widgets (Collapsible, TabView, Docking)
+// to filter recognizers based on their interactive region.
 func (w *Window) hitTestGestureAware(pos geometry.Point) []gesture.Recognizer {
 	var recognizers []gesture.Recognizer
 	hitTestGestureRecursive(w.root, pos, &recognizers)
@@ -1420,6 +1424,11 @@ func (w *Window) hitTestGestureAware(pos geometry.Point) []gesture.Recognizer {
 
 // hitTestGestureRecursive walks the widget tree depth-first, collecting
 // recognizers from GestureAware widgets that contain the point.
+//
+// When calling GestureHitTest, the window-coordinate position is translated
+// to widget-local coordinates using ScreenOrigin. This lets container widgets
+// decide whether the click is within their interactive area (e.g., Collapsible
+// header) before returning recognizers.
 func hitTestGestureRecursive(w widget.Widget, pos geometry.Point, out *[]gesture.Recognizer) {
 	if w == nil {
 		return
@@ -1439,8 +1448,14 @@ func hitTestGestureRecursive(w widget.Widget, pos geometry.Point, out *[]gesture
 	}
 
 	// Collect recognizers from GestureAware widgets.
+	// Translate pos to widget-local coordinates using ScreenOrigin.
 	if ga, ok := w.(gesture.GestureAware); ok {
-		recs := ga.GestureRecognizers()
+		localPos := pos
+		if so, ok2 := w.(interface{ ScreenOrigin() geometry.Point }); ok2 {
+			origin := so.ScreenOrigin()
+			localPos = geometry.Pt(pos.X-origin.X, pos.Y-origin.Y)
+		}
+		recs := ga.GestureHitTest(localPos)
 		if len(recs) > 0 {
 			*out = append(*out, recs...)
 		}

--- a/app/window_gesture_test.go
+++ b/app/window_gesture_test.go
@@ -31,7 +31,7 @@ func newGestureAwareMock(recs ...gesture.Recognizer) *gestureAwareMock {
 	return m
 }
 
-func (m *gestureAwareMock) GestureRecognizers() []gesture.Recognizer {
+func (m *gestureAwareMock) GestureHitTest(_ geometry.Point) []gesture.Recognizer {
 	return m.recognizers
 }
 
@@ -241,7 +241,7 @@ func newContainerGestureMock(children []widget.Widget, recs ...gesture.Recognize
 	return m
 }
 
-func (m *containerGestureMock) GestureRecognizers() []gesture.Recognizer {
+func (m *containerGestureMock) GestureHitTest(_ geometry.Point) []gesture.Recognizer {
 	return m.recognizers
 }
 

--- a/core/button/widget.go
+++ b/core/button/widget.go
@@ -205,9 +205,11 @@ func (w *Widget) Unmount() {
 	// Bindings are cleaned up automatically by WidgetBase.CleanupBindings().
 }
 
-// GestureRecognizers returns the gesture recognizers owned by this widget.
+// GestureHitTest returns the gesture recognizers for a pointer event at pos.
 // Implements [gesture.GestureAware] for the unified pointer pipeline (ADR-049).
-func (w *Widget) GestureRecognizers() []gesture.Recognizer {
+// Button is a leaf widget — always returns recognizers (hit-test already
+// confirmed bounds containment).
+func (w *Widget) GestureHitTest(_ geometry.Point) []gesture.Recognizer {
 	if w.clickRec == nil {
 		return nil
 	}

--- a/core/checkbox/widget.go
+++ b/core/checkbox/widget.go
@@ -196,9 +196,11 @@ func (w *Widget) Unmount() {
 	// Bindings are cleaned up automatically by WidgetBase.CleanupBindings().
 }
 
-// GestureRecognizers returns the gesture recognizers owned by this widget.
+// GestureHitTest returns the gesture recognizers for a pointer event at pos.
 // Implements [gesture.GestureAware] for the unified pointer pipeline (ADR-049).
-func (w *Widget) GestureRecognizers() []gesture.Recognizer {
+// Checkbox is a leaf widget — always returns recognizers (hit-test already
+// confirmed bounds containment).
+func (w *Widget) GestureHitTest(_ geometry.Point) []gesture.Recognizer {
 	if w.clickRec == nil {
 		return nil
 	}

--- a/core/chip/chip.go
+++ b/core/chip/chip.go
@@ -239,9 +239,11 @@ func (w *Widget) Unmount() {
 	// Bindings are cleaned up automatically by WidgetBase.CleanupBindings().
 }
 
-// GestureRecognizers returns the gesture recognizers owned by this widget.
+// GestureHitTest returns the gesture recognizers for a pointer event at pos.
 // Implements [gesture.GestureAware] for the unified pointer pipeline (ADR-049).
-func (w *Widget) GestureRecognizers() []gesture.Recognizer {
+// Chip is a leaf widget — always returns recognizers (hit-test already
+// confirmed bounds containment).
+func (w *Widget) GestureHitTest(_ geometry.Point) []gesture.Recognizer {
 	if w.clickRec == nil {
 		return nil
 	}

--- a/core/collapsible/collapsible.go
+++ b/core/collapsible/collapsible.go
@@ -352,10 +352,21 @@ func (w *Widget) Unmount() {
 	}
 }
 
-// GestureRecognizers returns the gesture recognizers owned by this widget.
+// GestureHitTest returns the gesture recognizers for a pointer event at pos
+// (widget-local coordinates).
 // Implements [gesture.GestureAware] for the unified pointer pipeline (ADR-049).
-func (w *Widget) GestureRecognizers() []gesture.Recognizer {
+//
+// Collapsible is a container widget — returns recognizers ONLY when pos is
+// within the header area. Content-area clicks return nil so child widgets'
+// recognizers are the sole participants in the gesture arena.
+func (w *Widget) GestureHitTest(pos geometry.Point) []gesture.Recognizer {
 	if w.clickRec == nil {
+		return nil
+	}
+	// Header occupies the top headerHeight pixels in local coordinates.
+	b := w.Bounds()
+	localHeader := geometry.NewRect(0, 0, b.Width(), w.cfg.headerHeight)
+	if !localHeader.Contains(pos) {
 		return nil
 	}
 	return []gesture.Recognizer{w.clickRec}

--- a/core/datatable/datatable.go
+++ b/core/datatable/datatable.go
@@ -544,9 +544,11 @@ func (w *Widget) Unmount() {
 	w.scroll.Unmount()
 }
 
-// GestureRecognizers returns the gesture recognizers owned by this widget.
+// GestureHitTest returns the gesture recognizers for a pointer event at pos.
 // Implements [gesture.GestureAware] for the unified pointer pipeline (ADR-049).
-func (w *Widget) GestureRecognizers() []gesture.Recognizer {
+// DataTable is a leaf widget — always returns recognizers (hit-test already
+// confirmed bounds containment).
+func (w *Widget) GestureHitTest(_ geometry.Point) []gesture.Recognizer {
 	if w.clickRec == nil {
 		return nil
 	}

--- a/core/docking/host.go
+++ b/core/docking/host.go
@@ -740,13 +740,31 @@ const (
 	defaultHostHeight float32 = 600
 )
 
-// GestureRecognizers returns the gesture recognizers owned by this widget.
+// GestureHitTest returns the gesture recognizers for a pointer event at pos
+// (widget-local coordinates).
 // Implements [gesture.GestureAware] for the unified pointer pipeline (ADR-049).
-func (h *Host) GestureRecognizers() []gesture.Recognizer {
+//
+// Docking host is a container widget — returns recognizers ONLY when pos is
+// within a zone tab bar area. Content-area clicks return nil so child
+// widgets' recognizers are the sole participants in the gesture arena.
+func (h *Host) GestureHitTest(pos geometry.Point) []gesture.Recognizer {
 	if h.clickRec == nil {
 		return nil
 	}
-	return []gesture.Recognizer{h.clickRec}
+	// Zone bounds are stored in parent-relative coordinates (include
+	// h.Bounds().Min offset). Convert pos to parent-relative for comparison.
+	origin := h.Bounds().Min
+	parentPos := geometry.Pt(pos.X+origin.X, pos.Y+origin.Y)
+	for z := Zone(0); z < zoneCount; z++ {
+		if z == Center || h.zones[z].isEmpty() {
+			continue
+		}
+		tabBar := zoneTabBarRect(h.zones[z].bounds)
+		if tabBar.Contains(parentPos) {
+			return []gesture.Recognizer{h.clickRec}
+		}
+	}
+	return nil
 }
 
 // Verify Host implements required interfaces at compile time.

--- a/core/dropdown/widget.go
+++ b/core/dropdown/widget.go
@@ -379,9 +379,11 @@ func (w *Widget) Unmount() {
 	// Bindings are cleaned up automatically by WidgetBase.CleanupBindings().
 }
 
-// GestureRecognizers returns the gesture recognizers owned by this widget.
+// GestureHitTest returns the gesture recognizers for a pointer event at pos.
 // Implements [gesture.GestureAware] for the unified pointer pipeline (ADR-049).
-func (w *Widget) GestureRecognizers() []gesture.Recognizer {
+// Dropdown is a leaf widget — always returns recognizers (hit-test already
+// confirmed bounds containment).
+func (w *Widget) GestureHitTest(_ geometry.Point) []gesture.Recognizer {
 	if w.clickRec == nil {
 		return nil
 	}

--- a/core/gridview/gridview.go
+++ b/core/gridview/gridview.go
@@ -611,9 +611,11 @@ func (w *Widget) Unmount() {
 	// Bindings are cleaned up automatically by WidgetBase.CleanupBindings().
 }
 
-// GestureRecognizers returns the gesture recognizers owned by this widget.
+// GestureHitTest returns the gesture recognizers for a pointer event at pos.
 // Implements [gesture.GestureAware] for the unified pointer pipeline (ADR-049).
-func (w *Widget) GestureRecognizers() []gesture.Recognizer {
+// GridView is a leaf widget — always returns recognizers (hit-test already
+// confirmed bounds containment).
+func (w *Widget) GestureHitTest(_ geometry.Point) []gesture.Recognizer {
 	if w.clickRec == nil {
 		return nil
 	}

--- a/core/listview/widget.go
+++ b/core/listview/widget.go
@@ -283,9 +283,11 @@ func (w *Widget) Unmount() {
 	// Bindings are cleaned up automatically by WidgetBase.CleanupBindings().
 }
 
-// GestureRecognizers returns the gesture recognizers owned by this widget.
+// GestureHitTest returns the gesture recognizers for a pointer event at pos.
 // Implements [gesture.GestureAware] for the unified pointer pipeline (ADR-049).
-func (w *Widget) GestureRecognizers() []gesture.Recognizer {
+// ListView is a leaf widget — always returns recognizers (hit-test already
+// confirmed bounds containment).
+func (w *Widget) GestureHitTest(_ geometry.Point) []gesture.Recognizer {
 	if w.clickRec == nil {
 		return nil
 	}

--- a/core/menu/menubar.go
+++ b/core/menu/menubar.go
@@ -393,9 +393,11 @@ const (
 	a11yLabelMenuBar = "menu bar"
 )
 
-// GestureRecognizers returns the gesture recognizers owned by this widget.
+// GestureHitTest returns the gesture recognizers for a pointer event at pos.
 // Implements [gesture.GestureAware] for the unified pointer pipeline (ADR-049).
-func (b *Bar) GestureRecognizers() []gesture.Recognizer {
+// MenuBar is a leaf widget — always returns recognizers (hit-test already
+// confirmed bounds containment).
+func (b *Bar) GestureHitTest(_ geometry.Point) []gesture.Recognizer {
 	if b.clickRec == nil {
 		return nil
 	}

--- a/core/popover/popover.go
+++ b/core/popover/popover.go
@@ -313,9 +313,11 @@ func (p *Popover) Unmount() {
 	// Bindings are cleaned up automatically by WidgetBase.CleanupBindings().
 }
 
-// GestureRecognizers returns the gesture recognizers owned by this widget.
+// GestureHitTest returns the gesture recognizers for a pointer event at pos.
 // Implements [gesture.GestureAware] for the unified pointer pipeline (ADR-049).
-func (p *Popover) GestureRecognizers() []gesture.Recognizer {
+// Popover is a leaf widget — always returns recognizers (hit-test already
+// confirmed bounds containment).
+func (p *Popover) GestureHitTest(_ geometry.Point) []gesture.Recognizer {
 	if p.clickRec == nil {
 		return nil
 	}

--- a/core/radio/item.go
+++ b/core/radio/item.go
@@ -158,9 +158,11 @@ func (it *Item) Unmount() {
 	}
 }
 
-// GestureRecognizers returns the gesture recognizers owned by this item.
+// GestureHitTest returns the gesture recognizers for a pointer event at pos.
 // Implements [gesture.GestureAware] for the unified pointer pipeline (ADR-049).
-func (it *Item) GestureRecognizers() []gesture.Recognizer {
+// Radio item is a leaf widget — always returns recognizers (hit-test already
+// confirmed bounds containment).
+func (it *Item) GestureHitTest(_ geometry.Point) []gesture.Recognizer {
 	if it.clickRec == nil {
 		return nil
 	}

--- a/core/scrollview/event.go
+++ b/core/scrollview/event.go
@@ -332,67 +332,9 @@ func setScroll(w *Widget, ctx widget.Context, rawX, rawY float32) {
 	ctx.InvalidateRect(w.Bounds())
 }
 
-// setScrollDirect updates scroll position without requiring a widget.Context.
-// Used by gesture recognizer callbacks.
-func setScrollDirect(w *Widget, rawX, rawY float32) {
-	newX := clampScroll(rawX, w.contentSize.Width, w.viewportSize.Width)
-	newY := clampScroll(rawY, w.contentSize.Height, w.viewportSize.Height)
-
-	currentX := w.cfg.ResolvedScrollX()
-	currentY := w.cfg.ResolvedScrollY()
-
-	if newX == currentX && newY == currentY {
-		return
-	}
-
-	if w.cfg.scrollXSignal != nil {
-		w.cfg.scrollXSignal.Set(newX)
-	} else {
-		w.cfg.scrollX = newX
-	}
-
-	if w.cfg.scrollYSignal != nil {
-		w.cfg.scrollYSignal.Set(newY)
-	} else {
-		w.cfg.scrollY = newY
-	}
-
-	if w.cfg.onScroll != nil {
-		w.cfg.onScroll(newX, newY)
-	}
-
-	w.SetNeedsRedraw(true)
-}
-
-// handleDragUpdateDirect processes a drag position update for scrollbar
-// thumb dragging, without requiring a widget.Context.
-func handleDragUpdateDirect(w *Widget, pos geometry.Point) {
-	_, hTrack := w.computeTrackRects()
-	vTrack, _ := w.computeTrackRects()
-
-	switch w.dragging {
-	case dragVertical:
-		deltaPixels := pos.Y - w.dragStart.Y
-		trackLen := vTrack.Height()
-		thumbSize := computeThumbSize(w.viewportSize.Height, w.contentSize.Height, trackLen)
-		scrollableTrack := trackLen - thumbSize
-		if scrollableTrack > 0 {
-			maxScrollY := w.contentSize.Height - w.viewportSize.Height
-			newScrollY := w.dragScrollStart + deltaPixels*(maxScrollY/scrollableTrack)
-			setScrollDirect(w, w.cfg.ResolvedScrollX(), newScrollY)
-		}
-	case dragHorizontal:
-		deltaPixels := pos.X - w.dragStart.X
-		trackLen := hTrack.Width()
-		thumbSize := computeThumbSize(w.viewportSize.Width, w.contentSize.Width, trackLen)
-		scrollableTrack := trackLen - thumbSize
-		if scrollableTrack > 0 {
-			maxScrollX := w.contentSize.Width - w.viewportSize.Width
-			newScrollX := w.dragScrollStart + deltaPixels*(maxScrollX/scrollableTrack)
-			setScrollDirect(w, newScrollX, w.cfg.ResolvedScrollY())
-		}
-	}
-}
+// Gesture-based scroll helpers removed: ScrollView does not implement
+// GestureAware. Scrollbar drag is handled by Event() handler
+// (MousePress/Move/Release) with proper scrollbar hit-testing.
 
 // clampScroll clamps a scroll offset to [0, maxScroll].
 func clampScroll(offset, contentSize, viewportSize float32) float32 {

--- a/core/scrollview/widget.go
+++ b/core/scrollview/widget.go
@@ -68,29 +68,9 @@ func New(content widget.Widget, opts ...Option) *Widget {
 		w.painter = w.cfg.painter
 	}
 
-	// Create DragRecognizer for scrollbar thumb drag (ADR-049).
-	w.dragRec = gesture.NewDragRecognizer(gesture.DragConfig{
-		OnDragStart: func(_ gesture.DragStartDetails) {
-			// Drag start is handled by the existing handleMousePress which
-			// sets dragAxis and dragScrollStart based on hit-testing.
-		},
-		OnDragUpdate: func(details gesture.DragUpdateDetails) {
-			if w.dragging == dragNone {
-				return
-			}
-			handleDragUpdateDirect(w, details.LocalPosition)
-		},
-		OnDragEnd: func(_ gesture.DragEndDetails) {
-			w.dragging = dragNone
-			w.trackRepeat = trackRepeatState{}
-			w.MarkRedrawLocal()
-		},
-		OnDragCancel: func() {
-			w.dragging = dragNone
-			w.trackRepeat = trackRepeatState{}
-			w.MarkRedrawLocal()
-		},
-	})
+	// Scrollbar drag handled by Event() handler (MousePress/Move/Release).
+	// GestureAware intentionally not implemented: container widgets must not
+	// compete with child widget recognizers in the gesture arena.
 
 	return w
 }
@@ -421,14 +401,12 @@ func (w *Widget) Unmount() {
 	// Bindings are cleaned up automatically by WidgetBase.CleanupBindings().
 }
 
-// GestureRecognizers returns the gesture recognizers owned by this widget.
-// Implements [gesture.GestureAware] for the unified pointer pipeline (ADR-049).
-func (w *Widget) GestureRecognizers() []gesture.Recognizer {
-	if w.dragRec == nil {
-		return nil
-	}
-	return []gesture.Recognizer{w.dragRec}
-}
+// ScrollView does NOT implement GestureAware. Scrollbar drag is handled
+// by the Event() handler (MousePress/Move/Release) which correctly
+// hit-tests the scrollbar thumb area. Adding GestureAware would cause
+// ScrollView's DragRecognizer to compete with child widget recognizers
+// (e.g., TextField's TapAndDragRecognizer for text selection), consuming
+// drags that should reach the child.
 
 // Content returns the scroll view's content widget.
 func (w *Widget) Content() widget.Widget {
@@ -592,8 +570,9 @@ func (w *Widget) Padding(_ float32) *Widget {
 
 // Verify Widget implements required interfaces at compile time.
 var (
-	_ widget.Widget        = (*Widget)(nil)
-	_ widget.Focusable     = (*Widget)(nil)
-	_ widget.Lifecycle     = (*Widget)(nil)
-	_ gesture.GestureAware = (*Widget)(nil)
+	_ widget.Widget    = (*Widget)(nil)
+	_ widget.Focusable = (*Widget)(nil)
+	_ widget.Lifecycle = (*Widget)(nil)
+	// ScrollView intentionally does NOT implement gesture.GestureAware.
+	// See comment on GestureHitTest removal above.
 )

--- a/core/slider/widget.go
+++ b/core/slider/widget.go
@@ -208,9 +208,11 @@ func (w *Widget) Unmount() {
 	// Bindings are cleaned up automatically by WidgetBase.CleanupBindings().
 }
 
-// GestureRecognizers returns the gesture recognizers owned by this widget.
+// GestureHitTest returns the gesture recognizers for a pointer event at pos.
 // Implements [gesture.GestureAware] for the unified pointer pipeline (ADR-049).
-func (w *Widget) GestureRecognizers() []gesture.Recognizer {
+// Slider is a leaf widget — always returns recognizers (hit-test already
+// confirmed bounds containment).
+func (w *Widget) GestureHitTest(_ geometry.Point) []gesture.Recognizer {
 	return w.teamRecs
 }
 

--- a/core/splitview/splitview.go
+++ b/core/splitview/splitview.go
@@ -772,9 +772,11 @@ func (w *Widget) Unmount() {
 	// Bindings are cleaned up automatically by WidgetBase.CleanupBindings().
 }
 
-// GestureRecognizers returns the gesture recognizers owned by this widget.
+// GestureHitTest returns the gesture recognizers for a pointer event at pos.
 // Implements [gesture.GestureAware] for the unified pointer pipeline (ADR-049).
-func (w *Widget) GestureRecognizers() []gesture.Recognizer {
+// SplitView is a leaf widget — always returns recognizers (hit-test already
+// confirmed bounds containment).
+func (w *Widget) GestureHitTest(_ geometry.Point) []gesture.Recognizer {
 	if w.dragRec == nil {
 		return nil
 	}

--- a/core/stripe/widget.go
+++ b/core/stripe/widget.go
@@ -451,9 +451,11 @@ func (w *Widget) AccessibilityActions() []a11y.Action {
 // a11yLabel is the accessibility label for the stripe.
 const a11yLabel = "Tool Window Strip"
 
-// GestureRecognizers returns the gesture recognizers owned by this widget.
+// GestureHitTest returns the gesture recognizers for a pointer event at pos.
 // Implements [gesture.GestureAware] for the unified pointer pipeline (ADR-049).
-func (w *Widget) GestureRecognizers() []gesture.Recognizer {
+// Stripe is a leaf widget — always returns recognizers (hit-test already
+// confirmed bounds containment).
+func (w *Widget) GestureHitTest(_ geometry.Point) []gesture.Recognizer {
 	if w.clickRec == nil {
 		return nil
 	}

--- a/core/tabview/widget.go
+++ b/core/tabview/widget.go
@@ -294,10 +294,19 @@ func (w *Widget) Unmount() {
 	// Bindings are cleaned up automatically by WidgetBase.CleanupBindings().
 }
 
-// GestureRecognizers returns the gesture recognizers owned by this widget.
+// GestureHitTest returns the gesture recognizers for a pointer event at pos
+// (widget-local coordinates).
 // Implements [gesture.GestureAware] for the unified pointer pipeline (ADR-049).
-func (w *Widget) GestureRecognizers() []gesture.Recognizer {
+//
+// TabView is a container widget — returns recognizers ONLY when pos is
+// within the tab strip area. Content-area clicks return nil so child widgets'
+// recognizers are the sole participants in the gesture arena.
+func (w *Widget) GestureHitTest(pos geometry.Point) []gesture.Recognizer {
 	if w.clickRec == nil {
+		return nil
+	}
+	// tabBarBounds is in local coordinates (computed by computeTabLayout).
+	if !w.tabBarBounds.Contains(pos) {
 		return nil
 	}
 	return []gesture.Recognizer{w.clickRec}

--- a/core/textfield/textfield_test.go
+++ b/core/textfield/textfield_test.go
@@ -606,7 +606,7 @@ func TestMouse_DoubleClickSelectsWord(t *testing.T) {
 
 	// Double-click is now handled by the TapAndDragRecognizer.
 	// Simulate two rapid taps at the same position through the gesture system.
-	recs := tf.GestureRecognizers()
+	recs := tf.GestureHitTest(geometry.Pt(0, 0))
 	if len(recs) == 0 {
 		t.Fatal("TextField should have a TapAndDragRecognizer")
 	}
@@ -670,7 +670,7 @@ func TestMouse_TripleClickSelectsAll(t *testing.T) {
 	tf.SetBounds(geometry.NewRect(0, 0, 300, 48))
 	tf.SetFocused(true)
 
-	recs := tf.GestureRecognizers()
+	recs := tf.GestureHitTest(geometry.Pt(0, 0))
 	if len(recs) == 0 {
 		t.Fatal("TextField should have a TapAndDragRecognizer")
 	}
@@ -725,9 +725,9 @@ func TestTextField_GestureAwareInterface(t *testing.T) {
 		t.Fatal("TextField should implement gesture.GestureAware")
 	}
 
-	recs := ga.GestureRecognizers()
+	recs := ga.GestureHitTest(geometry.Pt(0, 0))
 	if len(recs) != 1 {
-		t.Errorf("GestureRecognizers() returned %d, want 1", len(recs))
+		t.Errorf("GestureHitTest() returned %d, want 1", len(recs))
 	}
 }
 

--- a/core/textfield/widget.go
+++ b/core/textfield/widget.go
@@ -456,9 +456,11 @@ func (w *Widget) Unmount() {
 	// Bindings are cleaned up automatically by WidgetBase.CleanupBindings().
 }
 
-// GestureRecognizers returns the gesture recognizers owned by this widget.
+// GestureHitTest returns the gesture recognizers for a pointer event at pos.
 // Implements [gesture.GestureAware] for the unified pointer pipeline (ADR-049).
-func (w *Widget) GestureRecognizers() []gesture.Recognizer {
+// TextField is a leaf widget — always returns recognizers (hit-test already
+// confirmed bounds containment).
+func (w *Widget) GestureHitTest(_ geometry.Point) []gesture.Recognizer {
 	if w.tapDrag == nil {
 		return nil
 	}

--- a/core/titlebar/titlebar.go
+++ b/core/titlebar/titlebar.go
@@ -759,9 +759,11 @@ func setBounds(child widget.Widget, bounds geometry.Rect) {
 	}
 }
 
-// GestureRecognizers returns the gesture recognizers owned by this widget.
+// GestureHitTest returns the gesture recognizers for a pointer event at pos.
 // Implements [gesture.GestureAware] for the unified pointer pipeline (ADR-049).
-func (w *Widget) GestureRecognizers() []gesture.Recognizer {
+// TitleBar is a leaf widget — always returns recognizers (hit-test already
+// confirmed bounds containment).
+func (w *Widget) GestureHitTest(_ geometry.Point) []gesture.Recognizer {
 	if w.clickRec == nil {
 		return nil
 	}

--- a/core/toolbar/toolbar.go
+++ b/core/toolbar/toolbar.go
@@ -701,9 +701,11 @@ func (w *Widget) AccessibilityActions() []a11y.Action {
 // a11yLabel is the accessibility label for the toolbar.
 const a11yLabel = "Toolbar"
 
-// GestureRecognizers returns the gesture recognizers owned by this widget.
+// GestureHitTest returns the gesture recognizers for a pointer event at pos.
 // Implements [gesture.GestureAware] for the unified pointer pipeline (ADR-049).
-func (w *Widget) GestureRecognizers() []gesture.Recognizer {
+// Toolbar is a leaf widget — always returns recognizers (hit-test already
+// confirmed bounds containment).
+func (w *Widget) GestureHitTest(_ geometry.Point) []gesture.Recognizer {
 	if w.clickRec == nil {
 		return nil
 	}

--- a/core/treeview/treeview.go
+++ b/core/treeview/treeview.go
@@ -271,9 +271,11 @@ func (w *Widget) Unmount() {
 	// Bindings are cleaned up automatically by WidgetBase.CleanupBindings().
 }
 
-// GestureRecognizers returns the gesture recognizers owned by this widget.
+// GestureHitTest returns the gesture recognizers for a pointer event at pos.
 // Implements [gesture.GestureAware] for the unified pointer pipeline (ADR-049).
-func (w *Widget) GestureRecognizers() []gesture.Recognizer {
+// TreeView is a leaf widget — always returns recognizers (hit-test already
+// confirmed bounds containment).
+func (w *Widget) GestureHitTest(_ geometry.Point) []gesture.Recognizer {
 	if w.clickRec == nil {
 		return nil
 	}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -497,11 +497,15 @@ PointerDown event arrives
 
 ```go
 type GestureAware interface {
-    GestureRecognizers() []Recognizer
+    GestureHitTest(pos geometry.Point) []Recognizer
 }
 ```
 
-All 20+ interactive widgets implement `GestureAware`. Widgets that do not implement it continue to receive events through the existing `Event(ctx, event.Event)` path.
+Leaf widgets (Button, Checkbox, TextField) always return their recognizers.
+Container widgets with partial interactive areas (Collapsible header, TabView tab strip,
+Docking zone tabs) return recognizers only when `pos` is within their interactive region.
+ScrollView intentionally does NOT implement GestureAware — scrollbar drag is handled by
+Event() handler with proper thumb hit-testing to avoid competing with child recognizers.
 
 **Signals integration:**
 Recognizers support opt-in reactive signals via functional options (e.g., `WithDraggingSignal` binds a `Signal[bool]` to drag state).

--- a/gesture/aware.go
+++ b/gesture/aware.go
@@ -1,5 +1,7 @@
 package gesture
 
+import "github.com/gogpu/ui/geometry"
+
 // GestureAware is an optional interface implemented by widgets that
 // participate in the gesture recognition system.
 //
@@ -12,23 +14,47 @@ package gesture
 // the same opt-in pattern used by [widget.Focusable] and
 // [widget.RepaintBoundaryMarker].
 //
-// Example:
+// GestureHitTest receives the pointer position in widget-local coordinates.
+// This allows container widgets with partial interactive regions (e.g., a
+// Collapsible header or TabView tab strip) to return recognizers ONLY when
+// the pointer is within the interactive region. Child widgets' recognizers
+// are then the sole participants in the gesture arena, preventing parent
+// containers from consuming clicks meant for children.
 //
-//	type MyButton struct {
-//	    widget.WidgetBase
-//	    click *gesture.ClickRecognizer
-//	}
+// Example — leaf widget (always returns recognizers):
 //
-//	func (b *MyButton) GestureRecognizers() []gesture.Recognizer {
+//	func (b *MyButton) GestureHitTest(_ geometry.Point) []gesture.Recognizer {
 //	    return []gesture.Recognizer{b.click}
 //	}
+//
+// Example — container widget with interactive header:
+//
+//	func (c *Collapsible) GestureHitTest(pos geometry.Point) []gesture.Recognizer {
+//	    if !c.headerBounds().Contains(pos) {
+//	        return nil // let children handle the gesture
+//	    }
+//	    return []gesture.Recognizer{c.click}
+//	}
 type GestureAware interface {
-	// GestureRecognizers returns the gesture recognizers owned by this widget.
-	// Called during PointerDown hit-testing. The returned recognizers are
-	// added to the gesture arena for the pointer that triggered the event.
+	// GestureHitTest returns the gesture recognizers that should participate
+	// in the gesture arena for a pointer event at the given position.
+	//
+	// pos is in widget-local coordinates (relative to the widget's own
+	// origin). The hit-test framework translates window coordinates to
+	// widget-local space before calling this method.
+	//
+	// Leaf widgets (Button, Checkbox, etc.) should always return their
+	// recognizers — the framework already confirmed the point is within
+	// the widget's bounds.
+	//
+	// Container widgets with partial interactive areas (Collapsible header,
+	// TabView tab strip, Docking zone tabs) MUST check whether pos falls
+	// within their interactive region before returning recognizers. If pos
+	// is outside the interactive region, return nil to let child widgets'
+	// recognizers be the sole participants in the arena.
 	//
 	// Implementations should return the same recognizer instances across
 	// calls (created once in the constructor or Mount), not new instances
 	// each time. The arena manages recognizer lifecycle per-pointer.
-	GestureRecognizers() []Recognizer
+	GestureHitTest(pos geometry.Point) []Recognizer
 }

--- a/gesture/aware_test.go
+++ b/gesture/aware_test.go
@@ -3,6 +3,7 @@ package gesture_test
 import (
 	"testing"
 
+	"github.com/gogpu/ui/geometry"
 	"github.com/gogpu/ui/gesture"
 )
 
@@ -11,7 +12,7 @@ type testGestureWidget struct {
 	recognizers []gesture.Recognizer
 }
 
-func (w *testGestureWidget) GestureRecognizers() []gesture.Recognizer {
+func (w *testGestureWidget) GestureHitTest(_ geometry.Point) []gesture.Recognizer {
 	return w.recognizers
 }
 
@@ -24,20 +25,20 @@ func TestGestureAware_InterfaceCompliance(t *testing.T) {
 		recognizers: []gesture.Recognizer{click},
 	}
 
-	recs := w.GestureRecognizers()
+	recs := w.GestureHitTest(geometry.Pt(0, 0))
 	if len(recs) != 1 {
-		t.Fatalf("GestureRecognizers() returned %d, want 1", len(recs))
+		t.Fatalf("GestureHitTest() returned %d, want 1", len(recs))
 	}
 	if recs[0] != click {
-		t.Error("GestureRecognizers() returned wrong recognizer")
+		t.Error("GestureHitTest() returned wrong recognizer")
 	}
 }
 
 func TestGestureAware_EmptyRecognizers(t *testing.T) {
 	w := &testGestureWidget{}
-	recs := w.GestureRecognizers()
+	recs := w.GestureHitTest(geometry.Pt(0, 0))
 	if len(recs) != 0 {
-		t.Errorf("GestureRecognizers() returned %d, want 0", len(recs))
+		t.Errorf("GestureHitTest() returned %d, want 0", len(recs))
 	}
 }
 
@@ -48,9 +49,9 @@ func TestGestureAware_MultipleRecognizers(t *testing.T) {
 		recognizers: []gesture.Recognizer{click, drag},
 	}
 
-	recs := w.GestureRecognizers()
+	recs := w.GestureHitTest(geometry.Pt(0, 0))
 	if len(recs) != 2 {
-		t.Fatalf("GestureRecognizers() returned %d, want 2", len(recs))
+		t.Fatalf("GestureHitTest() returned %d, want 2", len(recs))
 	}
 }
 


### PR DESCRIPTION
## Summary

- **GestureHitTest(pos)** replaces `GestureRecognizers()` — container widgets return recognizers only for their interactive region
  - Collapsible: header area only
  - TabView: tab strip only
  - Docking: zone tabs only
- **ScrollView GestureAware removed** — scrollbar drag handled by Event() handler
- **hitTestGestureRecursive**: window→widget-local coordinate translation via ScreenOrigin()
- **deps:** gg v0.52.3, gogpu v0.53.0, gpucontext v0.28.0, wgpu v0.31.4

Fixes gallery regression: parent container recognizers no longer consume child widget clicks.

## Test plan

- [x] `go build ./...` / `go test ./...` / `golangci-lint` — all pass
- [x] Gallery: checkboxes, textfield, dropdown, collapsible — all work
- [x] Minimal repro: text selection, double-click, clipboard — all work
- [x] IDE example: layout renders correctly