### PR TITLE
feat: add IME composition to TextField

### DIFF
--- a/app/app_test.go
+++ b/app/app_test.go
@@ -19,6 +19,7 @@ type mockWidget struct {
 	drawCalled   bool
 	eventCalled  bool
 	lastEvent    event.Event
+	events       []event.Event
 	layoutSize   geometry.Size
 }
 
@@ -40,6 +41,7 @@ func (m *mockWidget) Draw(_ widget.Context, _ widget.Canvas) {
 func (m *mockWidget) Event(_ widget.Context, e event.Event) bool {
 	m.eventCalled = true
 	m.lastEvent = e
+	m.events = append(m.events, e)
 	return true
 }
 
@@ -61,6 +63,39 @@ func (m *mockWindowProvider) ScaleFactor() float64 {
 func (m *mockWindowProvider) RequestRedraw() {
 	m.redrawCount++
 }
+
+// mockIMEWindowProvider records the optional v2 controller calls made by the
+// Window IME synchronizer while retaining the normal WindowProvider behavior.
+type mockIMEWindowProvider struct {
+	mockWindowProvider
+	positions    []geometry.Point
+	enabled      []bool
+	areas        []gpucontext.IMECursorArea
+	contentTypes [][2]any
+	surrounding  []gpucontext.IMESurroundingText
+}
+
+func (m *mockIMEWindowProvider) SetIMEPosition(x, y int) {
+	m.positions = append(m.positions, geometry.Pt(float32(x), float32(y)))
+}
+
+func (m *mockIMEWindowProvider) SetIMEEnabled(enabled bool) {
+	m.enabled = append(m.enabled, enabled)
+}
+
+func (m *mockIMEWindowProvider) SetIMECursorArea(area gpucontext.IMECursorArea) {
+	m.areas = append(m.areas, area)
+}
+
+func (m *mockIMEWindowProvider) SetIMEContentType(purpose gpucontext.ContentPurpose, hints gpucontext.ContentHint) {
+	m.contentTypes = append(m.contentTypes, [2]any{purpose, hints})
+}
+
+func (m *mockIMEWindowProvider) SetIMESurroundingText(text gpucontext.IMESurroundingText) {
+	m.surrounding = append(m.surrounding, text)
+}
+
+func (m *mockIMEWindowProvider) CancelIME() {}
 
 // mockPlatformProvider implements gpucontext.PlatformProvider for testing.
 type mockPlatformProvider struct {
@@ -87,18 +122,42 @@ func (m *mockPlatformProvider) FontSmoothing() gpucontext.FontSmoothing {
 
 // mockEventSource implements gpucontext.EventSource and gpucontext.PointerEventSource for testing.
 type mockEventSource struct {
-	onKeyPress            func(gpucontext.Key, gpucontext.Modifiers)
-	onKeyRelease          func(gpucontext.Key, gpucontext.Modifiers)
-	onTextInput           func(string)
-	onMouseMove           func(float64, float64)
-	onMousePress          func(gpucontext.MouseButton, float64, float64)
-	onMouseRelease        func(gpucontext.MouseButton, float64, float64)
-	onScroll              func(float64, float64)
-	onResize              func(int, int)
-	onFocus               func(bool)
-	onIMECompositionStart func()
-	onIMECompositionEnd   func(string)
-	onPointer             func(gpucontext.PointerEvent)
+	onKeyPress             func(gpucontext.Key, gpucontext.Modifiers)
+	onKeyRelease           func(gpucontext.Key, gpucontext.Modifiers)
+	onTextInput            func(string)
+	onMouseMove            func(float64, float64)
+	onMousePress           func(gpucontext.MouseButton, float64, float64)
+	onMouseRelease         func(gpucontext.MouseButton, float64, float64)
+	onScroll               func(float64, float64)
+	onResize               func(int, int)
+	onFocus                func(bool)
+	onIMECompositionStart  func()
+	onIMECompositionUpdate func(gpucontext.IMEState)
+	onIMECompositionEnd    func(string)
+	onPointer              func(gpucontext.PointerEvent)
+}
+
+// mockV2EventSource exposes the additive IME callbacks without changing the
+// legacy mock's behavior. It is used to verify that the UI bridge subscribes
+// to one versioned update stream and routes a commit exactly once.
+type mockV2EventSource struct {
+	mockEventSource
+	onIMECompositionUpdateV2 func(gpucontext.IMEComposition)
+	onIMECanceled            func()
+	onIMEDisabled            func()
+	onIMEDeleteSurrounding   func(gpucontext.IMEDeleteSurroundingEvent)
+}
+
+func (m *mockV2EventSource) OnIMECompositionUpdateV2(fn func(gpucontext.IMEComposition)) {
+	m.onIMECompositionUpdateV2 = fn
+}
+
+func (m *mockV2EventSource) OnIMECanceled(fn func()) { m.onIMECanceled = fn }
+
+func (m *mockV2EventSource) OnIMEDisabled(fn func()) { m.onIMEDisabled = fn }
+
+func (m *mockV2EventSource) OnIMEDeleteSurrounding(fn func(gpucontext.IMEDeleteSurroundingEvent)) {
+	m.onIMEDeleteSurrounding = fn
 }
 
 func (m *mockEventSource) OnKeyPress(fn func(gpucontext.Key, gpucontext.Modifiers)) {
@@ -131,7 +190,9 @@ func (m *mockEventSource) OnFocus(fn func(bool)) {
 func (m *mockEventSource) OnIMECompositionStart(fn func()) {
 	m.onIMECompositionStart = fn
 }
-func (m *mockEventSource) OnIMECompositionUpdate(func(gpucontext.IMEState)) {}
+func (m *mockEventSource) OnIMECompositionUpdate(fn func(gpucontext.IMEState)) {
+	m.onIMECompositionUpdate = fn
+}
 func (m *mockEventSource) OnIMECompositionEnd(fn func(string)) {
 	m.onIMECompositionEnd = fn
 }

--- a/app/event_bridge.go
+++ b/app/event_bridge.go
@@ -67,6 +67,8 @@ func (s *eventBridgeState) scrollAllowed() bool {
 // application's event loop.
 func attachEventBridge(es gpucontext.EventSource, w *Window) {
 	st := &eventBridgeState{}
+	ime := &imeBridgeState{}
+	w.setIMEController(es)
 
 	_, hasPointerSource := es.(gpucontext.PointerEventSource)
 
@@ -134,7 +136,8 @@ func attachEventBridge(es gpucontext.EventSource, w *Window) {
 		})
 	}
 
-	attachKeyboardBridge(es, w, &st.mods)
+	attachKeyboardBridge(es, w, &st.mods, ime)
+	attachIMEBridge(es, w, ime)
 	attachScrollBridge(es, w, st)
 
 	es.OnResize(func(width, height int) {
@@ -239,8 +242,9 @@ func attachScrollBridge(es gpucontext.EventSource, w *Window, st *eventBridgeSta
 }
 
 // attachKeyboardBridge wires keyboard and text input callbacks.
-func attachKeyboardBridge(es gpucontext.EventSource, w *Window, mods *event.Modifiers) {
+func attachKeyboardBridge(es gpucontext.EventSource, w *Window, mods *event.Modifiers, ime *imeBridgeState) {
 	es.OnKeyPress(func(key gpucontext.Key, platMods gpucontext.Modifiers) {
+		ime.noteKeyPress()
 		uiKey := translateKey(key)
 		uiMods := translateModifiers(platMods)
 		// A key event reports the modifiers held BEFORE it, so pressing Shift
@@ -275,15 +279,121 @@ func attachKeyboardBridge(es gpucontext.EventSource, w *Window, mods *event.Modi
 	})
 
 	es.OnTextInput(func(text string) {
-		for _, r := range text {
-			e := event.NewKeyEvent(
-				event.KeyPress,
-				event.KeyUnknown,
-				r,
-				event.ModNone,
-			)
-			w.HandleEvent(e)
+		if ime.dropTextInput(text) {
+			return
 		}
+		if ime.active {
+			// Some platform bridges deliver a committed result through
+			// OnTextInput before the explicit composition-end callback. Keep
+			// the text routed normally, but remember it so the end callback
+			// cannot insert the same result a second time.
+			ime.lastText += text
+		}
+		dispatchTextInput(w, text)
+	})
+}
+
+// imeBridgeState keeps the small amount of ordering state needed to make
+// legacy OnTextInput and the versioned IME commit callback exactly-once. The
+// native P3 bridge already suppresses WM_CHAR echoes, but retaining this guard
+// at the UI boundary protects other backends and test doubles as well.
+type imeBridgeState struct {
+	active       bool
+	lastText     string
+	suppressNext string
+}
+
+func (s *imeBridgeState) noteKeyPress() {
+	// A new key gesture cannot be an echo of the previous IME result.
+	s.suppressNext = ""
+}
+
+func (s *imeBridgeState) dropTextInput(text string) bool {
+	if s.suppressNext == "" || text != s.suppressNext {
+		return false
+	}
+	s.suppressNext = ""
+	return true
+}
+
+func (s *imeBridgeState) begin() {
+	s.active = true
+	s.lastText = ""
+	s.suppressNext = ""
+}
+
+func (s *imeBridgeState) end(committed string) string {
+	duplicate := committed != "" && committed == s.lastText
+	s.active = false
+	s.lastText = ""
+	if duplicate {
+		s.suppressNext = ""
+		return ""
+	}
+	s.suppressNext = committed
+	return committed
+}
+
+func (s *imeBridgeState) cancel() {
+	s.active = false
+	s.lastText = ""
+	s.suppressNext = ""
+}
+
+func dispatchTextInput(w *Window, text string) {
+	for _, r := range text {
+		e := event.NewKeyEvent(
+			event.KeyPress,
+			event.KeyUnknown,
+			r,
+			event.ModNone,
+		)
+		w.HandleEvent(e)
+	}
+}
+
+// attachIMEBridge subscribes to the optional versioned IME event extension
+// when the host provides it. Legacy update callbacks are used only when the
+// extension is absent; the P3 adapter emits both forms, so subscribing to both
+// would render every preedit twice.
+func attachIMEBridge(es gpucontext.EventSource, w *Window, bridgeState *imeBridgeState) {
+	es.OnIMECompositionStart(func() {
+		bridgeState.begin()
+		w.HandleEvent(event.NewIMECompositionStartEvent())
+	})
+
+	if v2, ok := es.(gpucontext.IMEEventSourceV2); ok {
+		v2.OnIMECompositionUpdateV2(func(composition gpucontext.IMEComposition) {
+			bridgeState.active = true
+			w.HandleEvent(event.NewIMECompositionUpdateEvent(composition))
+		})
+		v2.OnIMECanceled(func() {
+			bridgeState.cancel()
+			w.HandleEvent(event.NewIMECanceledEvent())
+		})
+		v2.OnIMEDisabled(func() {
+			bridgeState.cancel()
+			w.HandleEvent(event.NewIMEDisabledEvent())
+		})
+		v2.OnIMEDeleteSurrounding(func(request gpucontext.IMEDeleteSurroundingEvent) {
+			w.HandleEvent(event.NewIMEDeleteSurroundingEvent(request))
+		})
+	} else {
+		es.OnIMECompositionUpdate(func(state gpucontext.IMEState) {
+			state.Composing = true
+			// Legacy providers are allowed to omit the explicit start callback;
+			// an update still establishes the duplicate-suppression window.
+			bridgeState.active = true
+			w.HandleEvent(event.NewIMECompositionUpdateEvent(state.Composition()))
+		})
+	}
+
+	es.OnIMECompositionEnd(func(committed string) {
+		accepted := bridgeState.end(committed)
+		// Always send an end event so the widget clears its preedit. If the
+		// legacy text callback already delivered the result, the payload is
+		// intentionally empty and cannot commit it twice.
+		w.HandleEvent(event.NewIMECompositionEndEvent(accepted))
 	})
 }
 

--- a/app/event_bridge.go
+++ b/app/event_bridge.go
@@ -1,6 +1,9 @@
 package app
 
 import (
+	"strings"
+	"unicode/utf8"
+
 	"github.com/gogpu/gpucontext"
 	"github.com/gogpu/ui/event"
 	"github.com/gogpu/ui/geometry"
@@ -68,6 +71,7 @@ func (s *eventBridgeState) scrollAllowed() bool {
 func attachEventBridge(es gpucontext.EventSource, w *Window) {
 	st := &eventBridgeState{}
 	ime := &imeBridgeState{}
+	w.imeBridge = ime
 	w.setIMEController(es)
 
 	_, hasPointerSource := es.(gpucontext.PointerEventSource)
@@ -150,6 +154,11 @@ func attachEventBridge(es gpucontext.EventSource, w *Window) {
 		// somewhere else and this window never saw it.
 		st.mods = event.ModNone
 		if !focused {
+			// Native focus loss invalidates the current IME session. Backends can
+			// queue a final end/echo after this callback; cancel the bridge state
+			// before dispatching FocusLost so that stale text cannot commit when
+			// the platform callback arrives later.
+			ime.invalidate()
 			// The cursor may leave the window while focus is switching to
 			// another application. Without a PointerLeave, the bridge
 			// would continue to believe the cursor is inside, allowing
@@ -244,6 +253,9 @@ func attachScrollBridge(es gpucontext.EventSource, w *Window, st *eventBridgeSta
 // attachKeyboardBridge wires keyboard and text input callbacks.
 func attachKeyboardBridge(es gpucontext.EventSource, w *Window, mods *event.Modifiers, ime *imeBridgeState) {
 	es.OnKeyPress(func(key gpucontext.Key, platMods gpucontext.Modifiers) {
+		if !w.prepareIMEInput(ime) {
+			return
+		}
 		ime.noteKeyPress()
 		uiKey := translateKey(key)
 		uiMods := translateModifiers(platMods)
@@ -279,15 +291,11 @@ func attachKeyboardBridge(es gpucontext.EventSource, w *Window, mods *event.Modi
 	})
 
 	es.OnTextInput(func(text string) {
-		if ime.dropTextInput(text) {
+		if !w.prepareIMEInput(ime) {
 			return
 		}
-		if ime.active {
-			// Some platform bridges deliver a committed result through
-			// OnTextInput before the explicit composition-end callback. Keep
-			// the text routed normally, but remember it so the end callback
-			// cannot insert the same result a second time.
-			ime.lastText += text
+		if ime.dropTextInput(text) {
+			return
 		}
 		dispatchTextInput(w, text)
 	})
@@ -298,46 +306,186 @@ func attachKeyboardBridge(es gpucontext.EventSource, w *Window, mods *event.Modi
 // native P3 bridge already suppresses WM_CHAR echoes, but retaining this guard
 // at the UI boundary protects other backends and test doubles as well.
 type imeBridgeState struct {
-	active       bool
-	lastText     string
-	suppressNext string
+	active bool
+	// hasComposition distinguishes a native preedit lifecycle from standalone
+	// text callbacks. Both feed the same exactly-once window, but a later
+	// composition update must reset any ordinary text accumulated beforehand.
+	hasComposition bool
+	lastText       string
+	suppressNext   string
+	// suppressPartial covers a suffix returned by commitWithoutEcho when a
+	// backend delivered only a prefix through OnTextInput before composition
+	// end. Hosts may echo either the full result or that suffix afterward.
+	suppressPartial string
+	// ended makes a repeated end callback for one native session idempotent.
+	// Backends normally emit one end, but queued teardown messages can otherwise
+	// commit the same result twice at the UI boundary.
+	ended bool
+	// canceled remains set until a new explicit composition start. This closes
+	// the teardown race where a backend queues IME end after focus loss or
+	// disabled/canceled notification.
+	canceled bool
 }
 
 func (s *imeBridgeState) noteKeyPress() {
 	// A new key gesture cannot be an echo of the previous IME result.
 	s.suppressNext = ""
+	s.suppressPartial = ""
+	if s.canceled {
+		// A key press establishes a fresh input gesture after cancellation. Keep
+		// ended set so a queued end from the canceled session remains blocked
+		// until explicit composition start or a new text payload arrives.
+		s.canceled = false
+		s.ended = true
+	}
 }
 
 func (s *imeBridgeState) dropTextInput(text string) bool {
-	if s.suppressNext == "" || text != s.suppressNext {
+	if s.canceled {
+		// Cancellation invalidates all text already queued by the native session.
+		// A subsequent key press clears this state; until then, do not leak a
+		// stale result into the focused field.
+		return true
+	}
+	matchesFull := s.suppressNext != "" && text == s.suppressNext
+	matchesPartial := s.suppressPartial != "" && text == s.suppressPartial
+	if !matchesFull && !matchesPartial {
+		// A different payload is not the armed echo; expire the old guard before
+		// opening a possible new direct-input session.
+		s.suppressNext = ""
+		s.suppressPartial = ""
+		if !s.active && !s.ended {
+			s.active = true
+			s.hasComposition = false
+			s.lastText = ""
+		}
+		if s.ended {
+			// A text callback after a completed session can be the first signal of
+			// a new direct-input gesture on hosts that omit composition start. It
+			// establishes a new deduplication window; a queued duplicate end with
+			// no such text remains blocked by ended.
+			s.active = true
+			s.hasComposition = false
+			s.lastText = ""
+			s.ended = false
+		}
+		if s.active {
+			s.lastText += text
+		}
 		return false
 	}
-	s.suppressNext = ""
+	// Keep suppressing the same post-END echo until a new key gesture or
+	// composition start establishes a new session. Some backends queue the
+	// same result through more than one text-input callback; clearing after the
+	// first callback would reinsert the duplicate.
+	if !s.ended {
+		if matchesFull {
+			s.suppressNext = ""
+		}
+		if matchesPartial {
+			s.suppressPartial = ""
+		}
+	}
 	return true
 }
 
 func (s *imeBridgeState) begin() {
 	s.active = true
+	s.hasComposition = true
 	s.lastText = ""
 	s.suppressNext = ""
+	s.suppressPartial = ""
+	s.ended = false
+	s.canceled = false
+}
+
+// update establishes (or continues) a native preedit lifecycle. A provider
+// may omit the explicit start callback; in that case reset any standalone
+// text that was already routed before the first update.
+func (s *imeBridgeState) update() {
+	if !s.hasComposition {
+		s.lastText = ""
+		s.suppressNext = ""
+		s.suppressPartial = ""
+	}
+	s.active = true
+	s.hasComposition = true
+	s.ended = false
+	s.canceled = false
 }
 
 func (s *imeBridgeState) end(committed string) string {
-	duplicate := committed != "" && committed == s.lastText
+	if s.canceled && !s.active {
+		// A queued end after cancellation/disabled/focus loss belongs to the
+		// invalidated session and must not commit into a replacement focus.
+		return ""
+	}
+	if !s.active && s.ended {
+		// A second native end before a new composition start belongs to the
+		// already-finished session, even if a stale callback carries a
+		// different payload. Do not let a queued teardown message commit into a
+		// subsequent key gesture.
+		return ""
+	}
+	accepted := commitWithoutEcho(s.lastText, committed)
 	s.active = false
+	s.hasComposition = false
 	s.lastText = ""
-	if duplicate {
-		s.suppressNext = ""
+	s.ended = true
+	s.suppressPartial = ""
+	if accepted == "" && committed != "" {
+		// The text callback already delivered the commit. Keep the same echo
+		// guard armed for a post-END duplicate from a backend that reports both
+		// callback forms.
+		s.suppressNext = committed
 		return ""
 	}
 	s.suppressNext = committed
+	if accepted != "" && accepted != committed {
+		s.suppressPartial = accepted
+	}
+	return accepted
+}
+
+// commitWithoutEcho removes text that was already delivered through the
+// legacy text-input callback before the explicit composition-end callback.
+// Native adapters usually avoid this ordering, but a few hosts can expose a
+// partial commit (for example "候" followed by end("候補")); inserting the
+// complete end payload would duplicate the prefix. Only UTF-8 boundary-aligned
+// prefixes are considered, so unrelated text is never discarded.
+func commitWithoutEcho(already, committed string) string {
+	if already == "" || committed == "" ||
+		!utf8.ValidString(already) || !utf8.ValidString(committed) {
+		return committed
+	}
+	if already == committed || strings.HasPrefix(committed, already) {
+		return committed[len(already):]
+	}
+	if strings.HasPrefix(already, committed) {
+		return ""
+	}
+
 	return committed
 }
 
 func (s *imeBridgeState) cancel() {
+	hadSession := s.active || s.ended || s.lastText != "" || s.suppressNext != "" || s.suppressPartial != ""
 	s.active = false
+	s.hasComposition = false
 	s.lastText = ""
 	s.suppressNext = ""
+	s.suppressPartial = ""
+	s.ended = false
+	s.canceled = hadSession
+}
+
+// invalidate marks the current native session unusable even when no start or
+// update callback has reached the UI yet. This is required for disabled,
+// focus-loss, and teardown notifications: a queued text/end callback must not
+// become the first event in a replacement field.
+func (s *imeBridgeState) invalidate() {
+	s.cancel()
+	s.canceled = true
 }
 
 func dispatchTextInput(w *Window, text string) {
@@ -357,38 +505,82 @@ func dispatchTextInput(w *Window, text string) {
 // extension is absent; the P3 adapter emits both forms, so subscribing to both
 // would render every preedit twice.
 func attachIMEBridge(es gpucontext.EventSource, w *Window, bridgeState *imeBridgeState) {
+	// A v2 event source is only useful when the host advertises composition
+	// support. Capability providers may live on either the WindowProvider or
+	// EventSource, so discover them through Window rather than assuming both
+	// interfaces are implemented by the same object. Legacy update callbacks
+	// remain the fallback for a versioned host that lacks v2 composition.
+	capabilityProvider := w.resolveIMECapabilities()
+	capabilities := gpucontext.IMECapabilities{}
+	capabilitiesKnown := capabilityProvider != nil
+	if capabilitiesKnown {
+		capabilities = capabilityProvider.IMECapabilities()
+	}
+	supports := func(feature gpucontext.IMECapability) bool {
+		return !capabilitiesKnown ||
+			(capabilities.Version >= gpucontext.IMEContractVersion && capabilities.Supports(feature))
+	}
+
 	es.OnIMECompositionStart(func() {
+		if !w.prepareIMEInput(bridgeState) {
+			return
+		}
 		bridgeState.begin()
 		w.HandleEvent(event.NewIMECompositionStartEvent())
 	})
 
-	if v2, ok := es.(gpucontext.IMEEventSourceV2); ok {
+	v2, hasV2 := es.(gpucontext.IMEEventSourceV2)
+	if hasV2 && supports(gpucontext.IMECapabilityComposition) {
 		v2.OnIMECompositionUpdateV2(func(composition gpucontext.IMEComposition) {
-			bridgeState.active = true
+			if !w.prepareIMEInput(bridgeState) {
+				return
+			}
+			bridgeState.update()
 			w.HandleEvent(event.NewIMECompositionUpdateEvent(composition))
-		})
-		v2.OnIMECanceled(func() {
-			bridgeState.cancel()
-			w.HandleEvent(event.NewIMECanceledEvent())
-		})
-		v2.OnIMEDisabled(func() {
-			bridgeState.cancel()
-			w.HandleEvent(event.NewIMEDisabledEvent())
-		})
-		v2.OnIMEDeleteSurrounding(func(request gpucontext.IMEDeleteSurroundingEvent) {
-			w.HandleEvent(event.NewIMEDeleteSurroundingEvent(request))
 		})
 	} else {
 		es.OnIMECompositionUpdate(func(state gpucontext.IMEState) {
+			if !w.prepareIMEInput(bridgeState) {
+				return
+			}
 			state.Composing = true
 			// Legacy providers are allowed to omit the explicit start callback;
 			// an update still establishes the duplicate-suppression window.
-			bridgeState.active = true
+			bridgeState.update()
 			w.HandleEvent(event.NewIMECompositionUpdateEvent(state.Composition()))
+		})
+	}
+	if hasV2 && supports(gpucontext.IMECapabilityCancel) {
+		v2.OnIMECanceled(func() {
+			bridgeState.invalidate()
+			if !w.prepareIMEInput(bridgeState) {
+				return
+			}
+			w.HandleEvent(event.NewIMECanceledEvent())
+		})
+	}
+	if hasV2 && supports(gpucontext.IMECapabilityDisabled) {
+		v2.OnIMEDisabled(func() {
+			bridgeState.invalidate()
+			if !w.prepareIMEInput(bridgeState) {
+				return
+			}
+			w.HandleEvent(event.NewIMEDisabledEvent())
+		})
+	}
+	if hasV2 && supports(gpucontext.IMECapabilityDeleteSurrounding) {
+		v2.OnIMEDeleteSurrounding(func(request gpucontext.IMEDeleteSurroundingEvent) {
+			if !w.prepareIMEInput(bridgeState) {
+				return
+			}
+			w.HandleEvent(event.NewIMEDeleteSurroundingEvent(request))
 		})
 	}
 
 	es.OnIMECompositionEnd(func(committed string) {
+		if !w.prepareIMEInput(bridgeState) {
+			return
+		}
 		accepted := bridgeState.end(committed)
 		// Always send an end event so the widget clears its preedit. If the
 		// legacy text callback already delivered the result, the payload is

--- a/app/event_bridge_test.go
+++ b/app/event_bridge_test.go
@@ -32,6 +32,9 @@ func TestEventBridge_V2IMECommitExactlyOnce(t *testing.T) {
 	// A backend may still echo the result through the legacy text callback;
 	// the bridge must drop that echo after routing the explicit end commit.
 	es.onTextInput("東京")
+	es.onTextInput("東京")
+	// A queued duplicate end from the same native session is also ignored.
+	es.onIMECompositionEnd("東京")
 
 	var keyEvents, updates, ends int
 	for _, raw := range root.events {
@@ -44,7 +47,7 @@ func TestEventBridge_V2IMECommitExactlyOnce(t *testing.T) {
 			if e.IsCompositionUpdate() {
 				updates++
 			}
-			if e.IsCompositionEnd() {
+			if e.IsCompositionEnd() && e.Committed != "" {
 				ends++
 				if e.Committed != "東京" {
 					t.Fatalf("end commit = %q, want 東京", e.Committed)
@@ -55,6 +58,313 @@ func TestEventBridge_V2IMECommitExactlyOnce(t *testing.T) {
 	if keyEvents != 0 || updates != 1 || ends != 1 {
 		t.Fatalf("IME routed key=%d updates=%d ends=%d events=%#v, want 0/1/1", keyEvents, updates, ends, root.events)
 	}
+}
+
+// legacyIMEOnlyWindowProvider deliberately exposes only the original
+// controller methods. A separate event source in the fallback test provides
+// the richer v2 controller, matching hosts that split these surfaces.
+type legacyIMEOnlyWindowProvider struct {
+	mockWindowProvider
+	positions []geometry.Point
+	enabled   []bool
+}
+
+func (p *legacyIMEOnlyWindowProvider) SetIMEPosition(x, y int) {
+	p.positions = append(p.positions, geometry.Pt(float32(x), float32(y)))
+}
+
+func (p *legacyIMEOnlyWindowProvider) SetIMEEnabled(enabled bool) {
+	p.enabled = append(p.enabled, enabled)
+}
+
+type v2ControllerEventSource struct {
+	mockV2EventSource
+	positions    []geometry.Point
+	enabled      []bool
+	areas        []gpucontext.IMECursorArea
+	contentTypes [][2]any
+	surrounding  []gpucontext.IMESurroundingText
+	sequence     []string
+	cancels      int
+}
+
+func (s *v2ControllerEventSource) SetIMEPosition(x, y int) {
+	s.sequence = append(s.sequence, "position")
+	s.positions = append(s.positions, geometry.Pt(float32(x), float32(y)))
+}
+
+func (s *v2ControllerEventSource) SetIMEEnabled(enabled bool) {
+	s.sequence = append(s.sequence, "enabled")
+	s.enabled = append(s.enabled, enabled)
+}
+
+func (s *v2ControllerEventSource) SetIMECursorArea(area gpucontext.IMECursorArea) {
+	s.sequence = append(s.sequence, "area")
+	s.areas = append(s.areas, area)
+}
+
+func (s *v2ControllerEventSource) SetIMEContentType(purpose gpucontext.ContentPurpose, hints gpucontext.ContentHint) {
+	s.sequence = append(s.sequence, "content")
+	s.contentTypes = append(s.contentTypes, [2]any{purpose, hints})
+}
+
+func (s *v2ControllerEventSource) SetIMESurroundingText(text gpucontext.IMESurroundingText) {
+	s.sequence = append(s.sequence, "surrounding")
+	s.surrounding = append(s.surrounding, text)
+}
+
+func (s *v2ControllerEventSource) CancelIME() {
+	s.cancels++
+	s.sequence = append(s.sequence, "cancel")
+}
+
+func TestWindowIMEIgnoresLateEventsAfterFocusLoss(t *testing.T) {
+	es := &mockV2EventSource{}
+	p := &imeStatePainter{}
+	a := New(WithEventSource(es))
+	tf := textfield.New(textfield.PainterOpt(p))
+	a.SetRoot(tf)
+	a.Window().Context().RequestFocus(tf)
+	a.Window().Frame()
+
+	es.onIMECompositionStart()
+	es.onIMECompositionUpdateV2(testIMEComposition())
+	tf.Draw(a.Window().Context(), &recordingCanvas{})
+	if !p.state.ShowComposition {
+		t.Fatal("composition did not become visible before focus loss")
+	}
+
+	a.Window().HandleFocusChange(false)
+	es.onIMECompositionUpdateV2(testIMEComposition())
+	tf.Draw(a.Window().Context(), &recordingCanvas{})
+	if p.state.ShowComposition {
+		t.Fatalf("late IME update resurrected preedit after focus loss: %#v", p.state)
+	}
+}
+
+func TestWindowSetRootAndCloseDisableFocusedIME(t *testing.T) {
+	wp := &mockIMEWindowProvider{mockWindowProvider: mockWindowProvider{width: 400, height: 200, scale: 1}}
+	a := New(WithWindowProvider(wp))
+	first := textfield.New(textfield.InitialValue("first"))
+	second := textfield.New(textfield.InitialValue("second"))
+	a.SetRoot(first)
+	a.Window().Context().RequestFocus(first)
+	a.Window().Frame()
+	if len(wp.enabled) == 0 || !wp.enabled[len(wp.enabled)-1] {
+		t.Fatalf("initial enabled calls = %#v, want true", wp.enabled)
+	}
+
+	a.SetRoot(second)
+	if wp.enabled[len(wp.enabled)-1] {
+		t.Fatalf("root replacement retained IME enabled: %#v", wp.enabled)
+	}
+
+	a.Window().Context().RequestFocus(second)
+	a.Window().Frame()
+	if !wp.enabled[len(wp.enabled)-1] {
+		t.Fatalf("replacement field did not re-enable IME: %#v", wp.enabled)
+	}
+	a.Window().Close()
+	if wp.enabled[len(wp.enabled)-1] {
+		t.Fatalf("close retained IME enabled: %#v", wp.enabled)
+	}
+}
+
+func TestEventBridgeDropsQueuedEventsAcrossRootReplacement(t *testing.T) {
+	es := &mockV2EventSource{}
+	a := New(WithEventSource(es))
+	first := textfield.New(textfield.InitialValue("first"))
+	second := textfield.New(textfield.InitialValue("second"))
+	a.SetRoot(first)
+	a.Window().Context().RequestFocus(first)
+	a.Window().Frame()
+	es.onIMECompositionStart()
+	es.onIMECompositionUpdateV2(testIMEComposition())
+	a.SetRoot(second)
+	es.onTextInput("stale")
+	es.onIMECompositionEnd("stale")
+	if first.Text() != "first" || second.Text() != "second" {
+		t.Fatalf("root replacement accepted stale IME text: first=%q second=%q", first.Text(), second.Text())
+	}
+}
+
+func TestWindowPrefersSplitV2ControllerOverLegacyProvider(t *testing.T) {
+	wp := &legacyIMEOnlyWindowProvider{mockWindowProvider: mockWindowProvider{width: 400, height: 200, scale: 1}}
+	es := &v2ControllerEventSource{}
+	a := New(WithWindowProvider(wp), WithEventSource(es))
+	tf := textfield.New(textfield.InitialValue("hello"))
+	a.SetRoot(tf)
+	a.Window().Context().RequestFocus(tf)
+	a.Window().Frame()
+	if len(es.enabled) == 0 || !es.enabled[len(es.enabled)-1] {
+		t.Fatalf("split v2 controller enabled calls = %#v, want true", es.enabled)
+	}
+	if len(wp.enabled) != 0 {
+		t.Fatalf("legacy provider unexpectedly received v2 session calls: %#v", wp.enabled)
+	}
+}
+
+func TestWindowCancelsNativeIMEWhenFocusOwnerChangesWithSameSnapshot(t *testing.T) {
+	es := &v2ControllerEventSource{}
+	a := New(WithEventSource(es))
+	a.SetRoot(newMockWidget())
+	first := textfield.New(textfield.InitialValue("same"))
+	second := textfield.New(textfield.InitialValue("same"))
+	a.Window().Context().RequestFocus(first)
+	a.Window().Frame()
+	a.Window().Context().RequestFocus(second)
+	a.Window().Frame()
+	if es.cancels == 0 {
+		t.Fatalf("native CancelIME calls=%d, want focus-owner transition cancellation", es.cancels)
+	}
+}
+
+func TestEventBridgeDropsEndQueuedBetweenFocusSwitchAndFrame(t *testing.T) {
+	es := &mockV2EventSource{}
+	a := New(WithEventSource(es))
+	a.SetRoot(newMockWidget())
+	first := textfield.New(textfield.InitialValue("first"))
+	second := textfield.New(textfield.InitialValue("second"))
+	a.Window().Context().RequestFocus(first)
+	a.Window().Frame()
+	es.onIMECompositionStart()
+	es.onIMECompositionUpdateV2(testIMEComposition())
+	a.Window().Context().RequestFocus(second)
+	// No Frame has run yet; the bridge must still observe the Context owner
+	// change before routing this queued end callback.
+	es.onIMECompositionEnd("stale")
+	if second.Text() != "second" {
+		t.Fatalf("queued end committed across pre-frame focus switch: %q", second.Text())
+	}
+}
+
+type capabilityV2ControllerEventSource struct {
+	v2ControllerEventSource
+	caps gpucontext.IMECapabilities
+}
+
+func (s *capabilityV2ControllerEventSource) IMECapabilities() gpucontext.IMECapabilities {
+	return s.caps
+}
+
+func TestWindowHonorsAdvertisedIMECapabilities(t *testing.T) {
+	es := &capabilityV2ControllerEventSource{
+		caps: gpucontext.IMECapabilities{
+			Version: gpucontext.IMEContractVersion,
+			Features: gpucontext.IMECapabilityComposition |
+				gpucontext.IMECapabilityCommit |
+				gpucontext.IMECapabilityCancel |
+				gpucontext.IMECapabilityDisabled,
+		},
+	}
+	a := New(WithEventSource(es))
+	tf := textfield.New(textfield.InitialValue("é你"))
+	a.SetRoot(tf)
+	a.Window().Context().RequestFocus(tf)
+	a.Window().Frame()
+
+	if len(es.areas) != 0 || len(es.contentTypes) != 0 || len(es.surrounding) != 0 {
+		t.Fatalf("unsupported v2 operations were called: sequence=%v", es.sequence)
+	}
+	if len(es.enabled) == 0 || !es.enabled[len(es.enabled)-1] {
+		t.Fatalf("legacy enable fallback calls = %#v, want true", es.enabled)
+	}
+	if len(es.positions) == 0 {
+		t.Fatalf("legacy position fallback calls = %#v, want candidate position", es.positions)
+	}
+}
+
+func TestEventBridgeFallsBackWhenV2CompositionIsUnadvertised(t *testing.T) {
+	es := &capabilityV2ControllerEventSource{
+		caps: gpucontext.IMECapabilities{
+			Version:  gpucontext.IMEContractVersion,
+			Features: gpucontext.IMECapabilityCommit,
+		},
+	}
+	a := New(WithEventSource(es))
+	root := newMockWidget()
+	a.SetRoot(root)
+
+	if es.onIMECompositionUpdateV2 != nil {
+		t.Fatal("v2 composition callback registered without advertised composition support")
+	}
+	if es.onIMECompositionUpdate == nil {
+		t.Fatal("legacy composition callback was not registered as fallback")
+	}
+	if es.onIMECanceled != nil || es.onIMEDisabled != nil || es.onIMEDeleteSurrounding != nil {
+		t.Fatal("unsupported v2 lifecycle callbacks were registered")
+	}
+	es.onIMECompositionUpdate(gpucontext.IMEState{
+		CompositionText: "候",
+		CursorPos:       len("候"),
+		SelectionStart:  0,
+		SelectionEnd:    len("候"),
+	})
+	var updates int
+	for _, raw := range root.events {
+		if e, ok := raw.(*event.IMEEvent); ok && e.IsCompositionUpdate() {
+			updates++
+		}
+	}
+	if updates != 1 {
+		t.Fatalf("legacy fallback updates=%d events=%#v, want one update", updates, root.events)
+	}
+}
+
+func TestWindowPublishesSurroundingAfterEnable(t *testing.T) {
+	es := &v2ControllerEventSource{}
+	a := New(WithEventSource(es))
+	tf := textfield.New(textfield.InitialValue("é你"))
+	a.SetRoot(tf)
+	a.Window().Context().RequestFocus(tf)
+	a.Window().Frame()
+
+	seenEnable, seenSurrounding := -1, -1
+	for i, call := range es.sequence {
+		if call == "enabled" && seenEnable == -1 && len(es.enabled) > 0 {
+			seenEnable = i
+		}
+		if call == "surrounding" {
+			seenSurrounding = i
+		}
+	}
+	if seenEnable == -1 || seenSurrounding == -1 || seenEnable > seenSurrounding {
+		t.Fatalf("IME call order = %v, want enable before surrounding", es.sequence)
+	}
+}
+
+func TestEventBridgeDropsDisabledPasswordSessionEcho(t *testing.T) {
+	es := &mockV2EventSource{}
+	a := New(WithEventSource(es))
+	tf := textfield.New(
+		textfield.InitialValue("keep"),
+		textfield.InputTypeOpt(textfield.TypePassword),
+	)
+	a.SetRoot(tf)
+	a.Window().Context().RequestFocus(tf)
+	a.Window().Frame()
+	es.onIMEDisabled()
+	es.onTextInput("stale")
+	es.onIMECompositionEnd("stale")
+	if tf.Text() != "keep" {
+		t.Fatalf("disabled password session mutated text to %q", tf.Text())
+	}
+}
+
+func testIMEComposition() gpucontext.IMEComposition {
+	return gpucontext.IMEComposition{
+		CompositionText: "かな",
+		CursorBegin:     len("か"),
+		CursorEnd:       len("か"),
+		SelectionStart:  0,
+		SelectionEnd:    len("かな"),
+	}
+}
+
+type imeStatePainter struct{ state textfield.PaintState }
+
+func (p *imeStatePainter) PaintTextField(_ widget.Canvas, state *textfield.PaintState) {
+	p.state = *state
 }
 
 func TestEventBridge_V2IMETextInputBeforeEndIsNotDuplicated(t *testing.T) {
@@ -81,6 +391,143 @@ func TestEventBridge_V2IMETextInputBeforeEndIsNotDuplicated(t *testing.T) {
 	}
 	if keyEvents != len([]rune("候補")) || committedEnds != 0 {
 		t.Fatalf("routed key=%d committed ends=%d events=%#v, want %d/0", keyEvents, committedEnds, root.events, len([]rune("候補")))
+	}
+}
+
+func TestEventBridge_PartialTextEchoIsNotDuplicated(t *testing.T) {
+	es := &mockV2EventSource{}
+	a := New(WithEventSource(es))
+	root := newMockWidget()
+	a.SetRoot(root)
+	es.onIMECompositionStart()
+	es.onTextInput("候")
+	es.onIMECompositionEnd("候補")
+
+	var runes []rune
+	var committed string
+	for _, raw := range root.events {
+		switch e := raw.(type) {
+		case *event.KeyEvent:
+			if e.HasRune() {
+				runes = append(runes, e.Rune)
+			}
+		case *event.IMEEvent:
+			if e.IsCompositionEnd() {
+				committed = e.Committed
+			}
+		}
+	}
+	if string(runes) != "候" || committed != "補" {
+		t.Fatalf("partial echo routing = keys=%q commit=%q events=%#v, want keys=候 commit=補", string(runes), committed, root.events)
+	}
+}
+
+func TestEventBridge_PartialTextSuffixEchoIsNotDuplicated(t *testing.T) {
+	es := &mockV2EventSource{}
+	a := New(WithEventSource(es))
+	root := newMockWidget()
+	a.SetRoot(root)
+	es.onIMECompositionStart()
+	es.onTextInput("候")
+	es.onIMECompositionEnd("候補")
+	es.onTextInput("補") // some hosts echo only the accepted suffix
+
+	var runes []rune
+	for _, raw := range root.events {
+		if key, ok := raw.(*event.KeyEvent); ok && key.HasRune() {
+			runes = append(runes, key.Rune)
+		}
+	}
+	if got := string(runes); got != "候" {
+		t.Fatalf("suffix echo reached UI as %q, want only prefix 候", got)
+	}
+}
+
+func TestEventBridge_DropsQueuedEndAfterCancel(t *testing.T) {
+	es := &mockV2EventSource{}
+	a := New(WithEventSource(es))
+	root := newMockWidget()
+	a.SetRoot(root)
+	es.onIMECompositionStart()
+	es.onIMECompositionUpdateV2(testIMEComposition())
+	es.onIMECanceled()
+	es.onIMECompositionEnd("stale")
+
+	for _, raw := range root.events {
+		if e, ok := raw.(*event.IMEEvent); ok && e.IsCompositionEnd() && e.Committed != "" {
+			t.Fatalf("queued canceled end committed %q: events=%#v", e.Committed, root.events)
+		}
+	}
+}
+
+func TestEventBridge_DropsQueuedTextAfterCancel(t *testing.T) {
+	es := &mockV2EventSource{}
+	a := New(WithEventSource(es))
+	root := newMockWidget()
+	a.SetRoot(root)
+	es.onIMECompositionStart()
+	es.onIMECompositionUpdateV2(testIMEComposition())
+	es.onIMECanceled()
+	es.onTextInput("stale")
+	es.onIMECompositionEnd("stale")
+
+	for _, raw := range root.events {
+		if key, ok := raw.(*event.KeyEvent); ok && key.HasRune() {
+			t.Fatalf("queued canceled text reached UI: %#v", root.events)
+		}
+		if end, ok := raw.(*event.IMEEvent); ok && end.IsCompositionEnd() && end.Committed != "" {
+			t.Fatalf("queued canceled end committed %q: events=%#v", end.Committed, root.events)
+		}
+	}
+}
+
+func TestEventBridgeDirectTextAfterEndStartsNewDedupWindow(t *testing.T) {
+	es := &mockV2EventSource{}
+	a := New(WithEventSource(es))
+	root := newMockWidget()
+	a.SetRoot(root)
+	es.onTextInput("first") // host omits both start and update callbacks
+	es.onIMECompositionEnd("first")
+	es.onTextInput("first") // echo from the first end
+	es.onTextInput("next")  // host omits the next composition-start callback
+	es.onIMECompositionEnd("next")
+
+	var keys string
+	var committed []string
+	for _, raw := range root.events {
+		switch e := raw.(type) {
+		case *event.KeyEvent:
+			if e.HasRune() {
+				keys += string(e.Rune)
+			}
+		case *event.IMEEvent:
+			if e.IsCompositionEnd() && e.Committed != "" {
+				committed = append(committed, e.Committed)
+			}
+		}
+	}
+	if got := string(keys); got != "firstnext" {
+		t.Fatalf("direct text keys=%q, want firstnext", got)
+	}
+	if len(committed) != 0 {
+		t.Fatalf("committed ends=%v, want none after text callbacks", committed)
+	}
+}
+
+func TestEventBridge_DropsQueuedEndAfterWindowFocusLoss(t *testing.T) {
+	es := &mockV2EventSource{}
+	a := New(WithEventSource(es))
+	root := newMockWidget()
+	a.SetRoot(root)
+	es.onIMECompositionStart()
+	es.onIMECompositionUpdateV2(testIMEComposition())
+	a.Window().HandleFocusChange(false)
+	es.onIMECompositionEnd("stale")
+
+	for _, raw := range root.events {
+		if e, ok := raw.(*event.IMEEvent); ok && e.IsCompositionEnd() && e.Committed != "" {
+			t.Fatalf("focus-loss queued end committed %q: events=%#v", e.Committed, root.events)
+		}
 	}
 }
 

--- a/app/event_bridge_test.go
+++ b/app/event_bridge_test.go
@@ -1770,3 +1770,167 @@ func TestEventBridge_PointerEventSource_Registration(t *testing.T) {
 
 // Verify no unused imports by using geometry in a test.
 var _ = geometry.Pt(0, 0)
+
+func TestIMEBridgeStateDeduplicationBranches(t *testing.T) {
+	if got := commitWithoutEcho("", "x"); got != "x" {
+		t.Fatalf("empty prefix commit = %q", got)
+	}
+	if got := commitWithoutEcho(string([]byte{0xff}), "x"); got != "x" {
+		t.Fatalf("invalid UTF-8 prefix commit = %q", got)
+	}
+	if got := commitWithoutEcho("abc", "ab"); got != "" {
+		t.Fatalf("committed prefix already delivered = %q", got)
+	}
+	if got := commitWithoutEcho("ab", "abc"); got != "c" {
+		t.Fatalf("partial prefix commit = %q", got)
+	}
+	if got := commitWithoutEcho("x", "abc"); got != "abc" {
+		t.Fatalf("unrelated commit = %q", got)
+	}
+
+	s := &imeBridgeState{active: true, suppressNext: "full", suppressPartial: "part"}
+	if !s.dropTextInput("full") || s.suppressNext != "" {
+		t.Fatalf("full echo did not clear active-session guard: %#v", s)
+	}
+	if !s.dropTextInput("part") || s.suppressPartial != "" {
+		t.Fatalf("partial echo did not clear active-session guard: %#v", s)
+	}
+	s.invalidate()
+	if !s.dropTextInput("stale") {
+		t.Fatal("canceled text should be dropped")
+	}
+	s.noteKeyPress()
+	if s.canceled || !s.ended {
+		t.Fatalf("key press did not establish post-cancel boundary: %#v", s)
+	}
+	if got := s.end("stale-end"); got != "" {
+		t.Fatalf("queued end crossed key boundary: %q", got)
+	}
+}
+
+func TestEventBridgeIMECallbacksAllSupportedAndRejected(t *testing.T) {
+	es := &capabilityV2ControllerEventSource{caps: gpucontext.IMECapabilities{
+		Version: gpucontext.IMEContractVersion,
+		Features: gpucontext.IMECapabilityComposition |
+			gpucontext.IMECapabilityCancel |
+			gpucontext.IMECapabilityDisabled |
+			gpucontext.IMECapabilityDeleteSurrounding |
+			gpucontext.IMECapabilityCommit,
+	}}
+	a := New(WithEventSource(es))
+	root := newMockWidget()
+	a.SetRoot(root)
+	es.onIMECompositionStart()
+	es.onIMECompositionUpdateV2(testIMEComposition())
+	es.onIMEDeleteSurrounding(gpucontext.IMEDeleteSurroundingEvent{Before: 1, After: 1})
+	es.onIMECanceled()
+	es.onIMEDisabled()
+	es.onIMECompositionEnd("")
+	var starts, updates, deletes, cancels, disabled, ends int
+	for _, raw := range root.events {
+		if e, ok := raw.(*event.IMEEvent); ok {
+			switch {
+			case e.IsCompositionStart():
+				starts++
+			case e.IsCompositionUpdate():
+				updates++
+			case e.IsDeleteSurrounding():
+				deletes++
+			case e.IsCanceled():
+				cancels++
+			case e.IsDisabled():
+				disabled++
+			case e.IsCompositionEnd():
+				ends++
+			}
+		}
+	}
+	if starts != 1 || updates != 1 || deletes != 1 || cancels != 1 || disabled != 1 || ends != 1 {
+		t.Fatalf("supported IME events = start/%d update/%d delete/%d cancel/%d disabled/%d end/%d", starts, updates, deletes, cancels, disabled, ends)
+	}
+
+	// Teardown before callback delivery must reject every callback without panic.
+	a.SetRoot(nil)
+	es.onIMECompositionStart()
+	es.onIMECompositionUpdateV2(testIMEComposition())
+	es.onIMEDeleteSurrounding(gpucontext.IMEDeleteSurroundingEvent{})
+	es.onIMECanceled()
+	es.onIMEDisabled()
+	es.onIMECompositionEnd("stale")
+}
+
+func TestEventBridgeLegacyControllerAndFocusGate(t *testing.T) {
+	wp := &legacyIMEOnlyWindowProvider{mockWindowProvider: mockWindowProvider{width: 100, height: 100, scale: 1}}
+	a := New(WithWindowProvider(wp))
+	if _, v2, _, ok := a.Window().resolveIMEController(); !ok || v2 != nil {
+		t.Fatalf("legacy controller resolution = ok:%v v2:%v", ok, v2)
+	}
+	es := &mockV2EventSource{}
+	a = New(WithEventSource(es))
+	a.SetRoot(newMockWidget())
+	a.Window().HandleFocusChange(false)
+	if es.onTextInput != nil {
+		es.onTextInput("ignored")
+	}
+	if es.onKeyPress != nil {
+		es.onKeyPress(gpucontext.KeyA, 0)
+	}
+	a.Window().HandleEvent(event.NewKeyEvent(event.KeyPress, event.KeyA, 0, event.ModNone))
+	a.Window().HandleEvent(event.NewIMECompositionStart())
+
+	legacyES := &mockEventSource{}
+	legacyApp := New(WithEventSource(legacyES))
+	legacyApp.SetRoot(newMockWidget())
+	legacyApp.SetRoot(nil)
+	legacyES.onIMECompositionUpdate(gpucontext.IMEState{CompositionText: "stale"})
+}
+
+func TestWindowCloseInvalidatesAttachedIMEBridge(t *testing.T) {
+	es := &mockV2EventSource{}
+	a := New(WithEventSource(es))
+	a.SetRoot(newMockWidget())
+	a.Window().Close()
+	es.onIMECompositionStart()
+	es.onIMECompositionEnd("stale")
+}
+
+type imeFocusContainer struct {
+	widget.WidgetBase
+	kids []widget.Widget
+}
+
+func (w *imeFocusContainer) Layout(_ widget.Context, c geometry.Constraints) geometry.Size {
+	return c.Constrain(geometry.Sz(400, 100))
+}
+
+func (w *imeFocusContainer) Draw(ctx widget.Context, canvas widget.Canvas) {
+	for _, child := range w.kids {
+		child.Draw(ctx, canvas)
+	}
+}
+
+func (w *imeFocusContainer) Event(ctx widget.Context, e event.Event) bool {
+	for _, child := range w.kids {
+		if child.Event(ctx, e) {
+			return true
+		}
+	}
+	return false
+}
+
+func (w *imeFocusContainer) Children() []widget.Widget { return w.kids }
+
+func TestEventBridgeFocusSwitchInvalidatesBeforeFrame(t *testing.T) {
+	es := &v2ControllerEventSource{}
+	a := New(WithEventSource(es))
+	first := textfield.New(textfield.InitialValue("first"))
+	second := textfield.New(textfield.InitialValue("second"))
+	root := &imeFocusContainer{kids: []widget.Widget{first, second}}
+	root.AddChild(first)
+	root.AddChild(second)
+	a.SetRoot(root)
+	a.Window().Context().RequestFocus(first)
+	a.Window().Frame()
+	a.Window().Context().RequestFocus(second)
+	es.onIMECompositionEnd("stale")
+}

--- a/app/event_bridge_test.go
+++ b/app/event_bridge_test.go
@@ -4,10 +4,171 @@ import (
 	"testing"
 
 	"github.com/gogpu/gpucontext"
+	"github.com/gogpu/ui/core/textfield"
 	"github.com/gogpu/ui/event"
 	"github.com/gogpu/ui/geometry"
 	"github.com/gogpu/ui/widget"
 )
+
+func TestEventBridge_V2IMECommitExactlyOnce(t *testing.T) {
+	es := &mockV2EventSource{}
+	a := New(WithEventSource(es))
+	root := newMockWidget()
+	a.SetRoot(root)
+
+	if es.onIMECompositionStart == nil || es.onIMECompositionUpdateV2 == nil || es.onIMECompositionEnd == nil {
+		t.Fatal("versioned IME callbacks were not attached")
+	}
+	es.onIMECompositionStart()
+	composition := gpucontext.IMEComposition{
+		CompositionText: "to",
+		CursorBegin:     2,
+		CursorEnd:       2,
+		SelectionStart:  0,
+		SelectionEnd:    2,
+	}
+	es.onIMECompositionUpdateV2(composition)
+	es.onIMECompositionEnd("東京")
+	// A backend may still echo the result through the legacy text callback;
+	// the bridge must drop that echo after routing the explicit end commit.
+	es.onTextInput("東京")
+
+	var keyEvents, updates, ends int
+	for _, raw := range root.events {
+		switch e := raw.(type) {
+		case *event.KeyEvent:
+			if e.HasRune() {
+				keyEvents++
+			}
+		case *event.IMEEvent:
+			if e.IsCompositionUpdate() {
+				updates++
+			}
+			if e.IsCompositionEnd() {
+				ends++
+				if e.Committed != "東京" {
+					t.Fatalf("end commit = %q, want 東京", e.Committed)
+				}
+			}
+		}
+	}
+	if keyEvents != 0 || updates != 1 || ends != 1 {
+		t.Fatalf("IME routed key=%d updates=%d ends=%d events=%#v, want 0/1/1", keyEvents, updates, ends, root.events)
+	}
+}
+
+func TestEventBridge_V2IMETextInputBeforeEndIsNotDuplicated(t *testing.T) {
+	es := &mockV2EventSource{}
+	a := New(WithEventSource(es))
+	root := newMockWidget()
+	a.SetRoot(root)
+	es.onIMECompositionStart()
+	es.onTextInput("候補")
+	es.onIMECompositionEnd("候補")
+
+	var keyEvents, committedEnds int
+	for _, raw := range root.events {
+		switch e := raw.(type) {
+		case *event.KeyEvent:
+			if e.HasRune() {
+				keyEvents++
+			}
+		case *event.IMEEvent:
+			if e.IsCompositionEnd() && e.Committed != "" {
+				committedEnds++
+			}
+		}
+	}
+	if keyEvents != len([]rune("候補")) || committedEnds != 0 {
+		t.Fatalf("routed key=%d committed ends=%d events=%#v, want %d/0", keyEvents, committedEnds, root.events, len([]rune("候補")))
+	}
+}
+
+func TestEventBridge_LegacyIMEUpdateConvertsRangesAndDeduplicates(t *testing.T) {
+	es := &mockEventSource{}
+	a := New(WithEventSource(es))
+	root := newMockWidget()
+	a.SetRoot(root)
+	if es.onIMECompositionUpdate == nil {
+		t.Fatal("legacy IME update callback was not attached")
+	}
+
+	es.onIMECompositionUpdate(gpucontext.IMEState{
+		CompositionText: "かな",
+		CursorPos:       len("か"),
+		SelectionStart:  0,
+		SelectionEnd:    len("かな"),
+	})
+	es.onTextInput("仮名")
+	es.onIMECompositionEnd("仮名")
+
+	var updates, keyEvents, committedEnds int
+	for _, raw := range root.events {
+		switch e := raw.(type) {
+		case *event.IMEEvent:
+			if e.IsCompositionUpdate() {
+				updates++
+				if e.Composition.CursorBegin != len("か") || e.Composition.CursorEnd != len("か") {
+					t.Fatalf("legacy composition ranges = %#v, want collapsed UTF-8 cursor", e.Composition)
+				}
+			}
+			if e.IsCompositionEnd() && e.Committed != "" {
+				committedEnds++
+			}
+		case *event.KeyEvent:
+			if e.HasRune() {
+				keyEvents++
+			}
+		}
+	}
+	if updates != 1 || keyEvents != len([]rune("仮名")) || committedEnds != 0 {
+		t.Fatalf("legacy routed updates=%d keys=%d committed ends=%d events=%#v, want 1/%d/0", updates, keyEvents, committedEnds, root.events, len([]rune("仮名")))
+	}
+}
+
+func TestWindowIMESyncFocusPrivacyAndCandidateArea(t *testing.T) {
+	wp := &mockIMEWindowProvider{mockWindowProvider: mockWindowProvider{width: 500, height: 300, scale: 1}}
+	a := New(WithWindowProvider(wp))
+	tf := textfield.New(textfield.InitialValue("é你"))
+	a.SetRoot(tf)
+	a.Window().Context().RequestFocus(tf)
+	a.Window().Frame()
+
+	if len(wp.enabled) == 0 || !wp.enabled[len(wp.enabled)-1] {
+		t.Fatalf("enabled calls = %#v, want focused text field enabled", wp.enabled)
+	}
+	if len(wp.surrounding) == 0 || wp.surrounding[len(wp.surrounding)-1].Text != "é你" {
+		t.Fatalf("surrounding calls = %#v, want committed UTF-8 text", wp.surrounding)
+	}
+	if len(wp.areas) == 0 || wp.areas[len(wp.areas)-1].Height <= 0 {
+		t.Fatalf("cursor areas = %#v, want non-empty candidate rect", wp.areas)
+	}
+
+	beforeSurrounding := len(wp.surrounding)
+	a.Window().HandleFocusChange(false)
+	if wp.enabled[len(wp.enabled)-1] {
+		t.Fatalf("focus loss enabled calls = %#v, want disabled", wp.enabled)
+	}
+	if len(wp.surrounding) != beforeSurrounding {
+		t.Fatalf("focus loss sent surrounding text: %#v", wp.surrounding)
+	}
+
+	password := textfield.New(textfield.InitialValue("secret"), textfield.InputTypeOpt(textfield.TypePassword))
+	a.Window().Context().ReleaseFocus(tf)
+	a.SetRoot(password)
+	a.Window().Context().RequestFocus(password)
+	a.Window().HandleFocusChange(true)
+	a.Window().Frame()
+	if wp.enabled[len(wp.enabled)-1] {
+		t.Fatal("password field enabled native IME")
+	}
+	if len(wp.contentTypes) == 0 || wp.contentTypes[len(wp.contentTypes)-1][0] != gpucontext.ContentPurposePassword {
+		t.Fatalf("content type calls = %#v, want password purpose", wp.contentTypes)
+	}
+	if len(wp.surrounding) != beforeSurrounding {
+		t.Fatalf("password field sent surrounding text: %#v", wp.surrounding)
+	}
+}
 
 func newBoundedEventBridgeRoot(es gpucontext.EventSource) *mockWidget {
 	wp := &mockWindowProvider{width: 400, height: 300, scale: 1}

--- a/app/window.go
+++ b/app/window.go
@@ -52,14 +52,23 @@ type animationStopper interface {
 }
 
 type Window struct {
-	root      widget.Widget
-	ctx       *widget.ContextImpl
-	wp        gpucontext.WindowProvider
-	pp        gpucontext.PlatformProvider
-	scheduler *state.Scheduler
-	theme     *theme.Theme
-	overlays  *overlay.Stack
-	focusMgr  *ifocus.Manager
+	root widget.Widget
+	ctx  *widget.ContextImpl
+	wp   gpucontext.WindowProvider
+	pp   gpucontext.PlatformProvider
+
+	// imeSource is the optional controller exposed by the event source or
+	// window provider. It is intentionally kept outside gpucontext's required
+	// WindowProvider/EventSource contracts so legacy hosts remain compatible.
+	imeSource      interface{}
+	imeWindowFocus bool
+	imeFocused     widget.Widget
+	imeSnapshot    imeSnapshot
+	imeSnapshotSet bool
+	scheduler      *state.Scheduler
+	theme          *theme.Theme
+	overlays       *overlay.Stack
+	focusMgr       *ifocus.Manager
 
 	// renderMode controls background ownership and incremental rendering.
 	// See RenderMode documentation for details.
@@ -174,6 +183,32 @@ type Window struct {
 	gestureArena *gesture.Arena
 }
 
+// imeClient is the small optional surface a focused widget exposes to let the
+// app synchronize the host IME. Keeping this as a structural interface avoids
+// making every widget or Context implementation depend on gpucontext.
+type imeClient interface {
+	IMEEnabled() bool
+	IMEContentType() (gpucontext.ContentPurpose, gpucontext.ContentHint)
+	IMESurroundingText() gpucontext.IMESurroundingText
+	IMECursorArea() gpucontext.IMECursorArea
+}
+
+// imeFocusReset is implemented by widgets that keep transient preedit state.
+// Window focus changes are not necessarily delivered as widget FocusEvents
+// when Context.RequestFocus switches between controls, so the old owner gets
+// an explicit composition reset before the new snapshot is published.
+type imeFocusReset interface {
+	CancelIMEComposition()
+}
+
+type imeSnapshot struct {
+	enabled     bool
+	purpose     gpucontext.ContentPurpose
+	hints       gpucontext.ContentHint
+	surrounding gpucontext.IMESurroundingText
+	area        gpucontext.IMECursorArea
+}
+
 // newWindow creates a Window with the given providers.
 func newWindow(
 	wp gpucontext.WindowProvider,
@@ -187,13 +222,17 @@ func newWindow(
 	tracker := dirty.NewTracker()
 	imgCache := internalRender.DefaultImageCache()
 	w := &Window{
-		ctx:              ctx,
-		wp:               wp,
-		pp:               pp,
-		scheduler:        scheduler,
-		theme:            t,
-		renderMode:       renderMode,
-		focusMgr:         ifocus.New(nil),
+		ctx:        ctx,
+		wp:         wp,
+		pp:         pp,
+		scheduler:  scheduler,
+		theme:      t,
+		renderMode: renderMode,
+		focusMgr:   ifocus.New(nil),
+		// Treat a newly-created window as focused until the host reports a
+		// focus loss. This keeps headless/test behavior deterministic while
+		// still gating IME ownership across real focus transitions.
+		imeWindowFocus:   true,
 		needsLayout:      true,
 		needsFullRepaint: true,
 		dirtyTracker:     tracker,
@@ -316,6 +355,95 @@ func newWindow(
 	return w
 }
 
+// setIMEController records an optional controller exposed by the event
+// source. Most gogpu hosts expose the controller on their WindowProvider
+// (gogpu.App); accepting it here also makes headless and adapter tests easy to
+// drive without changing the required gpucontext interfaces.
+func (w *Window) setIMEController(source interface{}) {
+	if source != nil {
+		w.imeSource = source
+	}
+	w.syncIMEController()
+}
+
+// resolveIMEController returns the strongest controller available. Prefer the
+// WindowProvider because gogpu.App keeps controller state there; fall back to
+// the event source for hosts that expose the optional interface on it.
+func (w *Window) resolveIMEController() (gpucontext.IMEController, gpucontext.IMEControllerV2, bool) {
+	if w.wp != nil {
+		legacy, _ := w.wp.(gpucontext.IMEController)
+		v2, _ := w.wp.(gpucontext.IMEControllerV2)
+		if legacy != nil || v2 != nil {
+			return legacy, v2, true
+		}
+	}
+	if w.imeSource != nil {
+		legacy, _ := w.imeSource.(gpucontext.IMEController)
+		v2, _ := w.imeSource.(gpucontext.IMEControllerV2)
+		if legacy != nil || v2 != nil {
+			return legacy, v2, true
+		}
+	}
+	return nil, nil, false
+}
+
+// syncIMEController applies the currently focused widget's IME policy to the
+// optional host controller. It is called after event dispatch and after draw,
+// so candidate placement follows the latest caret geometry while surrounding
+// text is never sent while a field is disabled or unfocused.
+func (w *Window) syncIMEController() {
+	legacy, v2, ok := w.resolveIMEController()
+	if !ok || w.ctx == nil {
+		return
+	}
+
+	snapshot := imeSnapshot{}
+	focusedWidget := widget.Widget(nil)
+	if w.imeWindowFocus {
+		focusedWidget = w.ctx.FocusedWidget()
+		if focusedWidget != nil {
+			if client, ok := focusedWidget.(imeClient); ok {
+				snapshot.enabled = client.IMEEnabled()
+				snapshot.purpose, snapshot.hints = client.IMEContentType()
+				snapshot.surrounding = client.IMESurroundingText()
+				snapshot.area = client.IMECursorArea()
+			}
+		}
+	}
+	if focusedWidget != w.imeFocused {
+		if reset, ok := w.imeFocused.(imeFocusReset); ok {
+			reset.CancelIMEComposition()
+		}
+		w.imeFocused = focusedWidget
+	}
+
+	if w.imeSnapshotSet && snapshot == w.imeSnapshot {
+		return
+	}
+	wasSet := w.imeSnapshotSet
+	w.imeSnapshot = snapshot
+	w.imeSnapshotSet = true
+	// Native IME starts disabled. Avoid emitting an initial disable/configure
+	// sequence when the bridge attaches before a root or focus target exists.
+	if !wasSet && !snapshot.enabled && snapshot.purpose == gpucontext.ContentPurposeNormal &&
+		snapshot.hints == gpucontext.ContentHintNone && snapshot.surrounding == (gpucontext.IMESurroundingText{}) &&
+		snapshot.area == (gpucontext.IMECursorArea{}) {
+		return
+	}
+
+	if v2 != nil {
+		v2.SetIMECursorArea(snapshot.area)
+		v2.SetIMEContentType(snapshot.purpose, snapshot.hints)
+		if snapshot.enabled && snapshot.surrounding.IsValid() {
+			v2.SetIMESurroundingText(snapshot.surrounding)
+		}
+	}
+	if legacy != nil {
+		legacy.SetIMEPosition(int(snapshot.area.X), int(snapshot.area.Y))
+		legacy.SetIMEEnabled(snapshot.enabled)
+	}
+}
+
 // SetRoot sets the root widget for this window.
 //
 // Setting a new root triggers a full layout on the next Frame call.
@@ -425,6 +553,7 @@ func (w *Window) HandleEvent(e event.Event) {
 	if w.root == nil || e == nil {
 		return
 	}
+	defer w.syncIMEController()
 
 	// Update context time for event processing.
 	w.ctx.SetNow(time.Now())
@@ -571,6 +700,8 @@ func invalidateScenesInTree(w widget.Widget) {
 
 // HandleFocusChange processes a window focus change.
 func (w *Window) HandleFocusChange(focused bool) {
+	w.imeWindowFocus = focused
+	defer w.syncIMEController()
 	if !focused {
 		w.cancelPointerState()
 	}
@@ -672,6 +803,7 @@ func (w *Window) Frame() {
 	if w.root == nil {
 		return
 	}
+	defer w.syncIMEController()
 
 	frameStart := time.Now()
 	didLayout := w.needsLayout
@@ -1093,6 +1225,7 @@ func (w *Window) DrawTo(canvas widget.Canvas) bool {
 			slog.String("mode", w.renderMode.String()),
 		)
 	}
+	w.syncIMEController()
 
 	return drawn
 }

--- a/app/window.go
+++ b/app/window.go
@@ -60,7 +60,11 @@ type Window struct {
 	// imeSource is the optional controller exposed by the event source or
 	// window provider. It is intentionally kept outside gpucontext's required
 	// WindowProvider/EventSource contracts so legacy hosts remain compatible.
-	imeSource      interface{}
+	imeSource interface{}
+	// imeBridge is the event-source ordering state. It is reset at native
+	// focus/session boundaries so queued callbacks cannot target a replacement
+	// root or commit after teardown.
+	imeBridge      *imeBridgeState
 	imeWindowFocus bool
 	imeFocused     widget.Widget
 	imeSnapshot    imeSnapshot
@@ -207,6 +211,28 @@ type imeSnapshot struct {
 	hints       gpucontext.ContentHint
 	surrounding gpucontext.IMESurroundingText
 	area        gpucontext.IMECursorArea
+}
+
+func (w *Window) imeInputAllowed() bool {
+	return w != nil && w.root != nil && w.imeWindowFocus
+}
+
+// prepareIMEInput synchronizes a context focus switch before an event-source
+// callback is routed. Context.RequestFocus can run between frames, so relying
+// only on the next Frame would let a queued end/text callback from the old
+// owner reach the replacement field. The bridge is invalidated on an owner
+// change; explicit start/update callbacks can then establish the new session.
+func (w *Window) prepareIMEInput(bridge *imeBridgeState) bool {
+	if !w.imeInputAllowed() {
+		bridge.invalidate()
+		return false
+	}
+	previous := w.imeFocused
+	w.syncIMEController()
+	if previous != w.imeFocused {
+		bridge.invalidate()
+	}
+	return w.imeInputAllowed()
 }
 
 // newWindow creates a Window with the given providers.
@@ -366,25 +392,48 @@ func (w *Window) setIMEController(source interface{}) {
 	w.syncIMEController()
 }
 
-// resolveIMEController returns the strongest controller available. Prefer the
-// WindowProvider because gogpu.App keeps controller state there; fall back to
-// the event source for hosts that expose the optional interface on it.
-func (w *Window) resolveIMEController() (gpucontext.IMEController, gpucontext.IMEControllerV2, bool) {
-	if w.wp != nil {
-		legacy, _ := w.wp.(gpucontext.IMEController)
-		v2, _ := w.wp.(gpucontext.IMEControllerV2)
-		if legacy != nil || v2 != nil {
-			return legacy, v2, true
+// resolveIMEController returns the strongest controller available. Prefer a
+// versioned controller on the WindowProvider, then one on the event source;
+// only fall back to the legacy controller when neither side exposes v2. A
+// host may split its legacy WindowProvider and richer event-source surfaces,
+// so checking only the first interface would silently disable v2 behavior.
+func (w *Window) resolveIMEController() (gpucontext.IMEController, gpucontext.IMEControllerV2, gpucontext.IMECapabilityProviderV2, bool) {
+	for _, source := range []interface{}{w.wp, w.imeSource} {
+		if source == nil {
+			continue
+		}
+		if v2, ok := source.(gpucontext.IMEControllerV2); ok && v2 != nil {
+			// IMEControllerV2 embeds the legacy controller, so use the same
+			// object for both calls and avoid double-configuring split hosts.
+			return v2, v2, w.resolveIMECapabilities(), true
 		}
 	}
-	if w.imeSource != nil {
-		legacy, _ := w.imeSource.(gpucontext.IMEController)
-		v2, _ := w.imeSource.(gpucontext.IMEControllerV2)
-		if legacy != nil || v2 != nil {
-			return legacy, v2, true
+	for _, source := range []interface{}{w.wp, w.imeSource} {
+		if source == nil {
+			continue
+		}
+		if legacy, ok := source.(gpucontext.IMEController); ok && legacy != nil {
+			return legacy, nil, w.resolveIMECapabilities(), true
 		}
 	}
-	return nil, nil, false
+	return nil, nil, nil, false
+}
+
+// resolveIMECapabilities discovers the optional capability provider across
+// both controller surfaces. Hosts commonly expose the controller on their
+// WindowProvider and the capability/event surface on EventSource; limiting
+// discovery to whichever object won controller selection would silently
+// enable unsupported operations on that split arrangement.
+func (w *Window) resolveIMECapabilities() gpucontext.IMECapabilityProviderV2 {
+	for _, source := range []interface{}{w.wp, w.imeSource} {
+		if source == nil {
+			continue
+		}
+		if provider, ok := source.(gpucontext.IMECapabilityProviderV2); ok && provider != nil {
+			return provider
+		}
+	}
+	return nil
 }
 
 // syncIMEController applies the currently focused widget's IME policy to the
@@ -392,9 +441,18 @@ func (w *Window) resolveIMEController() (gpucontext.IMEController, gpucontext.IM
 // so candidate placement follows the latest caret geometry while surrounding
 // text is never sent while a field is disabled or unfocused.
 func (w *Window) syncIMEController() {
-	legacy, v2, ok := w.resolveIMEController()
+	legacy, v2, capabilityProvider, ok := w.resolveIMEController()
 	if !ok || w.ctx == nil {
 		return
+	}
+	capabilities := gpucontext.IMECapabilities{}
+	capabilitiesKnown := capabilityProvider != nil
+	if capabilitiesKnown {
+		capabilities = capabilityProvider.IMECapabilities()
+	}
+	supports := func(feature gpucontext.IMECapability) bool {
+		return !capabilitiesKnown ||
+			(capabilities.Version >= gpucontext.IMEContractVersion && capabilities.Supports(feature))
 	}
 
 	snapshot := imeSnapshot{}
@@ -410,17 +468,27 @@ func (w *Window) syncIMEController() {
 			}
 		}
 	}
-	if focusedWidget != w.imeFocused {
+	focusChanged := focusedWidget != w.imeFocused
+	if focusChanged {
 		if reset, ok := w.imeFocused.(imeFocusReset); ok {
 			reset.CancelIMEComposition()
 		}
 		w.imeFocused = focusedWidget
 	}
+	// A focused widget can become disabled or hidden without a FocusEvent (for
+	// example, a reactive password toggle). Do not retain a preedit across
+	// that transient state even if it is re-enabled before the next draw.
+	if focusedWidget != nil && !snapshot.enabled {
+		if reset, ok := focusedWidget.(imeFocusReset); ok {
+			reset.CancelIMEComposition()
+		}
+	}
 
-	if w.imeSnapshotSet && snapshot == w.imeSnapshot {
+	if w.imeSnapshotSet && snapshot == w.imeSnapshot && !focusChanged {
 		return
 	}
 	wasSet := w.imeSnapshotSet
+	previousSnapshot := w.imeSnapshot
 	w.imeSnapshot = snapshot
 	w.imeSnapshotSet = true
 	// Native IME starts disabled. Avoid emitting an initial disable/configure
@@ -430,17 +498,36 @@ func (w *Window) syncIMEController() {
 		snapshot.area == (gpucontext.IMECursorArea{}) {
 		return
 	}
+	if v2 != nil && wasSet && previousSnapshot.enabled &&
+		(!snapshot.enabled || focusChanged) && supports(gpucontext.IMECapabilityCancel) {
+		// End the native session before changing ownership or disabling the
+		// focused field. SetIMEEnabled(false) is a policy update; CancelIME is
+		// the explicit no-commit boundary that prevents a queued preedit result
+		// from landing in the replacement widget.
+		v2.CancelIME()
+	}
 
 	if v2 != nil {
-		v2.SetIMECursorArea(snapshot.area)
-		v2.SetIMEContentType(snapshot.purpose, snapshot.hints)
-		if snapshot.enabled && snapshot.surrounding.IsValid() {
-			v2.SetIMESurroundingText(snapshot.surrounding)
+		if supports(gpucontext.IMECapabilityCursorArea) {
+			v2.SetIMECursorArea(snapshot.area)
+		}
+		if supports(gpucontext.IMECapabilityContentPurpose) ||
+			supports(gpucontext.IMECapabilityContentHints) {
+			v2.SetIMEContentType(snapshot.purpose, snapshot.hints)
 		}
 	}
 	if legacy != nil {
 		legacy.SetIMEPosition(int(snapshot.area.X), int(snapshot.area.Y))
 		legacy.SetIMEEnabled(snapshot.enabled)
+	}
+	if v2 != nil {
+		if supports(gpucontext.IMECapabilitySurroundingText) &&
+			snapshot.enabled && snapshot.surrounding.IsValid() {
+			// Configure the surrounding text after enabling the native session.
+			// Some v2 hosts intentionally reject context while disabled and do
+			// not replay it when they are enabled by a separate legacy controller.
+			v2.SetIMESurroundingText(snapshot.surrounding)
+		}
 	}
 }
 
@@ -450,6 +537,25 @@ func (w *Window) syncIMEController() {
 // The old root tree is unmounted and the new root tree is mounted,
 // which triggers signal binding setup/teardown via [widget.Lifecycle].
 func (w *Window) SetRoot(root widget.Widget) {
+	if w.imeBridge != nil {
+		if w.root != nil {
+			w.imeBridge.invalidate()
+		} else {
+			w.imeBridge.cancel()
+		}
+	}
+	// A root replacement is an input-session boundary. Release any focused
+	// widget before unmounting it so a stale context focus cannot keep the old
+	// field's IME enabled or allow a late composition to target the new tree.
+	if focused := w.ctx.FocusedWidget(); focused != nil {
+		if reset, ok := focused.(imeFocusReset); ok {
+			reset.CancelIMEComposition()
+		}
+		w.ctx.ReleaseFocus(focused)
+	}
+	w.imeFocused = nil
+	w.syncIMEController()
+
 	// Unmount old tree (triggers RepaintBoundary.Unmount which invalidates
 	// individual cache entries from the shared ImageCache).
 	if w.root != nil {
@@ -552,6 +658,19 @@ func (w *Window) setTheme(t *theme.Theme) {
 func (w *Window) HandleEvent(e event.Event) {
 	if w.root == nil || e == nil {
 		return
+	}
+	// Host focus loss can leave queued key/text/IME callbacks in the event
+	// source. The focused widget remains selected so focus can be restored, but
+	// no input from the unfocused native window may mutate it or resurrect a
+	// preedit.
+	if !w.imeWindowFocus {
+		switch e.(type) {
+		case *event.KeyEvent, *event.IMEEvent:
+			if w.imeBridge != nil {
+				w.imeBridge.invalidate()
+			}
+			return
+		}
 	}
 	defer w.syncIMEController()
 
@@ -701,6 +820,9 @@ func invalidateScenesInTree(w widget.Widget) {
 // HandleFocusChange processes a window focus change.
 func (w *Window) HandleFocusChange(focused bool) {
 	w.imeWindowFocus = focused
+	if !focused && w.imeBridge != nil {
+		w.imeBridge.invalidate()
+	}
 	defer w.syncIMEController()
 	if !focused {
 		w.cancelPointerState()
@@ -1120,6 +1242,24 @@ func (w *Window) draw() {
 //
 // Close is idempotent — calling it multiple times is safe.
 func (w *Window) Close() {
+	if w.imeBridge != nil {
+		w.imeBridge.invalidate()
+	}
+	// Disable the native IME before tearing down the focused widget tree. This
+	// also clears any backend-owned surrounding text and makes late callbacks
+	// harmless while preserving Close idempotence.
+	if w.ctx != nil {
+		if focused := w.ctx.FocusedWidget(); focused != nil {
+			if reset, ok := focused.(imeFocusReset); ok {
+				reset.CancelIMEComposition()
+			}
+			w.ctx.ReleaseFocus(focused)
+		}
+		w.imeWindowFocus = false
+		w.imeFocused = nil
+		w.syncIMEController()
+	}
+
 	// Stop animation pumper goroutine.
 	if w.animToken != nil {
 		w.animToken.Stop()

--- a/core/textfield/event.go
+++ b/core/textfield/event.go
@@ -9,24 +9,45 @@ import (
 // handleEvent processes input events for the text field widget.
 // It manages hover, focus, text editing, and selection states.
 func handleEvent(w *Widget, ctx widget.Context, e event.Event) bool {
-	if w.cfg.ResolvedDisabled() {
-		return false
-	}
-
 	switch ev := e.(type) {
 	case *event.MouseEvent:
+		if w.cfg.ResolvedDisabled() {
+			return false
+		}
 		return handleMouseEvent(w, ctx, ev)
 	case *event.KeyEvent:
+		if w.cfg.ResolvedDisabled() {
+			return false
+		}
 		return handleKeyEvent(w, ctx, ev)
 	case *event.FocusEvent:
 		if ev.IsLost() {
 			w.clearComposition()
+			w.cachedIMEAreaSet = false
 			w.SetNeedsRedraw(true)
 			ctx.InvalidateRect(w.Bounds())
 			return false
 		}
 		return false
 	case *event.IMEEvent:
+		// A disabled/hidden field can still be the context's focused widget
+		// until the next focus pass. Clear any transient preedit immediately so
+		// it cannot reappear when the field is re-enabled, and consume the
+		// lifecycle event rather than letting it reach another text field.
+		if !w.IsFocused() {
+			if w.composing {
+				w.clearComposition()
+				w.SetNeedsRedraw(true)
+				ctx.InvalidateRect(w.Bounds())
+			}
+			return false
+		}
+		if w.cfg.ResolvedDisabled() || !w.IsEnabled() || !w.IsVisible() {
+			w.clearComposition()
+			w.SetNeedsRedraw(true)
+			ctx.InvalidateRect(w.Bounds())
+			return true
+		}
 		return handleIMEEvent(w, ctx, ev)
 	default:
 		return false
@@ -69,6 +90,14 @@ func handleIMEEvent(w *Widget, ctx widget.Context, e *event.IMEEvent) bool {
 
 	case event.IMECompositionEnd:
 		w.clearComposition()
+		if w.cfg.inputType == TypePassword {
+			// A disabled native password session may still queue its end
+			// callback after focus/content-type changes. Never commit that stale
+			// payload into a password field.
+			w.SetNeedsRedraw(true)
+			ctx.InvalidateRect(w.Bounds())
+			return true
+		}
 		if e.Committed != "" {
 			w.deleteSelection()
 			w.insertText(e.Committed)
@@ -86,6 +115,9 @@ func handleIMEEvent(w *Widget, ctx widget.Context, e *event.IMEEvent) bool {
 		return true
 
 	case event.IMEDeleteSurrounding:
+		if w.cfg.inputType == TypePassword {
+			return true
+		}
 		if !e.Delete.IsValid() {
 			return true
 		}
@@ -110,6 +142,7 @@ func (w *Widget) CancelIMEComposition() {
 		return
 	}
 	w.clearComposition()
+	w.cachedIMEAreaSet = false
 	w.SetNeedsRedraw(true)
 }
 

--- a/core/textfield/event.go
+++ b/core/textfield/event.go
@@ -1,6 +1,7 @@
 package textfield
 
 import (
+	"github.com/gogpu/gpucontext"
 	"github.com/gogpu/ui/event"
 	"github.com/gogpu/ui/widget"
 )
@@ -17,9 +18,134 @@ func handleEvent(w *Widget, ctx widget.Context, e event.Event) bool {
 		return handleMouseEvent(w, ctx, ev)
 	case *event.KeyEvent:
 		return handleKeyEvent(w, ctx, ev)
+	case *event.FocusEvent:
+		if ev.IsLost() {
+			w.clearComposition()
+			w.SetNeedsRedraw(true)
+			ctx.InvalidateRect(w.Bounds())
+			return false
+		}
+		return false
+	case *event.IMEEvent:
+		return handleIMEEvent(w, ctx, ev)
 	default:
 		return false
 	}
+}
+
+// handleIMEEvent applies platform composition events to the focused field.
+// Preedit updates never mutate the committed value; only an accepted end
+// event invokes onChange, preserving exactly-once commit semantics at the
+// widget boundary.
+func handleIMEEvent(w *Widget, ctx widget.Context, e *event.IMEEvent) bool {
+	if !w.IsFocused() || w.cfg.ResolvedDisabled() || !w.IsEnabled() {
+		return false
+	}
+
+	switch e.IMEType {
+	case event.IMECompositionStart:
+		if w.cfg.inputType == TypePassword {
+			w.clearComposition()
+			return true
+		}
+		w.composing = true
+		w.composition = gpucontext.IMEComposition{}
+		w.SetNeedsRedraw(true)
+		ctx.InvalidateRect(w.Bounds())
+		return true
+
+	case event.IMECompositionUpdate:
+		if w.cfg.inputType == TypePassword || !e.Composition.IsValid() {
+			w.clearComposition()
+			w.SetNeedsRedraw(true)
+			ctx.InvalidateRect(w.Bounds())
+			return true
+		}
+		w.composing = true
+		w.composition = e.Composition
+		w.SetNeedsRedraw(true)
+		ctx.InvalidateRect(w.Bounds())
+		return true
+
+	case event.IMECompositionEnd:
+		w.clearComposition()
+		if e.Committed != "" {
+			w.deleteSelection()
+			w.insertText(e.Committed)
+			w.notifyChange(ctx)
+		} else {
+			w.SetNeedsRedraw(true)
+			ctx.InvalidateRect(w.Bounds())
+		}
+		return true
+
+	case event.IMECanceled, event.IMEDisabled:
+		w.clearComposition()
+		w.SetNeedsRedraw(true)
+		ctx.InvalidateRect(w.Bounds())
+		return true
+
+	case event.IMEDeleteSurrounding:
+		if !e.Delete.IsValid() {
+			return true
+		}
+		if w.deleteSurrounding(e.Delete.Before, e.Delete.After) {
+			w.notifyChange(ctx)
+		}
+		return true
+	default:
+		return false
+	}
+}
+
+func (w *Widget) clearComposition() {
+	w.composing = false
+	w.composition = gpucontext.IMEComposition{}
+}
+
+// CancelIMEComposition clears transient preedit state when focus moves to a
+// different widget without a platform FocusEvent reaching this field.
+func (w *Widget) CancelIMEComposition() {
+	if !w.composing {
+		return
+	}
+	w.clearComposition()
+	w.SetNeedsRedraw(true)
+}
+
+// deleteSurrounding applies byte-counted deletion around the current cursor.
+// Requests that split a UTF-8 sequence are rejected instead of corrupting the
+// committed string.
+func (w *Widget) deleteSurrounding(before, after int) bool {
+	runes := w.textRunes()
+	if len(runes) == 0 {
+		return false
+	}
+	cursor := clampPos(w.sel.cursor, len(runes))
+	cursorByte := runeToByteOffset(runes, cursor)
+	text := string(runes)
+	startByte := cursorByte - before
+	endByte := cursorByte + after
+	if startByte < 0 || endByte > len(text) {
+		return false
+	}
+	start, ok := byteOffsetToRune(text, startByte)
+	if !ok {
+		return false
+	}
+	end, ok := byteOffsetToRune(text, endByte)
+	if !ok || start > end {
+		return false
+	}
+	if start == end {
+		return false
+	}
+	newRunes := make([]rune, 0, len(runes)-(end-start))
+	newRunes = append(newRunes, runes[:start]...)
+	newRunes = append(newRunes, runes[end:]...)
+	w.setText(string(newRunes))
+	w.sel.SetCursor(start)
+	return true
 }
 
 // handleMouseEvent processes mouse events for focus and hover state.

--- a/core/textfield/ime_internal_test.go
+++ b/core/textfield/ime_internal_test.go
@@ -1,0 +1,131 @@
+package textfield
+
+import (
+	"image"
+	"testing"
+
+	"github.com/gogpu/gpucontext"
+	"github.com/gogpu/ui/event"
+	"github.com/gogpu/ui/geometry"
+	"github.com/gogpu/ui/internal/textmetrics"
+	"github.com/gogpu/ui/widget"
+)
+
+type imeMetricsCanvas struct{}
+
+func (imeMetricsCanvas) Clear(widget.Color)                                                         {}
+func (imeMetricsCanvas) DrawRect(geometry.Rect, widget.Color)                                       {}
+func (imeMetricsCanvas) FillRectDirect(geometry.Rect, widget.Color)                                 {}
+func (imeMetricsCanvas) StrokeRect(geometry.Rect, widget.Color, float32)                            {}
+func (imeMetricsCanvas) DrawRoundRect(geometry.Rect, widget.Color, float32)                         {}
+func (imeMetricsCanvas) StrokeRoundRect(geometry.Rect, widget.Color, float32, float32)              {}
+func (imeMetricsCanvas) DrawCircle(geometry.Point, float32, widget.Color)                           {}
+func (imeMetricsCanvas) StrokeCircle(geometry.Point, float32, widget.Color, float32)                {}
+func (imeMetricsCanvas) StrokeArc(geometry.Point, float32, float64, float64, widget.Color, float32) {}
+func (imeMetricsCanvas) DrawLine(geometry.Point, geometry.Point, widget.Color, float32)             {}
+func (imeMetricsCanvas) DrawText(string, geometry.Rect, float32, widget.Color, bool, widget.TextAlign) {
+}
+func (imeMetricsCanvas) MeasureText(text string, fontSize float32, _ bool) float32 {
+	return float32(len([]rune(text))) * fontSize
+}
+func (imeMetricsCanvas) DrawImage(image.Image, geometry.Point)    {}
+func (imeMetricsCanvas) PushClip(geometry.Rect)                   {}
+func (imeMetricsCanvas) PushClipRoundRect(geometry.Rect, float32) {}
+func (imeMetricsCanvas) PopClip()                                 {}
+func (imeMetricsCanvas) PushTransform(geometry.Point)             {}
+func (imeMetricsCanvas) PopTransform()                            {}
+func (imeMetricsCanvas) TransformOffset() geometry.Point          { return geometry.Point{} }
+func (imeMetricsCanvas) ScreenOriginBase() geometry.Point         { return geometry.Point{} }
+func (imeMetricsCanvas) ClipBounds() geometry.Rect                { return geometry.NewRect(0, 0, 1000, 1000) }
+func (imeMetricsCanvas) ReplayScene(widget.SceneCache)            {}
+
+func TestIMEGeometryValidationBranches(t *testing.T) {
+	if got, ok := byteOffsetToRune("é你", -1); ok || got != 0 {
+		t.Fatalf("negative byte offset = (%d,%v)", got, ok)
+	}
+	if got, ok := byteOffsetToRune(string([]byte{0xff}), 0); ok || got != 0 {
+		t.Fatalf("invalid UTF-8 offset = (%d,%v)", got, ok)
+	}
+	if got, ok := byteOffsetToRune("é", 1); ok || got != 0 {
+		t.Fatalf("mid-rune byte offset = (%d,%v)", got, ok)
+	}
+	if got, ok := byteOffsetToRune("é", len("é")); !ok || got != 1 {
+		t.Fatalf("terminal byte offset = (%d,%v)", got, ok)
+	}
+	if got, ok := compositionRangeToRunes("é", 0, 0); !ok || got != nil {
+		t.Fatalf("empty composition range = (%v,%v)", got, ok)
+	}
+	if got, ok := compositionRangeToRunes("é", 1, 0); ok || got != nil {
+		t.Fatalf("reversed composition range = (%v,%v)", got, ok)
+	}
+	if got, ok := compositionRangeToRunes("abc", 2, 1); ok || got != nil {
+		t.Fatalf("ordered-byte reversed range = (%v,%v)", got, ok)
+	}
+
+	w := New()
+	tm := &textmetrics.Metrics{Canvas: imeMetricsCanvas{}, FontSize: 12}
+	content := geometry.NewRect(0, 0, 200, 30)
+	if text, _, _, _ := w.compositionPaintGeometry(tm, content, ""); text != "" {
+		t.Fatal("inactive composition produced geometry")
+	}
+	w.composing = true
+	if text, _, _, _ := w.compositionPaintGeometry(tm, content, ""); text != "" {
+		t.Fatal("empty composition produced geometry")
+	}
+	w.composition = gpucontext.IMEComposition{CompositionText: "é", CursorBegin: 0, CursorEnd: 0, SelectionStart: 1, SelectionEnd: 0}
+	if text, _, _, _ := w.compositionPaintGeometry(tm, content, ""); text != "" {
+		t.Fatal("invalid range produced geometry")
+	}
+	w.composition = gpucontext.IMEComposition{CompositionText: "é你", CursorBegin: 2, CursorEnd: 2, SelectionStart: 0, SelectionEnd: len("é你")}
+	if text, _, _, cursor := w.compositionPaintGeometry(tm, content, ""); text == "" || cursor.IsEmpty() {
+		t.Fatal("valid cursor range did not produce caret")
+	}
+	w.composition = gpucontext.IMEComposition{CompositionText: "é你", CursorBegin: -1, CursorEnd: -1, SelectionStart: 0, SelectionEnd: len("é你")}
+	if text, _, _, cursor := w.compositionPaintGeometry(tm, content, ""); text == "" || !cursor.IsEmpty() {
+		t.Fatal("hidden cursor invented caret")
+	}
+	w.cfg.inputType = TypePassword
+	if text, _, _, _ := w.compositionPaintGeometry(tm, content, ""); text != "" {
+		t.Fatal("password composition geometry leaked preedit")
+	}
+}
+
+func TestIMEDeleteSurroundingRejectsInvalidDirectRequests(t *testing.T) {
+	if (&Widget{}).deleteSurrounding(0, 0) {
+		t.Fatal("empty text delete should be rejected")
+	}
+	w := New(InitialValue("abc"))
+	if w.deleteSurrounding(4, 0) || w.deleteSurrounding(0, 4) {
+		t.Fatal("out-of-bounds delete should be rejected")
+	}
+	w.SetText("é")
+	w.sel.SetCursor(1)
+	if w.deleteSurrounding(1, 0) {
+		t.Fatal("mid-rune before delete should be rejected")
+	}
+	w.sel.SetCursor(0)
+	if w.deleteSurrounding(0, 1) {
+		t.Fatal("mid-rune after delete should be rejected")
+	}
+	w.SetText("abc")
+	w.sel.SetCursor(1)
+	if w.deleteSurrounding(-1, -1) {
+		t.Fatal("reversed surrounding range should be rejected")
+	}
+	if w.deleteSurrounding(0, 0) {
+		t.Fatal("empty surrounding range should be rejected")
+	}
+}
+
+func TestIMEHandleEventGuardBranches(t *testing.T) {
+	ctx := widget.NewContext()
+	w := New()
+	if handleIMEEvent(w, ctx, event.NewIMECompositionStart()) {
+		t.Fatal("unfocused handleIMEEvent should be rejected")
+	}
+	w.SetFocused(true)
+	w.SetEnabled(false)
+	if handleIMEEvent(w, ctx, event.NewIMECompositionStart()) {
+		t.Fatal("disabled handleIMEEvent should be rejected")
+	}
+}

--- a/core/textfield/painter.go
+++ b/core/textfield/painter.go
@@ -66,6 +66,25 @@ type PaintState struct {
 
 	// ColorScheme provides theme-derived colors. Zero value means use built-in defaults.
 	ColorScheme TextFieldColorScheme
+
+	// CompositionText is the current IME preedit. It is rendered separately
+	// from DisplayText so committed content never changes until composition end.
+	CompositionText string
+
+	// CompositionTextRect is the preedit's draw area, positioned at the
+	// committed caret and shifted with TextRect when the field scrolls.
+	CompositionTextRect geometry.Rect
+
+	// CompositionSelectionRect highlights the marked/selected segment supplied
+	// by the IME. It is empty when no segment is selected.
+	CompositionSelectionRect geometry.Rect
+
+	// CompositionCursorRect is the active cursor range inside the preedit. A
+	// hidden IME cursor is represented by an empty rectangle.
+	CompositionCursorRect geometry.Rect
+
+	// ShowComposition is true while a non-password field has an active preedit.
+	ShowComposition bool
 }
 
 // LayoutMetrics allows theme painters to provide spatial metrics used by the
@@ -100,7 +119,15 @@ type TextFieldColorScheme struct {
 	DisabledBg  widget.Color
 	DisabledFg  widget.Color
 	SelectionBg widget.Color
-	ErrorText   widget.Color
+	// CompositionColor is the preedit text color. Zero falls back to TextColor.
+	CompositionColor widget.Color
+	// CompositionUnderline is used for the IME preedit underline. Zero falls
+	// back to CursorColor.
+	CompositionUnderline widget.Color
+	// CompositionSelection is used for a marked segment. Zero falls back to
+	// SelectionBg.
+	CompositionSelection widget.Color
+	ErrorText            widget.Color
 }
 
 // DefaultPainter provides a minimal fallback painter with no design system styling.
@@ -199,6 +226,57 @@ func paintContent(canvas widget.Canvas, st *PaintState, colors TextFieldColorSch
 	}
 
 	canvas.DrawText(st.DisplayText, st.TextRect, fontSize, textColor, false, textAlignLeft)
+	PaintComposition(canvas, st, colors)
+}
+
+// PaintComposition renders the focused IME preedit with a marked-segment
+// highlight, underline, and optional cursor. Theme painters call this helper
+// from their content path so all design systems share the same UTF-8/range
+// geometry computed by TextField.
+func PaintComposition(canvas widget.Canvas, st *PaintState, colors TextFieldColorScheme) {
+	if st == nil || !st.ShowComposition || st.CompositionText == "" || st.CompositionTextRect.IsEmpty() {
+		return
+	}
+	fontSize := st.FontSize
+	if fontSize <= 0 {
+		fontSize = defaultFontSize
+	}
+
+	textColor := colors.CompositionColor
+	if textColor.IsTransparent() {
+		textColor = colors.TextColor
+	}
+	underlineColor := colors.CompositionUnderline
+	if underlineColor.IsTransparent() {
+		underlineColor = colors.CursorColor
+	}
+	selectionColor := colors.CompositionSelection
+	if selectionColor.IsTransparent() {
+		selectionColor = colors.SelectionBg
+	}
+
+	if !st.CompositionSelectionRect.IsEmpty() {
+		canvas.DrawRect(st.CompositionSelectionRect, selectionColor)
+	}
+	canvas.DrawText(st.CompositionText, st.CompositionTextRect, fontSize, textColor, false, textAlignLeft)
+
+	// A one-pixel underline is the common cross-platform representation of an
+	// IME preedit. The marked segment gets a stronger underline when present.
+	lineY := st.CompositionTextRect.Max.Y - 1
+	from := geometry.Pt(st.CompositionTextRect.Min.X, lineY)
+	to := geometry.Pt(st.CompositionTextRect.Max.X, lineY)
+	canvas.DrawLine(from, to, underlineColor, 1)
+	if !st.CompositionSelectionRect.IsEmpty() {
+		selectionFrom := geometry.Pt(st.CompositionSelectionRect.Min.X, lineY)
+		selectionTo := geometry.Pt(st.CompositionSelectionRect.Max.X, lineY)
+		canvas.DrawLine(selectionFrom, selectionTo, underlineColor, 2)
+	}
+
+	if !st.CompositionCursorRect.IsEmpty() {
+		top := geometry.Pt(st.CompositionCursorRect.Min.X, st.CompositionCursorRect.Min.Y)
+		bottom := geometry.Pt(st.CompositionCursorRect.Min.X, st.CompositionCursorRect.Max.Y)
+		canvas.DrawLine(top, bottom, underlineColor, st.CompositionCursorRect.Width())
+	}
 }
 
 // paintCursorFromState draws the cursor using pre-computed CursorRect.

--- a/core/textfield/textfield_test.go
+++ b/core/textfield/textfield_test.go
@@ -2076,3 +2076,91 @@ func TestIMECompositionHiddenCursorDoesNotInventPreeditCaret(t *testing.T) {
 		t.Fatalf("hidden cursor composition state = %#v, want no preedit caret", p.state)
 	}
 }
+
+func TestIMEPolicyVariantsAndInputGates(t *testing.T) {
+	cases := []struct {
+		name    string
+		input   textfield.InputType
+		purpose gpucontext.ContentPurpose
+		hints   gpucontext.ContentHint
+	}{
+		{"normal", textfield.TypeText, gpucontext.ContentPurposeNormal, gpucontext.ContentHintNone},
+		{"email", textfield.TypeEmail, gpucontext.ContentPurposeEmail, gpucontext.ContentHintNone},
+		{"number", textfield.TypeNumber, gpucontext.ContentPurposeNumber, gpucontext.ContentHintNone},
+		{"search", textfield.TypeSearch, gpucontext.ContentPurposeNormal, gpucontext.ContentHintCompletion},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tf := textfield.New(textfield.InputTypeOpt(tc.input), textfield.InitialValue("é你"))
+			tf.SetFocused(true)
+			purpose, hints := tf.IMEContentType()
+			if purpose != tc.purpose || hints != tc.hints {
+				t.Fatalf("content type=(%v,%v), want (%v,%v)", purpose, hints, tc.purpose, tc.hints)
+			}
+			if !tf.IMEEnabled() || tf.IMESurroundingText().Text != "é你" {
+				t.Fatalf("enabled field did not expose surrounding text: %#v", tf.IMESurroundingText())
+			}
+			tf.SetFocused(false)
+			if tf.IMEEnabled() || tf.IMESurroundingText() != (gpucontext.IMESurroundingText{}) {
+				t.Fatalf("unfocused field leaked IME state: enabled=%v surrounding=%#v", tf.IMEEnabled(), tf.IMESurroundingText())
+			}
+		})
+	}
+}
+
+func TestIMEFallbackCursorAreaBeforeDraw(t *testing.T) {
+	tf := textfield.New()
+	tf.SetBounds(geometry.NewRect(10, 20, 200, 48))
+	area := tf.IMECursorArea()
+	if area.Width <= 0 || area.Height <= 0 {
+		t.Fatalf("fallback cursor area = %#v, want non-empty", area)
+	}
+}
+
+func TestIMEEventInputGatesAndInvalidPayloads(t *testing.T) {
+	ctx := widget.NewContext()
+	bound := geometry.NewRect(0, 0, 300, 48)
+	invalid := gpucontext.IMEComposition{CompositionText: "é", CursorBegin: 1, CursorEnd: 1, SelectionStart: 0, SelectionEnd: len("é")}
+	for _, tc := range []struct {
+		name  string
+		setup func(*textfield.Widget)
+	}{
+		{"unfocused", func(tf *textfield.Widget) { tf.SetFocused(false) }},
+		{"disabled", func(tf *textfield.Widget) { tf.SetFocused(true); tf.SetEnabled(false) }},
+		{"hidden", func(tf *textfield.Widget) { tf.SetFocused(true); tf.SetVisible(false) }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tf := textfield.New(textfield.InitialValue("keep"))
+			tf.SetBounds(bound)
+			tf.SetFocused(true)
+			if !tf.Event(ctx, event.NewIMECompositionStart()) {
+				t.Fatal("composition start should be consumed before gate")
+			}
+			tc.setup(tf)
+			if tf.Event(ctx, event.NewIMECompositionUpdate(invalid)) && tc.name == "unfocused" {
+				t.Fatal("unfocused IME event should not be consumed")
+			}
+			if tc.name != "unfocused" && !tf.Event(ctx, event.NewIMECompositionEnd("stale")) {
+				t.Fatal("disabled/hidden IME event should be consumed")
+			}
+		})
+	}
+
+	tf := textfield.New(textfield.InitialValue("keep"))
+	tf.SetBounds(bound)
+	tf.SetFocused(true)
+	if !tf.Event(ctx, event.NewIMECompositionUpdate(invalid)) {
+		t.Fatal("invalid composition update should be consumed")
+	}
+	if tf.Event(ctx, event.NewIMEDeleteSurrounding(gpucontext.IMEDeleteSurroundingEvent{Before: -1})) != true {
+		t.Fatal("invalid delete request should be consumed")
+	}
+	if !tf.Event(ctx, event.NewIMECompositionEnd("")) {
+		t.Fatal("empty composition end should be consumed")
+	}
+	// FocusLost is intentionally not consumed so parent focus managers can
+	// observe it after the field clears its transient IME state.
+	_ = tf.Event(ctx, event.NewFocusEvent(event.FocusLost))
+	_ = tf.Event(ctx, event.NewFocusEvent(event.FocusGained))
+	_ = tf.Event(ctx, nil)
+}

--- a/core/textfield/textfield_test.go
+++ b/core/textfield/textfield_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gogpu/gpucontext"
 	"github.com/gogpu/ui/a11y"
 	"github.com/gogpu/ui/core/textfield"
 	"github.com/gogpu/ui/event"
@@ -1769,5 +1770,180 @@ func TestUnmount_CleansBindings(t *testing.T) {
 
 	if sched.PendingCount() != 0 {
 		t.Error("signal change after unmount should not mark widget dirty")
+	}
+}
+
+// --- IME composition tests ---
+
+func TestIMECompositionLifecycleDoesNotMutatePreedit(t *testing.T) {
+	var changes []string
+	p := &testPainter{}
+	tf := textfield.New(
+		textfield.PainterOpt(p),
+		textfield.OnChange(func(value string) { changes = append(changes, value) }),
+	)
+	tf.SetBounds(geometry.NewRect(0, 0, 300, 48))
+	tf.SetFocused(true)
+	ctx := widget.NewContext()
+	canvas := &mockCanvas{}
+
+	composition := gpucontext.IMEComposition{
+		CompositionText: "かな",
+		CursorBegin:     len("か"),
+		CursorEnd:       len("か"),
+		SelectionStart:  0,
+		SelectionEnd:    len("かな"),
+	}
+	if !tf.Event(ctx, event.NewIMECompositionStart()) {
+		t.Fatal("composition start should be consumed")
+	}
+	if !tf.Event(ctx, event.NewIMECompositionUpdate(composition)) {
+		t.Fatal("composition update should be consumed")
+	}
+	if got := tf.Text(); got != "" {
+		t.Fatalf("preedit changed committed text to %q", got)
+	}
+	tf.Draw(ctx, canvas)
+	if !p.state.ShowComposition || p.state.CompositionText != composition.CompositionText {
+		t.Fatalf("paint state = %#v, want visible preedit", p.state)
+	}
+	if p.state.CompositionSelectionRect.IsEmpty() || p.state.CompositionCursorRect.IsEmpty() {
+		t.Fatalf("paint state = %#v, want marked range and cursor", p.state)
+	}
+
+	if !tf.Event(ctx, event.NewIMECompositionEnd("仮名")) {
+		t.Fatal("composition end should be consumed")
+	}
+	if got := tf.Text(); got != "仮名" {
+		t.Fatalf("committed text = %q, want %q", got, "仮名")
+	}
+	if len(changes) != 1 || changes[0] != "仮名" {
+		t.Fatalf("onChange = %#v, want one committed callback", changes)
+	}
+	tf.Draw(ctx, canvas)
+	if p.state.ShowComposition || p.state.CompositionText != "" {
+		t.Fatalf("composition remained after commit: %#v", p.state)
+	}
+}
+
+func TestIMECompositionCancelAndDisabledDiscardPreedit(t *testing.T) {
+	for _, cancel := range []struct {
+		name string
+		e    event.Event
+	}{
+		{name: "cancel", e: event.NewIMECanceled()},
+		{name: "disabled", e: event.NewIMEDisabled()},
+	} {
+		t.Run(cancel.name, func(t *testing.T) {
+			tf := textfield.New(textfield.InitialValue("keep"))
+			tf.SetBounds(geometry.NewRect(0, 0, 300, 48))
+			tf.SetFocused(true)
+			ctx := widget.NewContext()
+			composition := gpucontext.IMEComposition{CompositionText: "draft", CursorBegin: 0, CursorEnd: 0, SelectionStart: 0, SelectionEnd: 0}
+			tf.Event(ctx, event.NewIMECompositionStart())
+			tf.Event(ctx, event.NewIMECompositionUpdate(composition))
+			if !tf.Event(ctx, cancel.e) {
+				t.Fatal("cancel/disabled event should be consumed")
+			}
+			if tf.Text() != "keep" {
+				t.Fatalf("text = %q, want committed value unchanged", tf.Text())
+			}
+		})
+	}
+}
+
+func TestIMEPasswordPrivacyAndHints(t *testing.T) {
+	tf := textfield.New(
+		textfield.InitialValue("secret"),
+		textfield.InputTypeOpt(textfield.TypePassword),
+	)
+	tf.SetFocused(true)
+	if tf.IMEEnabled() {
+		t.Fatal("password field must not enable native IME")
+	}
+	purpose, hints := tf.IMEContentType()
+	if purpose != gpucontext.ContentPurposePassword ||
+		!hints.Has(gpucontext.ContentHintHiddenText) ||
+		!hints.Has(gpucontext.ContentHintSensitiveData) {
+		t.Fatalf("content type = (%v, %v), want password privacy hints", purpose, hints)
+	}
+	if surrounding := tf.IMESurroundingText(); surrounding != (gpucontext.IMESurroundingText{}) {
+		t.Fatalf("password surrounding text = %#v, want empty", surrounding)
+	}
+
+	p := &testPainter{}
+	tf = textfield.New(textfield.InputTypeOpt(textfield.TypePassword), textfield.PainterOpt(p))
+	tf.SetBounds(geometry.NewRect(0, 0, 300, 48))
+	tf.SetFocused(true)
+	ctx := widget.NewContext()
+	composition := gpucontext.IMEComposition{CompositionText: "secret-preedit", CursorBegin: 0, CursorEnd: 0, SelectionStart: 0, SelectionEnd: 0}
+	tf.Event(ctx, event.NewIMECompositionStart())
+	tf.Event(ctx, event.NewIMECompositionUpdate(composition))
+	tf.Draw(ctx, &mockCanvas{})
+	if p.state.ShowComposition || p.state.CompositionText != "" {
+		t.Fatalf("password paint state leaked composition: %#v", p.state)
+	}
+}
+
+func TestIMEDeleteSurroundingUsesUTF8ByteCounts(t *testing.T) {
+	var changes []string
+	tf := textfield.New(
+		textfield.InitialValue("é你a"),
+		textfield.OnChange(func(value string) { changes = append(changes, value) }),
+	)
+	tf.SetFocused(true)
+	ctx := widget.NewContext()
+
+	// Three bytes before the end would split the three-byte rune 你, so the
+	// request is rejected without a callback or text mutation.
+	if !tf.Event(ctx, event.NewIMEDeleteSurrounding(gpucontext.IMEDeleteSurroundingEvent{Before: 3})) {
+		t.Fatal("invalid UTF-8-boundary delete should still be consumed")
+	}
+	if tf.Text() != "é你a" || len(changes) != 0 {
+		t.Fatalf("invalid delete changed text=%q callbacks=%v", tf.Text(), changes)
+	}
+	if !tf.Event(ctx, event.NewIMEDeleteSurrounding(gpucontext.IMEDeleteSurroundingEvent{Before: 1})) {
+		t.Fatal("valid surrounding delete should be consumed")
+	}
+	if tf.Text() != "é你" || len(changes) != 1 || changes[0] != "é你" {
+		t.Fatalf("valid delete text=%q callbacks=%v, want é你/one callback", tf.Text(), changes)
+	}
+}
+
+func TestIMECursorAreaAndCompositionPainting(t *testing.T) {
+	tf := textfield.New(textfield.InitialValue("x"))
+	tf.SetBounds(geometry.NewRect(10, 20, 300, 48))
+	tf.SetFocused(true)
+	ctx := widget.NewContext()
+	canvas := &recordingCanvas{}
+	tf.Draw(ctx, canvas)
+	area := tf.IMECursorArea()
+	if area.Width <= 0 || area.Height <= 0 || area.X <= 0 || area.Y <= 0 {
+		t.Fatalf("cursor area = %#v, want non-empty window-local rect", area)
+	}
+
+	st := &textfield.PaintState{
+		Focused:                  true,
+		Bounds:                   geometry.NewRect(0, 0, 100, 40),
+		ContentRect:              geometry.NewRect(0, 0, 100, 40),
+		CompositionText:          "preedit",
+		CompositionTextRect:      geometry.NewRect(10, 5, 40, 20),
+		CompositionSelectionRect: geometry.NewRect(20, 5, 10, 20),
+		CompositionCursorRect:    geometry.NewRect(25, 5, 1, 20),
+		ShowComposition:          true,
+	}
+	paintCanvas := &recordingCanvas{}
+	(textfield.DefaultPainter{}).PaintTextField(paintCanvas, st)
+	foundPreedit := false
+	for _, call := range paintCanvas.drawTexts {
+		if call.text == "preedit" {
+			foundPreedit = true
+			if call.fontSize <= 0 {
+				t.Errorf("preedit font size = %v, want positive fallback", call.fontSize)
+			}
+		}
+	}
+	if !foundPreedit || len(paintCanvas.drawLines) < 2 {
+		t.Fatalf("composition paint calls = texts=%#v lines=%#v, want preedit and underline/cursor", paintCanvas.drawTexts, paintCanvas.drawLines)
 	}
 }

--- a/core/textfield/textfield_test.go
+++ b/core/textfield/textfield_test.go
@@ -1852,6 +1852,42 @@ func TestIMECompositionCancelAndDisabledDiscardPreedit(t *testing.T) {
 	}
 }
 
+func TestIMECompositionClearsAcrossProgrammaticStateToggles(t *testing.T) {
+	p := &testPainter{}
+	tf := textfield.New(textfield.PainterOpt(p))
+	tf.SetBounds(geometry.NewRect(0, 0, 300, 48))
+	tf.SetFocused(true)
+	ctx := widget.NewContext()
+	composition := gpucontext.IMEComposition{
+		CompositionText: "draft",
+		CursorBegin:     0,
+		CursorEnd:       0,
+		SelectionStart:  0,
+		SelectionEnd:    len("draft"),
+	}
+	tf.Event(ctx, event.NewIMECompositionStart())
+	tf.Event(ctx, event.NewIMECompositionUpdate(composition))
+
+	// Neither transition necessarily emits a FocusEvent. Draw must still
+	// clear the transient preedit, including the case where the field is
+	// re-enabled before any frame is rendered while hidden/disabled.
+	tf.SetEnabled(false)
+	tf.SetEnabled(true)
+	tf.Draw(ctx, &mockCanvas{})
+	if p.state.ShowComposition || p.state.CompositionText != "" {
+		t.Fatalf("preedit survived disabled/re-enabled toggle: %#v", p.state)
+	}
+
+	tf.Event(ctx, event.NewIMECompositionStart())
+	tf.Event(ctx, event.NewIMECompositionUpdate(composition))
+	tf.SetVisible(false)
+	tf.SetVisible(true)
+	tf.Draw(ctx, &mockCanvas{})
+	if p.state.ShowComposition || p.state.CompositionText != "" {
+		t.Fatalf("preedit survived hidden/re-enabled toggle: %#v", p.state)
+	}
+}
+
 func TestIMEPasswordPrivacyAndHints(t *testing.T) {
 	tf := textfield.New(
 		textfield.InitialValue("secret"),
@@ -1879,6 +1915,18 @@ func TestIMEPasswordPrivacyAndHints(t *testing.T) {
 	composition := gpucontext.IMEComposition{CompositionText: "secret-preedit", CursorBegin: 0, CursorEnd: 0, SelectionStart: 0, SelectionEnd: 0}
 	tf.Event(ctx, event.NewIMECompositionStart())
 	tf.Event(ctx, event.NewIMECompositionUpdate(composition))
+	if !tf.Event(ctx, event.NewIMECompositionEnd("stale-commit")) {
+		t.Fatal("password IME end should be consumed")
+	}
+	if tf.Text() != "" {
+		t.Fatalf("password stale end committed %q", tf.Text())
+	}
+	if !tf.Event(ctx, event.NewIMEDeleteSurrounding(gpucontext.IMEDeleteSurroundingEvent{Before: 1})) {
+		t.Fatal("password delete-surrounding should be consumed")
+	}
+	if tf.Text() != "" {
+		t.Fatalf("password delete-surrounding changed text to %q", tf.Text())
+	}
 	tf.Draw(ctx, &mockCanvas{})
 	if p.state.ShowComposition || p.state.CompositionText != "" {
 		t.Fatalf("password paint state leaked composition: %#v", p.state)
@@ -1907,6 +1955,29 @@ func TestIMEDeleteSurroundingUsesUTF8ByteCounts(t *testing.T) {
 	}
 	if tf.Text() != "é你" || len(changes) != 1 || changes[0] != "é你" {
 		t.Fatalf("valid delete text=%q callbacks=%v, want é你/one callback", tf.Text(), changes)
+	}
+}
+
+func TestIMEDeleteSurroundingDeletesBeforeAndAfterAtRuneBoundaries(t *testing.T) {
+	var changes []string
+	tf := textfield.New(
+		textfield.InitialValue("é你a"),
+		textfield.OnChange(func(value string) { changes = append(changes, value) }),
+	)
+	tf.SetFocused(true)
+	ctx := widget.NewContext()
+	pressKey(tf, ctx, event.KeyHome, event.ModNone)
+	pressKey(tf, ctx, event.KeyRight, event.ModNone) // between é and 你
+
+	request := gpucontext.IMEDeleteSurroundingEvent{Before: len("é"), After: len("你")}
+	if !tf.Event(ctx, event.NewIMEDeleteSurrounding(request)) {
+		t.Fatal("delete-surrounding request should be consumed")
+	}
+	if tf.Text() != "a" || tf.CursorPosition() != 0 {
+		t.Fatalf("delete before/after text=%q cursor=%d, want a/0", tf.Text(), tf.CursorPosition())
+	}
+	if len(changes) != 1 || changes[0] != "a" {
+		t.Fatalf("onChange=%v, want one callback for atomic deletion", changes)
 	}
 }
 
@@ -1945,5 +2016,63 @@ func TestIMECursorAreaAndCompositionPainting(t *testing.T) {
 	}
 	if !foundPreedit || len(paintCanvas.drawLines) < 2 {
 		t.Fatalf("composition paint calls = texts=%#v lines=%#v, want preedit and underline/cursor", paintCanvas.drawTexts, paintCanvas.drawLines)
+	}
+}
+
+func TestIMECompositionGeometryUsesUTF8RangesAndSingleCursor(t *testing.T) {
+	p := &testPainter{}
+	tf := textfield.New(textfield.PainterOpt(p))
+	tf.SetBounds(geometry.NewRect(0, 0, 300, 48))
+	tf.SetFocused(true)
+	ctx := widget.NewContext()
+	composition := gpucontext.IMEComposition{
+		CompositionText: "aé你",
+		CursorBegin:     len("aé"),
+		CursorEnd:       len("aé你"),
+		SelectionStart:  len("a"),
+		SelectionEnd:    len("aé"),
+	}
+	tf.Event(ctx, event.NewIMECompositionStart())
+	tf.Event(ctx, event.NewIMECompositionUpdate(composition))
+	tf.Draw(ctx, &mockCanvas{})
+	if !p.state.ShowComposition || p.state.CompositionText != composition.CompositionText {
+		t.Fatalf("paint state = %#v, want UTF-8 preedit", p.state)
+	}
+	if p.state.CompositionSelectionRect.IsEmpty() || p.state.CompositionCursorRect.IsEmpty() {
+		t.Fatalf("paint state = %#v, want selected segment and cursor range", p.state)
+	}
+	if p.state.ShowCursor {
+		t.Fatal("committed cursor drawn alongside visible preedit cursor")
+	}
+
+	// A byte offset inside the two-byte rune is invalid and must never reach
+	// the painter as a malformed geometry range.
+	invalid := composition
+	invalid.SelectionStart = 2
+	tf.Event(ctx, event.NewIMECompositionUpdate(invalid))
+	tf.Draw(ctx, &mockCanvas{})
+	if p.state.ShowComposition || p.state.CompositionText != "" {
+		t.Fatalf("invalid UTF-8 range rendered as composition: %#v", p.state)
+	}
+}
+
+func TestIMECompositionHiddenCursorDoesNotInventPreeditCaret(t *testing.T) {
+	p := &testPainter{}
+	tf := textfield.New(textfield.PainterOpt(p))
+	tf.SetBounds(geometry.NewRect(0, 0, 300, 48))
+	tf.SetFocused(true)
+	ctx := widget.NewContext()
+	composition := gpucontext.IMEComposition{
+		CompositionText: "かな",
+		CursorBegin:     -1,
+		CursorEnd:       -1,
+		SelectionStart:  0,
+		SelectionEnd:    len("かな"),
+	}
+	tf.Event(ctx, event.NewIMECompositionStart())
+	tf.Event(ctx, event.NewIMECompositionUpdate(composition))
+	tf.Draw(ctx, &mockCanvas{})
+	if !p.state.ShowComposition || !p.state.CompositionCursorRect.IsEmpty() {
+		t.Fatalf("hidden cursor composition state = %#v, want no preedit caret", p.state)
 	}
 }

--- a/core/textfield/widget.go
+++ b/core/textfield/widget.go
@@ -316,19 +316,14 @@ func (w *Widget) compositionPaintGeometry(
 		return "", geometry.Rect{}, geometry.Rect{}, geometry.Rect{}
 	}
 
-	start, ok := compositionRangeToRunes(composition.CompositionText, composition.SelectionStart, composition.SelectionEnd)
-	if !ok {
-		return "", geometry.Rect{}, geometry.Rect{}, geometry.Rect{}
-	}
+	// IsValid above guarantees that all supplied byte offsets are UTF-8
+	// boundaries in CompositionText, so conversion cannot fail here.
+	start, _ := compositionRangeToRunes(composition.CompositionText, composition.SelectionStart, composition.SelectionEnd)
 	cursorBegin, cursorEnd := composition.CursorBegin, composition.CursorEnd
 	if cursorBegin < 0 || cursorEnd < 0 {
 		cursorBegin, cursorEnd = 0, 0
 	}
-	cursorStart, cursorOK := byteOffsetToRune(composition.CompositionText, cursorBegin)
-	cursorFinish, cursorEndOK := byteOffsetToRune(composition.CompositionText, cursorEnd)
-	if !cursorOK || !cursorEndOK {
-		return "", geometry.Rect{}, geometry.Rect{}, geometry.Rect{}
-	}
+	cursorStart, _ := byteOffsetToRune(composition.CompositionText, cursorBegin)
 
 	startX := tm.CursorX(contentRect, displayText, w.sel.cursor) + w.scrollOffsetX
 	width := tm.Canvas.MeasureText(composition.CompositionText, tm.FontSize, false)
@@ -344,12 +339,9 @@ func (w *Widget) compositionPaintGeometry(
 	}
 	cursorRect := geometry.Rect{}
 	if composition.HasCursor() {
-		// CursorBegin may be a range start; the caret is placed at its leading
-		// edge so selected segments remain visibly underlined instead.
+		// CursorBegin is the leading edge of the valid cursor range, so selected
+		// segments remain visibly underlined instead of moving the caret.
 		cursorRect = tm.CursorRect(compositionRect, composition.CompositionText, cursorStart, resolveLayoutMetrics(w.painter).TextFieldCursorWidth())
-		if cursorFinish < cursorStart {
-			cursorRect = tm.CursorRect(compositionRect, composition.CompositionText, cursorFinish, resolveLayoutMetrics(w.painter).TextFieldCursorWidth())
-		}
 	}
 	return composition.CompositionText, compositionRect, selectionRect, cursorRect
 }

--- a/core/textfield/widget.go
+++ b/core/textfield/widget.go
@@ -1,6 +1,9 @@
 package textfield
 
 import (
+	"unicode/utf8"
+
+	"github.com/gogpu/gpucontext"
 	"github.com/gogpu/ui/event"
 	"github.com/gogpu/ui/geometry"
 	"github.com/gogpu/ui/gesture"
@@ -55,10 +58,18 @@ type Widget struct {
 	// (positionFromGlobal) that don't have access to canvas.
 	cachedMetrics *textmetrics.Metrics
 	// Cached layout values from last Draw call.
-	cachedContentRect geometry.Rect
-	cachedDisplayText string
-	cachedFontSize    float32
-	gestureHandledTap bool
+	cachedContentRect   geometry.Rect
+	cachedDisplayText   string
+	cachedFontSize      float32
+	cachedIMECursorArea gpucontext.IMECursorArea
+	cachedIMEAreaSet    bool
+	gestureHandledTap   bool
+
+	// IME composition is kept separate from committed text. Cursor and
+	// selection positions in the preedit are UTF-8 byte offsets supplied by the
+	// gpucontext v2 contract and converted to rune positions only for drawing.
+	composition gpucontext.IMEComposition
+	composing   bool
 }
 
 // New creates a new text field Widget with the given options.
@@ -138,6 +149,7 @@ func (w *Widget) Draw(_ widget.Context, canvas widget.Canvas) {
 	if w.cfg.signal != nil {
 		current := w.cfg.signal.Get()
 		if current != w.cfg.value {
+			w.clearComposition()
 			w.cfg.value = current
 			runes := []rune(current)
 			w.sel.SetCursor(clampPos(w.sel.cursor, len(runes)))
@@ -152,6 +164,11 @@ func (w *Widget) Draw(_ widget.Context, canvas widget.Canvas) {
 	bounds := w.Bounds()
 	focused := w.IsFocused()
 	disabled := w.cfg.ResolvedDisabled()
+	if disabled || !w.IsEnabled() || !w.IsVisible() {
+		// A programmatic disable/visibility change may not emit a FocusEvent;
+		// cancel the in-memory preedit before it can reappear on re-enable.
+		w.clearComposition()
+	}
 	hasSelection := w.sel.anchor != w.sel.cursor
 
 	displayText := text
@@ -205,6 +222,23 @@ func (w *Widget) Draw(_ widget.Context, canvas widget.Canvas) {
 		selectionRect.Max.X += w.scrollOffsetX
 	}
 
+	compositionText, compositionRect, compositionSelectionRect, compositionCursorRect :=
+		w.compositionPaintGeometry(tm, contentRect, displayText)
+	showComposition := focused && w.IsVisible() && w.IsEnabled() &&
+		compositionText != "" && !compositionRect.IsEmpty() && !disabled
+	if showComposition {
+		// Candidate placement follows the active preedit cursor when the IME
+		// provides one; otherwise it remains anchored to the committed caret.
+		candidate := compositionCursorRect
+		if candidate.IsEmpty() {
+			candidate = cursorRect
+		}
+		w.cachedIMECursorArea = w.areaFromLocalRect(candidate, bounds)
+	} else {
+		w.cachedIMECursorArea = w.areaFromLocalRect(cursorRect, bounds)
+	}
+	w.cachedIMEAreaSet = true
+
 	w.painter.PaintTextField(canvas, &PaintState{
 		// Legacy fields.
 		Text:        text,
@@ -221,15 +255,180 @@ func (w *Widget) Draw(_ widget.Context, canvas widget.Canvas) {
 		Bounds:      bounds,
 
 		// Pre-computed fields.
-		DisplayText:   displayText,
-		ContentRect:   contentRect,
-		TextRect:      scrolledRect,
-		CursorRect:    cursorRect,
-		SelectionRect: selectionRect,
-		ShowCursor:    showCursor,
-		ShowSelection: showSelection,
-		FontSize:      fontSize,
+		DisplayText:              displayText,
+		ContentRect:              contentRect,
+		TextRect:                 scrolledRect,
+		CursorRect:               cursorRect,
+		SelectionRect:            selectionRect,
+		ShowCursor:               showCursor,
+		ShowSelection:            showSelection,
+		FontSize:                 fontSize,
+		CompositionText:          compositionText,
+		CompositionTextRect:      compositionRect,
+		CompositionSelectionRect: compositionSelectionRect,
+		CompositionCursorRect:    compositionCursorRect,
+		ShowComposition:          showComposition,
 	})
+}
+
+// compositionPaintGeometry converts the versioned UTF-8 composition ranges
+// into the rune-index geometry used by textmetrics. The committed text stays
+// unchanged; the preedit is drawn at the committed caret and therefore never
+// participates in selection or clipboard operations until it is committed.
+func (w *Widget) compositionPaintGeometry(
+	tm *textmetrics.Metrics,
+	contentRect geometry.Rect,
+	displayText string,
+) (string, geometry.Rect, geometry.Rect, geometry.Rect) {
+	if !w.composing || w.cfg.inputType == TypePassword {
+		return "", geometry.Rect{}, geometry.Rect{}, geometry.Rect{}
+	}
+	composition := w.composition
+	if !composition.IsValid() || composition.CompositionText == "" {
+		return "", geometry.Rect{}, geometry.Rect{}, geometry.Rect{}
+	}
+
+	start, ok := compositionRangeToRunes(composition.CompositionText, composition.SelectionStart, composition.SelectionEnd)
+	if !ok {
+		return "", geometry.Rect{}, geometry.Rect{}, geometry.Rect{}
+	}
+	cursorBegin, cursorEnd := composition.CursorBegin, composition.CursorEnd
+	if cursorBegin < 0 || cursorEnd < 0 {
+		cursorBegin, cursorEnd = 0, 0
+	}
+	cursorStart, cursorOK := byteOffsetToRune(composition.CompositionText, cursorBegin)
+	cursorFinish, cursorEndOK := byteOffsetToRune(composition.CompositionText, cursorEnd)
+	if !cursorOK || !cursorEndOK {
+		return "", geometry.Rect{}, geometry.Rect{}, geometry.Rect{}
+	}
+
+	startX := tm.CursorX(contentRect, displayText, w.sel.cursor) + w.scrollOffsetX
+	width := tm.Canvas.MeasureText(composition.CompositionText, tm.FontSize, false)
+	compositionRect := geometry.NewRect(
+		startX,
+		contentRect.Min.Y,
+		width,
+		contentRect.Height(),
+	)
+	selectionRect := geometry.Rect{}
+	if start != nil {
+		selectionRect = tm.SelectionRect(compositionRect, composition.CompositionText, start[0], start[1])
+	}
+	cursorRect := geometry.Rect{}
+	if composition.HasCursor() {
+		// CursorBegin may be a range start; the caret is placed at its leading
+		// edge so selected segments remain visibly underlined instead.
+		cursorRect = tm.CursorRect(compositionRect, composition.CompositionText, cursorStart, resolveLayoutMetrics(w.painter).TextFieldCursorWidth())
+		if cursorFinish < cursorStart {
+			cursorRect = tm.CursorRect(compositionRect, composition.CompositionText, cursorFinish, resolveLayoutMetrics(w.painter).TextFieldCursorWidth())
+		}
+	}
+	return composition.CompositionText, compositionRect, selectionRect, cursorRect
+}
+
+// areaFromLocalRect converts a widget-local caret rectangle to window-local
+// logical DIP coordinates as required by gpucontext.IMECursorArea.
+func (w *Widget) areaFromLocalRect(rect, bounds geometry.Rect) gpucontext.IMECursorArea {
+	if rect.IsEmpty() {
+		return gpucontext.IMECursorArea{}
+	}
+	origin := w.ScreenOrigin()
+	return gpucontext.IMECursorArea{
+		X:      float64(origin.X + rect.Min.X - bounds.Min.X),
+		Y:      float64(origin.Y + rect.Min.Y - bounds.Min.Y),
+		Width:  float64(rect.Width()),
+		Height: float64(rect.Height()),
+	}
+}
+
+// byteOffsetToRune converts a validated UTF-8 byte offset to a rune index.
+func byteOffsetToRune(text string, offset int) (int, bool) {
+	if offset < 0 || offset > len(text) || !utf8.ValidString(text) {
+		return 0, false
+	}
+	if offset < len(text) && !utf8.RuneStart(text[offset]) {
+		return 0, false
+	}
+	return len([]rune(text[:offset])), true
+}
+
+func compositionRangeToRunes(text string, start, end int) ([]int, bool) {
+	if start == end {
+		return nil, true
+	}
+	first, ok := byteOffsetToRune(text, start)
+	if !ok {
+		return nil, false
+	}
+	last, ok := byteOffsetToRune(text, end)
+	if !ok || first > last {
+		return nil, false
+	}
+	return []int{first, last}, true
+}
+
+// IMEEnabled reports whether this field should own the platform IME.
+// Password fields deliberately disable native composition to avoid leaking
+// preedit/surrounding text into IME candidate stores.
+func (w *Widget) IMEEnabled() bool {
+	return w.IsFocused() && w.IsVisible() && w.IsEnabled() &&
+		!w.cfg.ResolvedDisabled() && w.cfg.inputType != TypePassword
+}
+
+// IMEContentType returns the advisory purpose and privacy hints for this
+// field's input type.
+func (w *Widget) IMEContentType() (gpucontext.ContentPurpose, gpucontext.ContentHint) {
+	switch w.cfg.inputType {
+	case TypePassword:
+		return gpucontext.ContentPurposePassword,
+			gpucontext.ContentHintHiddenText | gpucontext.ContentHintSensitiveData
+	case TypeEmail:
+		return gpucontext.ContentPurposeEmail, gpucontext.ContentHintNone
+	case TypeNumber:
+		// gpucontext deliberately models the semantic purpose separately from
+		// presentation hints; there is no digits-only hint in the contract.
+		return gpucontext.ContentPurposeNumber, gpucontext.ContentHintNone
+	case TypeSearch:
+		return gpucontext.ContentPurposeNormal, gpucontext.ContentHintCompletion
+	default:
+		return gpucontext.ContentPurposeNormal, gpucontext.ContentHintNone
+	}
+}
+
+// IMESurroundingText returns the committed UTF-8 text and cursor/anchor byte
+// offsets. It returns an empty payload whenever IME is disabled or unfocused.
+func (w *Widget) IMESurroundingText() gpucontext.IMESurroundingText {
+	if !w.IMEEnabled() {
+		return gpucontext.IMESurroundingText{}
+	}
+	text := w.resolvedText()
+	runes := []rune(text)
+	cursor := clampPos(w.sel.cursor, len(runes))
+	anchor := clampPos(w.sel.anchor, len(runes))
+	return gpucontext.IMESurroundingText{
+		Text:   text,
+		Cursor: runeToByteOffset(runes, cursor),
+		Anchor: runeToByteOffset(runes, anchor),
+	}
+}
+
+// IMECursorArea returns the latest caret rectangle in window-local logical
+// DIP coordinates. Before the first draw it falls back to the field's content
+// origin, which is still a safe candidate anchor for native IMEs.
+func (w *Widget) IMECursorArea() gpucontext.IMECursorArea {
+	if w.cachedIMEAreaSet {
+		return w.cachedIMECursorArea
+	}
+	bounds := w.Bounds()
+	lm := resolveLayoutMetrics(w.painter)
+	hPad, vPad := lm.ContentPadding()
+	area := geometry.NewRect(bounds.Min.X+hPad, bounds.Min.Y+vPad, lm.TextFieldCursorWidth(), bounds.Height()-2*vPad)
+	return w.areaFromLocalRect(area, bounds)
+}
+
+func runeToByteOffset(runes []rune, index int) int {
+	index = clampPos(index, len(runes))
+	return len(string(runes[:index]))
 }
 
 // scrollMargin is the horizontal margin in pixels to keep between the cursor
@@ -322,6 +521,7 @@ func (w *Widget) Text() string {
 
 // SetText sets the text value programmatically and revalidates.
 func (w *Widget) SetText(text string) {
+	w.clearComposition()
 	w.setText(text)
 	runes := []rune(text)
 	w.sel.SetCursor(clampPos(w.sel.cursor, len(runes)))

--- a/core/textfield/widget.go
+++ b/core/textfield/widget.go
@@ -134,6 +134,27 @@ func (w *Widget) IsFocusable() bool {
 	return w.IsVisible() && w.IsEnabled() && !w.cfg.ResolvedDisabled()
 }
 
+// SetEnabled updates the widget's enabled state and invalidates any transient
+// IME preedit immediately. Programmatic toggles do not necessarily produce a
+// FocusEvent, so waiting until Draw would let a disabled-then-reenabled field
+// resurrect stale composition text.
+func (w *Widget) SetEnabled(enabled bool) {
+	if !enabled {
+		w.CancelIMEComposition()
+	}
+	w.WidgetBase.SetEnabled(enabled)
+}
+
+// SetVisible updates visibility and clears transient IME state when the field
+// is hidden. This mirrors SetEnabled for callers that toggle visibility
+// reactively between frames.
+func (w *Widget) SetVisible(visible bool) {
+	if !visible {
+		w.CancelIMEComposition()
+	}
+	w.WidgetBase.SetVisible(visible)
+}
+
 // Layout calculates the text field's preferred size within the given constraints.
 func (w *Widget) Layout(_ widget.Context, constraints geometry.Constraints) geometry.Size {
 	width := constraints.MaxWidth
@@ -164,9 +185,10 @@ func (w *Widget) Draw(_ widget.Context, canvas widget.Canvas) {
 	bounds := w.Bounds()
 	focused := w.IsFocused()
 	disabled := w.cfg.ResolvedDisabled()
-	if disabled || !w.IsEnabled() || !w.IsVisible() {
-		// A programmatic disable/visibility change may not emit a FocusEvent;
-		// cancel the in-memory preedit before it can reappear on re-enable.
+	if !focused || disabled || !w.IsEnabled() || !w.IsVisible() {
+		// A programmatic focus/disable/visibility change may not emit a
+		// FocusEvent; cancel the in-memory preedit before it can reappear on
+		// re-enable or on a later focus restore.
 		w.clearComposition()
 	}
 	hasSelection := w.sel.anchor != w.sel.cursor
@@ -226,6 +248,12 @@ func (w *Widget) Draw(_ widget.Context, canvas widget.Canvas) {
 		w.compositionPaintGeometry(tm, contentRect, displayText)
 	showComposition := focused && w.IsVisible() && w.IsEnabled() &&
 		compositionText != "" && !compositionRect.IsEmpty() && !disabled
+	if showComposition && !compositionCursorRect.IsEmpty() {
+		// The marked-text cursor is the only insertion caret during a visible
+		// preedit. Drawing the committed caret as well produces two cursors,
+		// often at different positions, while the IME is active.
+		showCursor = false
+	}
 	if showComposition {
 		// Candidate placement follows the active preedit cursor when the IME
 		// provides one; otherwise it remains anchored to the committed caret.

--- a/event/event.go
+++ b/event/event.go
@@ -33,6 +33,13 @@ const (
 
 	// TypeResize represents window/widget resize events.
 	TypeResize
+
+	// TypeIME represents input-method composition events.
+	//
+	// IME events are delivered to the focused widget and carry preedit,
+	// commit, cancellation, and surrounding-text requests without
+	// overloading keyboard events.
+	TypeIME
 )
 
 // Event type string constants.
@@ -45,6 +52,7 @@ const (
 	typeTextStr   = "Text"
 	typeDropStr   = "Drop"
 	typeResizeStr = "Resize"
+	typeIMEStr    = "IME"
 )
 
 // String returns a human-readable name for the event type.
@@ -66,6 +74,8 @@ func (t Type) String() string {
 		return typeDropStr
 	case TypeResize:
 		return typeResizeStr
+	case TypeIME:
+		return typeIMEStr
 	default:
 		return unknownStr
 	}

--- a/event/event_test.go
+++ b/event/event_test.go
@@ -19,6 +19,7 @@ func TestType_String(t *testing.T) {
 		{"Text", TypeText, "Text"},
 		{"Drop", TypeDrop, "Drop"},
 		{"Resize", TypeResize, "Resize"},
+		{"IME", TypeIME, "IME"},
 		{"Unknown", Type(99), "Unknown"},
 		{"Zero", Type(0), "Unknown"},
 	}
@@ -130,6 +131,7 @@ func TestBase_Type(t *testing.T) {
 		{"Text", TypeText},
 		{"Drop", TypeDrop},
 		{"Resize", TypeResize},
+		{"IME", TypeIME},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/event/ime.go
+++ b/event/ime.go
@@ -1,0 +1,191 @@
+package event
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/gogpu/gpucontext"
+)
+
+// IMEEventType identifies one stage of an input-method interaction.
+type IMEEventType uint8
+
+const (
+	// IMECompositionStart indicates that the IME started a preedit.
+	IMECompositionStart IMEEventType = iota + 1
+	// IMECompositionUpdate replaces the current preedit.
+	IMECompositionUpdate
+	// IMECompositionEnd ends the preedit and may commit text.
+	IMECompositionEnd
+	// IMECanceled cancels the preedit without committing it.
+	IMECanceled
+	// IMEDisabled indicates that the platform disabled text input.
+	IMEDisabled
+	// IMEDeleteSurrounding asks the focused field to delete text around its
+	// insertion point.
+	IMEDeleteSurrounding
+)
+
+const (
+	imeCompositionStartStr  = "CompositionStart"
+	imeCompositionUpdateStr = "CompositionUpdate"
+	imeCompositionEndStr    = "CompositionEnd"
+	imeCanceledStr          = "Canceled"
+	imeDisabledStr          = "Disabled"
+	imeDeleteSurroundingStr = "DeleteSurrounding"
+)
+
+// String returns a stable human-readable event name.
+func (t IMEEventType) String() string {
+	switch t {
+	case IMECompositionStart:
+		return imeCompositionStartStr
+	case IMECompositionUpdate:
+		return imeCompositionUpdateStr
+	case IMECompositionEnd:
+		return imeCompositionEndStr
+	case IMECanceled:
+		return imeCanceledStr
+	case IMEDisabled:
+		return imeDisabledStr
+	case IMEDeleteSurrounding:
+		return imeDeleteSurroundingStr
+	default:
+		return unknownStr
+	}
+}
+
+// IMEEvent is delivered to the focused text input widget.
+//
+// Composition ranges are UTF-8 byte offsets into Composition. The event is
+// mutable only through the embedded Base handled flag; payloads are snapshots
+// and must not be retained for mutation by a widget.
+type IMEEvent struct {
+	Base
+
+	// IMEType identifies the lifecycle operation represented by this event.
+	IMEType IMEEventType
+
+	// Composition is the current preedit for IMECompositionUpdate.
+	Composition gpucontext.IMEComposition
+
+	// Committed is the text committed by IMECompositionEnd. It is empty for a
+	// canceled or empty commit.
+	Committed string
+
+	// Delete contains a delete-surrounding request for IMEDeleteSurrounding.
+	Delete gpucontext.IMEDeleteSurroundingEvent
+}
+
+// NewIMECompositionStartEvent creates a composition-start event.
+func NewIMECompositionStartEvent() *IMEEvent {
+	return &IMEEvent{Base: NewBase(TypeIME, ModNone), IMEType: IMECompositionStart}
+}
+
+// NewIMECompositionUpdateEvent creates a preedit update event.
+func NewIMECompositionUpdateEvent(composition gpucontext.IMEComposition) *IMEEvent {
+	return &IMEEvent{
+		Base:        NewBase(TypeIME, ModNone),
+		IMEType:     IMECompositionUpdate,
+		Composition: composition,
+	}
+}
+
+// NewIMECompositionEndEvent creates a preedit-end event.
+func NewIMECompositionEndEvent(committed string) *IMEEvent {
+	return &IMEEvent{
+		Base:      NewBase(TypeIME, ModNone),
+		IMEType:   IMECompositionEnd,
+		Committed: committed,
+	}
+}
+
+// NewIMECanceledEvent creates an event that cancels the active preedit.
+func NewIMECanceledEvent() *IMEEvent {
+	return &IMEEvent{Base: NewBase(TypeIME, ModNone), IMEType: IMECanceled}
+}
+
+// NewIMEDisabledEvent creates an event that clears platform text input state.
+func NewIMEDisabledEvent() *IMEEvent {
+	return &IMEEvent{Base: NewBase(TypeIME, ModNone), IMEType: IMEDisabled}
+}
+
+// NewIMEDeleteSurroundingEvent creates a delete-surrounding request.
+func NewIMEDeleteSurroundingEvent(request gpucontext.IMEDeleteSurroundingEvent) *IMEEvent {
+	return &IMEEvent{
+		Base:    NewBase(TypeIME, ModNone),
+		IMEType: IMEDeleteSurrounding,
+		Delete:  request,
+	}
+}
+
+// NewIMECompositionStart is a concise alias for
+// [NewIMECompositionStartEvent].
+func NewIMECompositionStart() *IMEEvent { return NewIMECompositionStartEvent() }
+
+// NewIMECompositionUpdate is a concise alias for
+// [NewIMECompositionUpdateEvent].
+func NewIMECompositionUpdate(composition gpucontext.IMEComposition) *IMEEvent {
+	return NewIMECompositionUpdateEvent(composition)
+}
+
+// NewIMECompositionEnd is a concise alias for [NewIMECompositionEndEvent].
+func NewIMECompositionEnd(committed string) *IMEEvent {
+	return NewIMECompositionEndEvent(committed)
+}
+
+// NewIMECanceled is a concise alias for [NewIMECanceledEvent].
+func NewIMECanceled() *IMEEvent { return NewIMECanceledEvent() }
+
+// NewIMEDisabled is a concise alias for [NewIMEDisabledEvent].
+func NewIMEDisabled() *IMEEvent { return NewIMEDisabledEvent() }
+
+// NewIMEDeleteSurrounding is a concise alias for
+// [NewIMEDeleteSurroundingEvent].
+func NewIMEDeleteSurrounding(request gpucontext.IMEDeleteSurroundingEvent) *IMEEvent {
+	return NewIMEDeleteSurroundingEvent(request)
+}
+
+// IsCompositionStart reports whether this event starts a composition.
+func (e *IMEEvent) IsCompositionStart() bool { return e != nil && e.IMEType == IMECompositionStart }
+
+// IsCompositionUpdate reports whether this event updates a preedit.
+func (e *IMEEvent) IsCompositionUpdate() bool { return e != nil && e.IMEType == IMECompositionUpdate }
+
+// IsCompositionEnd reports whether this event ends a composition.
+func (e *IMEEvent) IsCompositionEnd() bool { return e != nil && e.IMEType == IMECompositionEnd }
+
+// IsCanceled reports whether this event cancels a composition.
+func (e *IMEEvent) IsCanceled() bool { return e != nil && e.IMEType == IMECanceled }
+
+// IsDisabled reports whether this event disables text input.
+func (e *IMEEvent) IsDisabled() bool { return e != nil && e.IMEType == IMEDisabled }
+
+// IsDeleteSurrounding reports whether this event requests surrounding text
+// deletion.
+func (e *IMEEvent) IsDeleteSurrounding() bool {
+	return e != nil && e.IMEType == IMEDeleteSurrounding
+}
+
+// NewIMECompositionUpdateEventWithTime creates a preedit update with a fixed
+// timestamp, primarily for deterministic event tests.
+func NewIMECompositionUpdateEventWithTime(
+	composition gpucontext.IMEComposition,
+	t time.Time,
+) *IMEEvent {
+	return &IMEEvent{
+		Base:        NewBaseWithTime(TypeIME, t, ModNone),
+		IMEType:     IMECompositionUpdate,
+		Composition: composition,
+	}
+}
+
+// String returns a concise representation useful in event diagnostics.
+func (e *IMEEvent) String() string {
+	if e == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("IMEEvent{Type: %s, Committed: %q}", e.IMEType, e.Committed)
+}
+
+var _ Event = (*IMEEvent)(nil)

--- a/event/ime_test.go
+++ b/event/ime_test.go
@@ -1,0 +1,77 @@
+package event
+
+import (
+	"testing"
+	"time"
+
+	"github.com/gogpu/gpucontext"
+)
+
+func TestIMEEventLifecycle(t *testing.T) {
+	composition := gpucontext.IMEComposition{
+		CompositionText: "かな",
+		CursorBegin:     len("か"),
+		CursorEnd:       len("か"),
+		SelectionStart:  0,
+		SelectionEnd:    len("かな"),
+	}
+
+	start := NewIMECompositionStartEvent()
+	if start.Type() != TypeIME || !start.IsCompositionStart() {
+		t.Fatalf("start = %#v, want TypeIME composition start", start)
+	}
+	update := NewIMECompositionUpdate(composition)
+	if !update.IsCompositionUpdate() || update.Composition != composition {
+		t.Fatalf("update = %#v, want composition %#v", update, composition)
+	}
+	end := NewIMECompositionEnd("仮名")
+	if !end.IsCompositionEnd() || end.Committed != "仮名" {
+		t.Fatalf("end = %#v, want committed text", end)
+	}
+
+	for _, tc := range []struct {
+		name string
+		e    *IMEEvent
+		want IMEEventType
+	}{
+		{"cancel", NewIMECanceled(), IMECanceled},
+		{"disabled", NewIMEDisabled(), IMEDisabled},
+		{"delete", NewIMEDeleteSurrounding(gpucontext.IMEDeleteSurroundingEvent{Before: 2, After: 3}), IMEDeleteSurrounding},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.e.IMEType != tc.want || tc.e.Type() != TypeIME {
+				t.Fatalf("event = %#v, want type %v", tc.e, tc.want)
+			}
+		})
+	}
+}
+
+func TestIMECompositionUpdateWithTime(t *testing.T) {
+	when := time.Date(2026, 8, 14, 12, 34, 56, 0, time.UTC)
+	e := NewIMECompositionUpdateEventWithTime(gpucontext.IMEComposition{CompositionText: "x", CursorBegin: 0, CursorEnd: 0, SelectionStart: 0, SelectionEnd: 0}, when)
+	if !e.Time().Equal(when) {
+		t.Fatalf("Time() = %v, want %v", e.Time(), when)
+	}
+	if e.String() == "" {
+		t.Fatal("String() should not be empty")
+	}
+}
+
+func TestIMEEventTypeString(t *testing.T) {
+	for _, tc := range []struct {
+		typ  IMEEventType
+		want string
+	}{
+		{IMECompositionStart, "CompositionStart"},
+		{IMECompositionUpdate, "CompositionUpdate"},
+		{IMECompositionEnd, "CompositionEnd"},
+		{IMECanceled, "Canceled"},
+		{IMEDisabled, "Disabled"},
+		{IMEDeleteSurrounding, "DeleteSurrounding"},
+		{IMEEventType(255), "Unknown"},
+	} {
+		if got := tc.typ.String(); got != tc.want {
+			t.Errorf("IMEEventType(%d).String() = %q, want %q", tc.typ, got, tc.want)
+		}
+	}
+}

--- a/event/ime_test.go
+++ b/event/ime_test.go
@@ -75,3 +75,38 @@ func TestIMEEventTypeString(t *testing.T) {
 		}
 	}
 }
+
+func TestIMEEventAllPredicatesAndAliases(t *testing.T) {
+	composition := gpucontext.IMEComposition{CompositionText: "x", CursorBegin: 0, CursorEnd: 0, SelectionStart: 0, SelectionEnd: 0}
+	request := gpucontext.IMEDeleteSurroundingEvent{Before: 1, After: 2}
+	events := []*IMEEvent{
+		NewIMECompositionStart(),
+		NewIMECompositionUpdate(composition),
+		NewIMECompositionEnd("x"),
+		NewIMECanceled(),
+		NewIMEDisabled(),
+		NewIMEDeleteSurrounding(request),
+	}
+	if !events[0].IsCompositionStart() || events[0].IsCompositionUpdate() || events[0].IsCompositionEnd() {
+		t.Fatalf("start predicates incorrect: %#v", events[0])
+	}
+	if !events[1].IsCompositionUpdate() || events[1].IsCompositionStart() || events[1].IsCompositionEnd() {
+		t.Fatalf("update predicates incorrect: %#v", events[1])
+	}
+	if !events[2].IsCompositionEnd() || events[2].IsCompositionStart() || events[2].IsCompositionUpdate() {
+		t.Fatalf("end predicates incorrect: %#v", events[2])
+	}
+	if !events[3].IsCanceled() || !events[4].IsDisabled() || !events[5].IsDeleteSurrounding() {
+		t.Fatalf("lifecycle predicates incorrect: %#v", events)
+	}
+	if events[5].Delete != request {
+		t.Fatalf("delete request = %#v, want %#v", events[5].Delete, request)
+	}
+	var nilEvent *IMEEvent
+	if nilEvent.IsCompositionStart() || nilEvent.IsCompositionUpdate() || nilEvent.IsCompositionEnd() || nilEvent.IsCanceled() || nilEvent.IsDisabled() || nilEvent.IsDeleteSurrounding() {
+		t.Fatal("nil event predicates must be false")
+	}
+	if got := nilEvent.String(); got != "<nil>" {
+		t.Fatalf("nil event String() = %q, want <nil>", got)
+	}
+}

--- a/theme/cupertino/cupertino_test.go
+++ b/theme/cupertino/cupertino_test.go
@@ -1072,3 +1072,17 @@ func TestDarkThemeCheckboxColors(t *testing.T) {
 		t.Fatal("dark theme checkbox painter should produce draw calls")
 	}
 }
+
+func TestPaintTextFieldComposition(t *testing.T) {
+	canvas := &recordCanvas{}
+	(cupertino.TextFieldPainter{}).PaintTextField(canvas, &textfield.PaintState{
+		DisplayText: "committed", TextRect: testBounds(), Bounds: testBounds(),
+		Focused: true, ShowComposition: true,
+		CompositionText: "preedit", CompositionTextRect: geometry.NewRect(10, 10, 30, 20),
+		CompositionSelectionRect: geometry.NewRect(10, 10, 10, 20),
+		CompositionCursorRect:    geometry.NewRect(20, 10, 1, 20),
+	})
+	if len(canvas.calls) == 0 {
+		t.Fatal("composition painter produced no draw calls")
+	}
+}

--- a/theme/cupertino/textfield.go
+++ b/theme/cupertino/textfield.go
@@ -128,6 +128,7 @@ func cupPaintTFContent(canvas widget.Canvas, st *textfield.PaintState, colors te
 	}
 
 	canvas.DrawText(st.DisplayText, st.TextRect, fontSize, textColor, false, cupTFTextAlignLeft)
+	textfield.PaintComposition(canvas, st, colors)
 }
 
 // cupPaintTFCursorFromState draws the cursor using pre-computed CursorRect.

--- a/theme/devtools/painters_test.go
+++ b/theme/devtools/painters_test.go
@@ -1431,3 +1431,17 @@ func TestAllPaintersWithLightTheme(t *testing.T) {
 		})
 	}
 }
+
+func TestPaintTextFieldComposition(t *testing.T) {
+	canvas := &recordCanvas{}
+	(devtools.TextFieldPainter{}).PaintTextField(canvas, &textfield.PaintState{
+		DisplayText: "committed", TextRect: geometry.NewRect(0, 0, 100, 40), Bounds: geometry.NewRect(0, 0, 100, 40),
+		Focused: true, ShowComposition: true,
+		CompositionText: "preedit", CompositionTextRect: geometry.NewRect(10, 10, 30, 20),
+		CompositionSelectionRect: geometry.NewRect(10, 10, 10, 20),
+		CompositionCursorRect:    geometry.NewRect(20, 10, 1, 20),
+	})
+	if len(canvas.calls) == 0 {
+		t.Fatal("composition painter produced no draw calls")
+	}
+}

--- a/theme/devtools/textfield.go
+++ b/theme/devtools/textfield.go
@@ -130,6 +130,7 @@ func dtPaintTFContent(canvas widget.Canvas, st *textfield.PaintState, colors tex
 	}
 
 	canvas.DrawText(st.DisplayText, st.TextRect, fontSize, textColor, false, dtTFTextAlignLeft)
+	textfield.PaintComposition(canvas, st, colors)
 }
 
 // dtPaintTFCursorFromState draws the cursor using pre-computed CursorRect.

--- a/theme/fluent/fluent_test.go
+++ b/theme/fluent/fluent_test.go
@@ -733,3 +733,17 @@ func absF32(v float32) float32 {
 	}
 	return v
 }
+
+func TestPaintTextFieldComposition(t *testing.T) {
+	canvas := &recordCanvas{}
+	(fluent.TextFieldPainter{}).PaintTextField(canvas, &textfield.PaintState{
+		DisplayText: "committed", TextRect: testBounds(), Bounds: testBounds(),
+		Focused: true, ShowComposition: true,
+		CompositionText: "preedit", CompositionTextRect: geometry.NewRect(10, 10, 30, 20),
+		CompositionSelectionRect: geometry.NewRect(10, 10, 10, 20),
+		CompositionCursorRect:    geometry.NewRect(20, 10, 1, 20),
+	})
+	if len(canvas.calls) == 0 {
+		t.Fatal("composition painter produced no draw calls")
+	}
+}

--- a/theme/fluent/textfield.go
+++ b/theme/fluent/textfield.go
@@ -129,6 +129,7 @@ func flPaintTFContent(canvas widget.Canvas, st *textfield.PaintState, colors tex
 	}
 
 	canvas.DrawText(st.DisplayText, st.TextRect, fontSize, textColor, false, flTFTextAlignLeft)
+	textfield.PaintComposition(canvas, st, colors)
 }
 
 // flPaintTFCursorFromState draws the cursor using pre-computed CursorRect.

--- a/theme/material3/textfield.go
+++ b/theme/material3/textfield.go
@@ -129,6 +129,7 @@ func m3PaintTextFieldContent(canvas widget.Canvas, st *textfield.PaintState, col
 	}
 
 	canvas.DrawText(st.DisplayText, st.TextRect, fontSize, textColor, false, m3TFTextAlignLeft)
+	textfield.PaintComposition(canvas, st, colors)
 }
 
 // m3PaintTextFieldCursorFromState draws the cursor using pre-computed CursorRect.

--- a/theme/material3/textfield_ime_test.go
+++ b/theme/material3/textfield_ime_test.go
@@ -1,0 +1,22 @@
+package material3
+
+import (
+	"testing"
+
+	"github.com/gogpu/ui/core/textfield"
+	"github.com/gogpu/ui/geometry"
+)
+
+func TestPaintTextFieldComposition(t *testing.T) {
+	canvas := &pbMockCanvas{}
+	(TextFieldPainter{}).PaintTextField(canvas, &textfield.PaintState{
+		DisplayText: "committed", TextRect: geometry.NewRect(0, 0, 100, 40), Bounds: geometry.NewRect(0, 0, 100, 40),
+		Focused: true, ShowComposition: true,
+		CompositionText: "preedit", CompositionTextRect: geometry.NewRect(10, 10, 30, 20),
+		CompositionSelectionRect: geometry.NewRect(10, 10, 10, 20),
+		CompositionCursorRect:    geometry.NewRect(20, 10, 1, 20),
+	})
+	if canvas.drawCount == 0 {
+		t.Fatal("composition painter produced no draw calls")
+	}
+}


### PR DESCRIPTION
## Summary

- add backend-neutral IME events and bridge optional gpucontext v2 controllers into UI windows
- keep TextField preedit separate from committed text, render marked ranges/underline/cursor geometry, and publish candidate cursor rectangles
- support UTF-8-safe delete-surrounding, exactly-once commit echo suppression, focus/cancel/disabled ordering, and legacy fallback
- prevent password/sensitive fields from enabling composition, accepting IME mutations, or publishing surrounding text
- harden stale callbacks, duplicate ends, visibility/enabled/root changes, controller capability discovery, and teardown

## Dependencies

This PR depends on:

1. [gpucontext #30](https://github.com/gogpu/gpucontext/pull/30), the optional versioned IME interface contract.
2. [gogpu #462](https://github.com/gogpu/gogpu/pull/462), the integrated platform IME event/controller implementation.

The branch contains no committed `replace` directives and intentionally remains draft until both dependencies are merged and released. After releases are available, update `go.mod`, run `go mod tidy`, rerun the matrix below, and mark this PR ready.

## Verification

Dependency validation used temporary modfile replacements only; none are committed.

- focused app/TextField/event tests: PASS
- `go test -count=1 ./...`: PASS
- focused changed IME race tests: PASS
- `go build ./...` and focused `go vet`: PASS
- supported Linux/Windows/macOS/browser builds and test compilation: PASS
- `gofmt` and `git diff --check`: PASS

The full app race suite still reproduces the pre-existing animation-pumper mock `RequestRedraw` race outside this diff. Live native compositor/locale testing requires target hosts.

Refs gogpu/gogpu#331. Depends on gogpu/gpucontext#30 and gogpu/gogpu#462.
